### PR TITLE
Fix set_mouse_mode being called with null last_mouse_mode

### DIFF
--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -378,9 +378,11 @@ func add_choice_button(option):
 
 	button.connect("pressed", self, "answer_question", [button, option['event_id'], option['question_id']])
 	
-	last_mouse_mode = Input.get_mouse_mode()
-	Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE) # Make sure the cursor is visible for the options selection
 	$Options.add_child(button)
+
+	if Input.get_mouse_mode() != Input.MOUSE_MODE_VISIBLE:
+		last_mouse_mode = Input.get_mouse_mode()
+		Input.set_mouse_mode(Input.MOUSE_MODE_VISIBLE) # Make sure the cursor is visible for the options selection
 
 
 func answer_question(i, event_id, question_id):
@@ -392,9 +394,10 @@ func answer_question(i, event_id, question_id):
 	print('    dialog_index = ', dialog_index)
 	reset_options()
 	load_dialog()
-	
-	Input.set_mouse_mode(last_mouse_mode) # Revert to last mouse mode when selection is done
-	last_mouse_mode = null
+	if last_mouse_mode != null:
+		Input.set_mouse_mode(last_mouse_mode) # Revert to last mouse mode when selection is done
+		last_mouse_mode = null
+
 
 func _on_option_selected(option, variable, value):
 	dialog_resource.custom_variables[variable] = value


### PR DESCRIPTION
I am not fully sure if this approach is ideal (as this dialogue system could be used in games without reliance on mouse input), however this should guarantee the mouse mode is not set to "null" at the very least.
Fixes https://github.com/coppolaemilio/dialogic/issues/38