### PR TITLE
WIP signals and debug mode variable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* text eol=lf

--- a/addons/dialogic/Other/dialogic_class.gd
+++ b/addons/dialogic/Other/dialogic_class.gd
@@ -2,9 +2,10 @@ extends Node
 class_name Dialogic
 
 
-static func start(timeline: String):
+static func start(timeline: String, debug_mode=true):
 	var dialog = load("res://addons/dialogic/Dialog.tscn")
 	var d = dialog.instance()
+	d.debug_mode = debug_mode
 	for t in DialogicUtil.get_timeline_list():
 		if t['name'] == timeline:
 			d.timeline = t['file'].replace('.json', '')


### PR DESCRIPTION
* Add `.gitattributes` so windows doesn't mess up line endings
* Expose `debug_mode` in scene, add variable to `start` function (default true)
* Add some signals:
  * `dialogue_start()` (NOT WORKING YET)
  * `dialogue_end()` (NOT WORKING YET)
  * `text_event(event)`
  * `wait_event_start(seconds)`
  * `wait_event_timeout()`

This should, for the most part, address #68 (and maybe #67).

More signals should be added to make it more complete, and I'm not sure where to put the start and end signals to make them work. Should be understandable if I read the code a bit!

I ran into a bug where I would try to connect the `text_event` signal in my scene's `_ready` function, but the first event wasn't connected in time. I should be adding the dialogue via code anyway, but it's something to keep in mind.

My editor (vscode) also strips all whitespace automatically, so there'll be some tabs cleared out. I can try to add them back if you want them.