### PR TITLE
Add more 'if' conditions

### DIFF
--- a/addons/dialogic/Editor/Pieces/Common/ConditionPicker.gd
+++ b/addons/dialogic/Editor/Pieces/Common/ConditionPicker.gd
@@ -1,0 +1,58 @@
+tool
+extends MenuButton
+
+var options = [
+	{
+		"text": "[ Equal to ]",
+		"condition": "=="
+	},
+	{
+		"text": "[ Different from ]",
+		"condition": "!="
+	},
+	{
+		"text": "[ Greater than ]",
+		"condition": ">"
+	},
+	{
+		"text": "[ Greater or equal to ]",
+		"condition": ">="
+	},
+	{
+		"text": "[ Less than ]",
+		"condition": "<"
+	},
+	{
+		"text": "[ Less or equal to ]",
+		"condition": "<="
+	}
+]
+
+func _ready():
+	get_popup().connect("index_pressed", self, '_on_entry_selected')
+	get_popup().clear()
+	connect("about_to_show", self, "_on_MenuButton_about_to_show")
+
+
+func _on_MenuButton_about_to_show():
+	get_popup().clear()
+	var index = 0
+	for o in options:
+		get_popup().add_item(o['text'])
+		get_popup().set_item_metadata(index, o)
+		index += 1
+
+
+func _on_entry_selected(index):
+	var _text = get_popup().get_item_text(index)
+	var metadata = get_popup().get_item_metadata(index)
+	text = _text
+
+
+func load_condition(condition):
+	if condition != '':
+		for o in options:
+			if (o['condition'] == condition):
+				text = o['text']
+	else:
+		text = options[0]['text']

--- a/addons/dialogic/Editor/Pieces/Common/ConditionPicker.tscn
+++ b/addons/dialogic/Editor/Pieces/Common/ConditionPicker.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/ConditionPicker.gd" type="Script" id=1]
+
+[node name="ConditionPicker" type="MenuButton"]
+margin_left = 173.0
+margin_right = 252.0
+margin_bottom = 28.0
+text = "[ = ]"
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/addons/dialogic/Editor/Pieces/IfCondition.gd
+++ b/addons/dialogic/Editor/Pieces/IfCondition.gd
@@ -14,10 +14,12 @@ var event_data = {
 
 onready var nodes = {
 	'definition_picker': $PanelContainer/VBoxContainer/Header/DefinitionPicker,
+	'condition_picker': $PanelContainer/VBoxContainer/Header/ConditionPicker,
 }
 
 func _ready():
 	nodes['definition_picker'].get_popup().connect("index_pressed", self, '_on_definition_entry_selected')
+	nodes['condition_picker'].get_popup().connect("index_pressed", self, '_on_condition_entry_selected')
 	$PanelContainer/VBoxContainer/Header/CustomLineEdit.connect("text_changed", self, '_on_text_changed')
 
 
@@ -29,8 +31,14 @@ func load_data(data):
 	event_data = data
 	$PanelContainer/VBoxContainer/Header/CustomLineEdit.text = event_data['value']
 	nodes['definition_picker'].load_definition(data['definition'])
+	nodes['condition_picker'].load_condition(data['condition'])
 
 
 func _on_definition_entry_selected(index):
 	var metadata = nodes['definition_picker'].get_popup().get_item_metadata(index)
 	event_data['definition'] = metadata['section']
+
+
+func _on_condition_entry_selected(index):
+	var metadata = nodes['condition_picker'].get_popup().get_item_metadata(index)
+	event_data['condition'] = metadata['condition']

--- a/addons/dialogic/Editor/Pieces/IfCondition.tscn
+++ b/addons/dialogic/Editor/Pieces/IfCondition.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/condition.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/IfCondition.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/ConditionPicker.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/CustomLineEdit.tscn" type="PackedScene" id=6]
@@ -70,26 +71,23 @@ margin_left = 26.0
 margin_right = 169.0
 margin_bottom = 28.0
 
-[node name="MenuButton2" type="MenuButton" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 173.0
-margin_right = 252.0
-margin_bottom = 28.0
-text = "[ Equal to ]"
+[node name="ConditionPicker" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
+margin_right = 209.0
 
 [node name="CustomLineEdit" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 6 )]
-margin_left = 256.0
-margin_right = 304.0
+margin_left = 213.0
+margin_right = 261.0
 margin_bottom = 28.0
 
 [node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 308.0
+margin_left = 265.0
 margin_top = 7.0
-margin_right = 308.0
+margin_right = 265.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
 [node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 312.0
+margin_left = 269.0
 margin_right = 941.0
 margin_bottom = 28.0
 size_flags_horizontal = 3

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -462,16 +462,30 @@ func event_handler(event: Dictionary):
 						def_value = d['config'].get_value(event['definition'], 'value-' + runtime_id, null)
 					else:
 						def_value = d['config'].get_value(event['definition'], 'value', null)
-			if def_value != null:
-				if def_value != event['value']:
-					current_question['answered'] = true # This will abort the current conditional branch
 
-			if current_question['answered']:
-				# If the option is for an answered question, skip to the end of it.
+			var condition_met = false;
+			if def_value != null:
+				match event['condition']:
+					"==":
+						condition_met = def_value == event['value']
+					"!=":
+						condition_met = def_value != event['value']
+					">":
+						condition_met = def_value > event['value']
+					">=":
+						condition_met = def_value >= event['value']
+					"<":
+						condition_met = def_value < event['value']
+					"<=":
+						condition_met = def_value <= event['value']
+			
+			current_question['answered'] = !condition_met
+			if !condition_met:
+				# condition not met, skipping branch
 				dialog_index = current_question['end_id']
 				load_dialog(true)
 			else:
-				# It should never get here, but if it does, go to the next place.
+				# condition met, entering branch
 				go_to_next_event()
 		{'set_value', 'definition'}:
 			emit_signal("event_start", "set_value", event)


### PR DESCRIPTION
This pull request adds support for more conditions in if statements, as requested in issue https://github.com/coppolaemilio/dialogic/issues/80.

This adds a new scene, `ConditionPicker` to allow selecting conditions, used only in the `IfCondition` Scene. It follows the same structure as the `DefinitionPicker` scene.

Conditions can be saved and loaded back like definitions and values.

Supported conditions are:

```
==
!=
>
>=
<
<=
```

![Screenshot_20210316_184140](https://user-images.githubusercontent.com/80701113/111355045-40c08d80-8687-11eb-8b1a-f16a0c1c38a3.png)
