### PR TITLE
Add dialog_scene_path param

### DIFF
--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -2,7 +2,7 @@ extends Node
 class_name Dialogic
 
 
-static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode:bool=false):
+static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
 	var dialog = load(dialog_scene_path)
 	var d = dialog.instance()
 	d.debug_mode = debug_mode

--- a/addons/dialogic/Other/dialogic_class.gd
+++ b/addons/dialogic/Other/dialogic_class.gd
@@ -2,8 +2,8 @@ extends Node
 class_name Dialogic
 
 
-static func start(timeline: String, debug_mode=true):
-	var dialog = load("res://addons/dialogic/Dialog.tscn")
+static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode:bool=false):
+	var dialog = load(dialog_scene_path)
 	var d = dialog.instance()
 	d.debug_mode = debug_mode
 	for t in DialogicUtil.get_timeline_list():


### PR DESCRIPTION
This allows users to use their own custom dialog scene. The scene should probably be inherited from the base `Dialog.tscn` to ensure compatibility.

I also set the `debug_mode` variable to false by default and made it the third param. If a user wants to set it to `true` and not pass in a custom scene, then user can set it to the node that is returned by the method. It would be a lot easier if Godot had kwargs, but it doesn't yet.