### PR TITLE
add inline variables support

### DIFF
--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -172,12 +172,11 @@ func _on_PreviewButton_pressed():
 	preview_dialog.dialog_script['events'] = [{
 		"character":"",
 		"portrait":"",
-		"text": n['text_preview'].text
+		"text": preview_dialog.parse_definitions(n['text_preview'].text)
 	}]
 	# Settings
 	preview_dialog.settings = DialogicUtil.get_settings()
 	# Alignment
-	preview_dialog.dialog_script = preview_dialog.parse_definitions(preview_dialog.dialog_script)
 	preview_dialog.dialog_script = preview_dialog.parse_text_lines(preview_dialog.dialog_script)
 	n['preview_panel'].add_child(preview_dialog)
 	# Not sure why but I need to reload the theme again for it to work properly

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -235,7 +235,7 @@ func _insert_variable_definitions(text: String):
 	for d in definitions:
 		if d['type'] == 0:
 			var value = DialogicUtil.get_definition_value(d, runtime_id)
-			final_text = final_text.replace('${' + d['name'] + '}', value)
+			final_text = final_text.replace('[' + d['name'] + ']', value)
 	return final_text;
 	
 	

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -95,7 +95,6 @@ func set_current_dialog(dialog_path):
 		dialog_script = parse_characters(dialog_script)
 	
 	dialog_script = parse_text_lines(dialog_script)
-	dialog_script = parse_definitions(dialog_script)
 	dialog_script = parse_branches(dialog_script)
 	return dialog_script
 
@@ -219,28 +218,27 @@ func parse_branches(dialog_script: Dictionary) -> Dictionary:
 	return dialog_script
 
 
-func parse_definitions(dialog_script):
+func parse_definitions(text: String):
 	var words = []
 	var definition_list = DialogicUtil.get_definition_list()
 	if Engine.is_editor_hint():
 		# Loading variables again to avoid issues in the preview dialog
 		load_config_files()
-		
 
+	var final_text: String;
+	final_text = _insert_variable_definitions(text)
+	final_text = _insert_glossary_definitions(final_text)
+	return final_text
+
+func _insert_variable_definitions(text: String):
+	var final_text := text;
 	for d in definitions:
-		if d['type'] == 1:
-			words.append(d)
-	if words.size() > 0:
-		for t in dialog_script['events']:
-			# Text node
-			if t.has('text') and t.has('character') and t.has('portrait'):
-				t['text'] = _insert_glossary_definitions(t['text'])
-			# Question node
-			if t.has('question'):
-				t['question'] = _insert_glossary_definitions(t['question'])
-
-	return dialog_script
-
+		if d['type'] == 0:
+			var value = DialogicUtil.get_definition_value(d, runtime_id)
+			final_text = final_text.replace('${' + d['name'] + '}', value)
+	return final_text;
+	
+	
 func _insert_glossary_definitions(text: String):
 	var color = self.current_theme.get_value('definitions', 'color', '#ffbebebe')
 	var final_text := text;
@@ -304,7 +302,7 @@ func update_name(character, color='#FFFFFF'):
 
 func update_text(text):
 	# Updating the text and starting the animation from 0
-	$TextBubble/RichTextLabel.bbcode_text = text
+	$TextBubble/RichTextLabel.bbcode_text = self.parse_definitions(text)
 	$TextBubble/RichTextLabel.percent_visible = 0
 
 	# The call to this function needs to be deferred.
@@ -464,10 +462,7 @@ func event_handler(event: Dictionary):
 			var current_question = questions[event['question_id']]
 			for d in definitions:
 				if d['section'] == event['definition']:
-					if d['config'].has_section_key(event['definition'], 'value-' + runtime_id):
-						def_value = d['config'].get_value(event['definition'], 'value-' + runtime_id, null)
-					else:
-						def_value = d['config'].get_value(event['definition'], 'value', null)
+					def_value = DialogicUtil.get_definition_value(d, runtime_id)
 
 			var condition_met = self._compare_definitions(def_value, event['value'], event['condition']);
 			

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -167,19 +167,21 @@ static func set_definition(current_section: String, key,  value) -> void:
 		config.save(get_path('DEFINITIONS_FILE'))
 
 
+static func get_definition_value(d, running_id):
+	if d['config'].has_section_key(d['section'], 'value-' + running_id):
+		return d['config'].get_value(d['section'], 'value-' + running_id)
+	else:
+		return d['config'].get_value(d['section'], 'value')
+
+
 static func get_var(variable: String, singleton):
-	print(get_definition_list())
 	for d in get_definition_list():
 		if d['name'] == variable:
-			if d['config'].has_section_key(d['section'], 'value-' + singleton.running_id):
-				return d['config'].get_value(d['section'], 'value-' + singleton.running_id)
-			else:
-				return d['config'].get_value(d['section'], 'value')
+			return get_definition_value(d, singleton.running_id)
 	return ''
 
 
 static func set_var(variable: String):
-	print(get_definition_list())
 	for d in get_definition_list():
 		if d['name'] == variable:
 			return d['config'].get_value(d['section'], 'value')


### PR DESCRIPTION
Allows showing inline variables using `${variable_name}` inside a text message.

Parsing takes place before each text update, not just in the initial timeline loading.
This allows showing dynamic variables inside a dialogue.

Variable values are inserted before glossary parsing, allowing dynamic glossary text.

For example, if `test_value`'s value is `test_gloss`, then putting `${test_value}` inside a text/question will show test_gloss and enable the glossary popup on the word.

Might help solve #84.