### PR TITLE
Implement two-step start to allow timeline data manipulation

### DIFF
--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -19,6 +19,7 @@ var current_theme
 export(String, "TimelineDropdown") var timeline: String
 export(bool) var reset_saves = true
 export(bool) var debug_mode = true
+export(bool) var stop_on_load = false
 signal event_start(type, event)
 signal event_end(type)
 signal dialogic_signal(value)
@@ -55,7 +56,17 @@ func _ready():
 	# Getting the character information
 	characters = DialogicUtil.get_character_list()
 
-	if Engine.is_editor_hint() == false:
+	if stop_on_load:
+		hide()
+		set_process(false)
+	else:
+		start()
+
+
+func start():
+	if Engine.is_editor_hint() == false && timeline != '':
+		show_dialog()
+		set_process(true)
 		load_dialog()
 
 

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -2,10 +2,11 @@ extends Node
 class_name Dialogic
 
 
-static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false, stop_on_load: bool=false):
 	var dialog = load(dialog_scene_path)
 	var d = dialog.instance()
 	d.debug_mode = debug_mode
+	d.stop_on_load = stop_on_load
 	for t in DialogicUtil.get_timeline_list():
 		if t['name'] == timeline:
 			d.timeline = t['file'].replace('.json', '')


### PR DESCRIPTION
I can imagine a lot of situations where "adding one more feature" to the visual editor will be too much, and too many features will make this plugin hard to use for "normal" users. This is a kind of "advanced user" tool. Dialogic is called with `stop_on_load=true`, when timeline and basically all dialog_node data can be edited before a real "start".
Code example - dynamic portrait change:
```GDScript
	var new_dialog = Dialogic.start(timeline, "res://addons/dialogic/Dialog.tscn", false, true)
	for item in new_dialog.dialog_script.events:
		if item.get("action") == "join" && item.get("portrait") == "p1":
			item.portrait = $"/root/Player".sprite_string
	new_dialog.start()
```