### PR TITLE
Synchronize definitions and timeline saving

### DIFF
--- a/addons/dialogic/Editor/DefinitionEditor/DefinitionEditor.gd
+++ b/addons/dialogic/Editor/DefinitionEditor/DefinitionEditor.gd
@@ -3,7 +3,7 @@ extends ScrollContainer
 
 var editor_reference
 onready var master_tree = get_node('../MasterTree')
-var current_section = ''
+var current_definition = null
 
 onready var nodes = {
 	'name' : $VBoxContainer/HBoxContainer/VBoxContainer/Name,
@@ -22,19 +22,19 @@ func _ready():
 	nodes['type'].connect('item_selected', self, '_on_type_selected')
 
 
-func load_definition(section):
-	current_section = section
+func load_definition(id):
+	current_definition = DialogicResources.get_default_definition_item(id)
 	reset_editor()
 	nodes['name'].editable = true
-	nodes['name'].text = get_definition('name', 'Unnamed')
-	var type = get_definition('type', 0)
+	nodes['name'].text = current_definition['name']
+	var type = current_definition['type']
 	nodes['type'].select(type)
 	if type == 0:
-		nodes['value'].text = get_definition('value', '')
+		nodes['value'].text = current_definition['value']
 	if type == 1:
-		nodes['extra_title'].text = get_definition('extra_title', '')
-		nodes['extra_text'].text = get_definition('extra_text', '')
-		nodes['extra_extra'].text = get_definition('extra_extra', '')
+		nodes['extra_title'].text = current_definition['title']
+		nodes['extra_text'].text = current_definition['text']
+		nodes['extra_extra'].text = current_definition['extra']
 	show_sub_editor(type)
 
 
@@ -44,7 +44,10 @@ func reset_editor():
 	nodes['extra_title'].text = ''
 	nodes['extra_text'].text = ''
 	nodes['extra_extra'].text = ''
-	nodes['type'].select(get_definition('type', 0))
+	var type = 0
+	if current_definition != null:
+		type = current_definition['type']
+	nodes['type'].select(type)
 
 
 func _on_name_changed(text):
@@ -70,23 +73,16 @@ func show_sub_editor(type):
 		nodes['extra_editor'].visible = true
 
 
-func get_definition(key: String, default):
-	if current_section != '':
-		return DialogicResources.get_default_definition_key(current_section, key, default)
-	else:
-		return default
-
-
 func new_definition():
-	var section = DialogicUtil.generate_random_id()
-	DialogicResources.add_default_definition_variable(section, 'New definition', 0, '')
-	master_tree.add_definition({'section': section,'name': 'New definition', 'type': 0}, true)
+	var id = DialogicUtil.generate_random_id()
+	DialogicResources.set_default_definition_variable(id, 'New definition', '')
+	master_tree.add_definition({'id': id, 'name': 'New definition', 'type': 0}, true)
 
 
 func save_definition():
-	if current_section != '':
+	if current_definition['id'] != '':
 		var type: int = nodes['type'].selected
 		if type == 0:
-			DialogicResources.set_default_definition_variable(current_section, nodes['name'].text, nodes['value'].text)
+			DialogicResources.set_default_definition_variable(current_definition['id'], nodes['name'].text, nodes['value'].text)
 		if type == 1:
-			DialogicResources.set_default_definition_glossary(current_section, nodes['name'].text, nodes['extra_title'].text, nodes['extra_text'].text, nodes['extra_extra'].text)
+			DialogicResources.set_default_definition_glossary(current_definition['id'], nodes['name'].text, nodes['extra_title'].text, nodes['extra_text'].text, nodes['extra_extra'].text)

--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -67,9 +67,9 @@ func _on_TimelinePopupMenu_id_pressed(id):
 
 func _on_RemoveTimelineConfirmation_confirmed():
 	var dir = Directory.new()
-	var target = $MainPanel/TimelineEditor.working_timeline_file
+	var target = $MainPanel/TimelineEditor.timeline_file
 	print('target: ', target)
-	dir.remove(target)
+	DialogicResources.delete_timeline(target)
 	$MainPanel/MasterTree.remove_selected()
 	$MainPanel/MasterTree.hide_all_editors(true)
 
@@ -99,7 +99,7 @@ func _on_DefinitionPopupMenu_id_pressed(id):
 
 
 func _on_RemoveDefinitionConfirmation_confirmed():
-	var target = $MainPanel/DefinitionEditor.current_section
+	var target = $MainPanel/DefinitionEditor.current_definition['id']
 	DialogicResources.delete_default_definition(target)
 	$MainPanel/MasterTree.remove_selected()
 	$MainPanel/MasterTree.hide_all_editors(true)
@@ -114,7 +114,7 @@ func _on_RemoveCharacterConfirmation_confirmed():
 
 func _on_RemoveThemeConfirmation_confirmed():
 	var filename = $MainPanel/MasterTree.get_selected().get_metadata(0)['file']
-	DialogicResources.delete_timeline(filename)
+	DialogicResources.delete_theme(filename)
 	$MainPanel/MasterTree.remove_selected()
 	$MainPanel/MasterTree.hide_all_editors(true)
 

--- a/addons/dialogic/Editor/MasterTree/MasterTree.gd
+++ b/addons/dialogic/Editor/MasterTree/MasterTree.gd
@@ -69,7 +69,7 @@ func _ready():
 		add_character(c)
 	
 	# Adding Definitions
-	for d in DialogicUtil.get_default_definition_list():
+	for d in DialogicUtil.get_default_definitions_list():
 		add_definition(d)
 	
 	# Adding Themes

--- a/addons/dialogic/Editor/MasterTree/MasterTree.gd
+++ b/addons/dialogic/Editor/MasterTree/MasterTree.gd
@@ -155,7 +155,7 @@ func _on_item_selected():
 		character_editor.load_character(metadata['file'])
 	if metadata['editor'] == 'Definition':
 		definition_editor.visible = true
-		definition_editor.load_definition(metadata['section'])
+		definition_editor.load_definition(metadata['id'])
 	if metadata['editor'] == 'Theme':
 		theme_editor.load_theme(metadata['file'])
 		theme_editor.visible = true

--- a/addons/dialogic/Editor/Pieces/Common/DefinitionPicker.gd
+++ b/addons/dialogic/Editor/Pieces/Common/DefinitionPicker.gd
@@ -12,13 +12,12 @@ func _ready():
 func _on_MenuButton_about_to_show():
 	get_popup().clear()
 	var index = 0
-	for d in DialogicUtil.get_default_definitions_list():
-		if d['type'] == 0:
-			get_popup().add_item(d['name'])
-			get_popup().set_item_metadata(index, {
-				'section': d['section'],
-			})
-			index += 1
+	for d in DialogicResources.get_default_definitions()['variables']:
+		get_popup().add_item(d['name'])
+		get_popup().set_item_metadata(index, {
+			'id': d['id'],
+		})
+		index += 1
 
 
 func _on_entry_selected(index):
@@ -27,10 +26,10 @@ func _on_entry_selected(index):
 	text = _text
 
 
-func load_definition(section):
-	if section != '':
-		for d in DialogicUtil.get_default_definitions_list():
-			if d['section'] == section:
+func load_definition(id):
+	if id != '':
+		for d in DialogicResources.get_default_definitions()['variables']:
+			if d['id'] == id:
 				text = d['name']
 	else:
 		text = default_text

--- a/addons/dialogic/Editor/Pieces/Common/DefinitionPicker.gd
+++ b/addons/dialogic/Editor/Pieces/Common/DefinitionPicker.gd
@@ -12,7 +12,7 @@ func _ready():
 func _on_MenuButton_about_to_show():
 	get_popup().clear()
 	var index = 0
-	for d in DialogicUtil.get_default_definition_list():
+	for d in DialogicUtil.get_default_definitions_list():
 		if d['type'] == 0:
 			get_popup().add_item(d['name'])
 			get_popup().set_item_metadata(index, {
@@ -29,7 +29,7 @@ func _on_entry_selected(index):
 
 func load_definition(section):
 	if section != '':
-		for d in DialogicUtil.get_default_definition_list():
+		for d in DialogicUtil.get_default_definitions_list():
 			if d['section'] == section:
 				text = d['name']
 	else:

--- a/addons/dialogic/Editor/Pieces/IfCondition.gd
+++ b/addons/dialogic/Editor/Pieces/IfCondition.gd
@@ -36,7 +36,7 @@ func load_data(data):
 
 func _on_definition_entry_selected(index):
 	var metadata = nodes['definition_picker'].get_popup().get_item_metadata(index)
-	event_data['definition'] = metadata['section']
+	event_data['definition'] = metadata['id']
 
 
 func _on_condition_entry_selected(index):

--- a/addons/dialogic/Editor/Pieces/SetValue.gd
+++ b/addons/dialogic/Editor/Pieces/SetValue.gd
@@ -21,7 +21,7 @@ func _ready():
 
 func _on_definition_entry_selected(index):
 	var metadata = nodes['definition_picker'].get_popup().get_item_metadata(index)
-	event_data['definition'] = metadata['section']
+	event_data['definition'] = metadata['id']
 
 
 func load_data(data):

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -323,4 +323,4 @@ func _on_Alignment_item_selected(index):
 
 
 func _on_Preview_text_changed():
-	DialogicUtil.set_theme_value(current_theme, 'text', 'preview', n['text_preview'].text)
+	DialogicResources.set_theme_value(current_theme, 'text', 'preview', n['text_preview'].text)

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -35,9 +35,6 @@ func _ready():
 	# Loading the config files
 	load_config_files()
 	
-	# Make sure saves are ready
-	DialogicDefinitionsSingleton.init(reset_saves)
-	
 	# Checking if the dialog should read the code from a external file
 	if timeline != '':
 		dialog_script = set_current_dialog(timeline + '.json')
@@ -55,12 +52,17 @@ func _ready():
 	# Getting the character information
 	characters = DialogicUtil.get_character_list()
 
-	if Engine.is_editor_hint() == false:
+	if not Engine.is_editor_hint():
 		load_dialog()
 
 
 func load_config_files():
-	definitions = DialogicDefinitionsSingleton.get_definitions_list()
+	if not Engine.is_editor_hint():
+		# Make sure saves are ready
+		DialogicDefinitionsSingleton.init(reset_saves)
+		definitions = DialogicDefinitionsSingleton.get_definitions_list()
+	else:
+		definitions = DialogicUtil.get_default_definitions_list()
 	settings = DialogicResources.get_settings_config()
 	var theme_file = 'res://addons/dialogic/Editor/ThemeEditor/default-theme.cfg'
 	if settings.has_section('theme'):
@@ -217,7 +219,6 @@ func parse_branches(dialog_script: Dictionary) -> Dictionary:
 
 func parse_definitions(text: String):
 	var words = []
-	var definition_list = DialogicDefinitionsSingleton.get_definitions_list()
 	if Engine.is_editor_hint():
 		# Loading variables again to avoid issues in the preview dialog
 		load_config_files()
@@ -353,8 +354,6 @@ func get_character(character_id):
 func event_handler(event: Dictionary):
 	# Handling an event and updating the available nodes accordingly.
 	reset_dialog_extras()
-	# Updating the settings and definitions in case that they were modified by a timelien
-	load_config_files()
 	
 	dprint('[D] Current Event: ', event)
 	match event:

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -36,10 +36,7 @@ func _ready():
 	load_config_files()
 	
 	# Make sure saves are ready
-	if (reset_saves):
-		DialogicDefinitionsSingleton.reset_to_defaults()
-	else:
-		DialogicResources.init_definitions_saves(false)
+	DialogicDefinitionsSingleton.init(reset_saves)
 	
 	# Checking if the dialog should read the code from a external file
 	if timeline != '':

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -11,9 +11,10 @@ class_name Dialogic
 # Do not use methods from other classes as it could break the plugin's integrity
 # ### /!\ ###
 
-static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
-	var dialog = load(dialog_scene_path)
+static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+	var dialog:  = load(dialog_scene_path)
 	var d = dialog.instance()
+	d.reset_saves = reset_saves
 	d.debug_mode = debug_mode
 	for t in DialogicUtil.get_timeline_list():
 		if t['name'] == timeline:
@@ -39,7 +40,7 @@ func save_definitions():
 
 
 func reset_definitions():
-	return DialogicDefinitionsSingleton.reset_to_defaults()
+	return DialogicDefinitionsSingleton.init(true)
 
 
 static func get_variable(name: String) -> String:

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -16,44 +16,56 @@ static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: S
 	var d = dialog.instance()
 	d.reset_saves = reset_saves
 	d.debug_mode = debug_mode
-	for t in DialogicUtil.get_timeline_list():
-		if t['name'] == timeline:
-			d.timeline = t['file'].replace('.json', '')
-			return d
-	d.dialog_script = {
-		"events":[{"character":"","portrait":"",
-		"text":"[Dialogic Error] Loading dialog [color=red]" + timeline + "[/color]. It seems like the timeline doesn't exists. Maybe the name is wrong?"}]
-	}
+	if not timeline.empty():
+		for t in DialogicUtil.get_timeline_list():
+			if t['name'] == timeline or t['file'] == timeline:
+				d.timeline = t['file']
+				return d
+		d.dialog_script = {
+			"events":[{"character":"","portrait":"",
+			"text":"[Dialogic Error] Loading dialog [color=red]" + timeline + "[/color]. It seems like the timeline doesn't exists. Maybe the name is wrong?"}]
+		}
 	return d
 
 
+static func start_from_save(initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+	var current := get_current_timeline()
+	if current.empty():
+		current = initial_timeline
+	return start(current, false, dialog_scene_path, debug_mode)
+
+
 static func get_default_definitions_list() -> Array:
-	return DialogicDefinitionsSingleton.get_default_definitions_list()
+	return DialogicSingleton.get_default_definitions_list()
 
 
 static func get_definitions_list() -> Array:
-	return DialogicDefinitionsSingleton.get_definitions_list()
+	return DialogicSingleton.get_definitions_list()
 
 
 func save_definitions():
-	return DialogicDefinitionsSingleton.save_definitions()
+	return DialogicSingleton.save_definitions()
 
 
-func reset_definitions():
-	return DialogicDefinitionsSingleton.init(true)
+func reset_saves():
+	return DialogicSingleton.init(true)
 
 
 static func get_variable(name: String) -> String:
-	return DialogicDefinitionsSingleton.get_variable(name)
+	return DialogicSingleton.get_variable(name)
 
 
 static func set_variable(name: String, value) -> void:
-	DialogicDefinitionsSingleton.set_variable(name, value)
+	DialogicSingleton.set_variable(name, value)
 
 
-func get_glossary(name: String) -> Dictionary:
-	return DialogicDefinitionsSingleton.get_glossary(name)
+static func get_glossary(name: String) -> Dictionary:
+	return DialogicSingleton.get_glossary(name)
 
 
-func set_glossary(name: String, title: String, text: String, extra: String) -> void:
-	DialogicDefinitionsSingleton.set_glossary(name, title, text, extra)
+static func set_glossary(name: String, title: String, text: String, extra: String) -> void:
+	DialogicSingleton.set_glossary(name, title, text, extra)
+
+
+static func get_current_timeline() -> String:
+	return DialogicSingleton.get_current_timeline()

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -35,12 +35,12 @@ static func start_from_save(initial_timeline: String, dialog_scene_path: String=
 	return start(current, false, dialog_scene_path, debug_mode)
 
 
-static func get_default_definitions_list() -> Array:
-	return DialogicSingleton.get_default_definitions_list()
+static func get_default_definitions() -> Dictionary:
+	return DialogicSingleton.get_default_definitions()
 
 
-static func get_definitions_list() -> Array:
-	return DialogicSingleton.get_definitions_list()
+static func get_definitions() -> Dictionary:
+	return DialogicSingleton.get_default_definitions()
 
 
 func save_definitions():

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -1,6 +1,15 @@
 extends Node
 class_name Dialogic
 
+# TODO save definitions on timeline end
+
+# Exposed and safe to use methods for Dialogic
+# See documentation here:
+# https://github.com/coppolaemilio/dialogic
+
+# ### /!\ ###
+# Do not use methods from other classes as it could break the plugin's integrity
+# ### /!\ ###
 
 static func start(timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
 	var dialog = load(dialog_scene_path)
@@ -17,13 +26,33 @@ static func start(timeline: String, dialog_scene_path: String="res://addons/dial
 	return d
 
 
-static func reset_saves():
-	DialogicResources.init_definitions_saves(true)
+static func get_default_definitions_list() -> Array:
+	return DialogicDefinitionsSingleton.get_default_definitions_list()
 
 
-static func get_var(variable: String):
-	return DialogicUtil.get_var(variable)
+static func get_definitions_list() -> Array:
+	return DialogicDefinitionsSingleton.get_definitions_list()
 
 
-static func set_var(variable: String, value):
-	DialogicUtil.set_var(variable, value)
+func save_definitions():
+	return DialogicDefinitionsSingleton.save_definitions()
+
+
+func reset_definitions():
+	return DialogicDefinitionsSingleton.reset_to_defaults()
+
+
+static func get_variable(name: String) -> String:
+	return DialogicDefinitionsSingleton.get_variable(name)
+
+
+static func set_variable(name: String, value) -> void:
+	DialogicDefinitionsSingleton.set_variable(name, value)
+
+
+func get_glossary(name: String) -> Dictionary:
+	return DialogicDefinitionsSingleton.get_glossary(name)
+
+
+func set_glossary(name: String, title: String, text: String, extra: String) -> void:
+	DialogicDefinitionsSingleton.set_glossary(name, title, text, extra)

--- a/addons/dialogic/Other/DialogicDefinitionsSingleton.gd
+++ b/addons/dialogic/Other/DialogicDefinitionsSingleton.gd
@@ -1,0 +1,75 @@
+extends Node
+
+var current_definitions: Array
+var default_definitions: Array
+
+
+func _init() -> void:
+	# Loads saved definitions into memory
+	current_definitions = []
+	var config = DialogicResources.get_saved_definitions_config()
+	current_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
+	config = DialogicResources.get_default_definitions_config()
+	default_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
+
+
+func get_definitions_list() -> Array:
+	return current_definitions
+
+
+func get_default_definitions_list() -> Array:
+	return default_definitions
+
+
+func save_definitions():
+	var config = ConfigFile.new()
+	for d in current_definitions:
+		var s = d['section'];
+		if d['type'] == 0:
+			DialogicDefinitionsUtil.set_definition_variable(config, s, d['name'], d['value'])
+		else:
+			DialogicDefinitionsUtil.set_definition_glossary(config, s, d['name'], d['title'], d['text'], d['extra'])
+	
+	return DialogicResources.save_saved_definitions(config)
+
+
+func reset_to_defaults():
+	DialogicResources.init_definitions_saves(true)
+	self._init()
+
+
+func get_variable(name: String) -> String:
+	for d in current_definitions:
+		if d['type'] == 0 and d['name'] == name:
+			return d['value']
+	return ''
+
+
+func set_variable(name: String, value) -> void:
+	for d in current_definitions:
+		if d['type'] == 0 and d['name'] == name:
+			d['value'] = str(value)
+
+
+func set_variable_from_id(section: String, value) -> void:
+	for d in current_definitions:
+		if d['type'] == 0 and d['section'] == section:
+			d['value'] = str(value)
+
+func get_glossary(name: String) -> Dictionary:
+	for d in current_definitions:
+		if d['type'] == 1 and d['name'] == name:
+			return d
+	return { 
+		'title': '',
+		'text': '',
+		'extra': ''
+	}
+
+
+func set_glossary(name: String, title: String, text: String, extra: String) -> void:
+	for d in current_definitions:
+		if d['type'] == 1 and d['name'] == name:
+			d['title'] = title
+			d['text'] = text
+			d['extra'] = extra

--- a/addons/dialogic/Other/DialogicDefinitionsSingleton.gd
+++ b/addons/dialogic/Other/DialogicDefinitionsSingleton.gd
@@ -4,8 +4,9 @@ var current_definitions: Array
 var default_definitions: Array
 
 
-func _init() -> void:
+func init(reset: bool=false) -> void:
 	# Loads saved definitions into memory
+	DialogicResources.init_definitions_saves(reset)
 	current_definitions = []
 	var config = DialogicResources.get_saved_definitions_config()
 	current_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
@@ -31,11 +32,6 @@ func save_definitions():
 			DialogicDefinitionsUtil.set_definition_glossary(config, s, d['name'], d['title'], d['text'], d['extra'])
 	
 	return DialogicResources.save_saved_definitions(config)
-
-
-func reset_to_defaults():
-	DialogicResources.init_definitions_saves(true)
-	self._init()
 
 
 func get_variable(name: String) -> String:

--- a/addons/dialogic/Other/DialogicDefinitionsUtil.gd
+++ b/addons/dialogic/Other/DialogicDefinitionsUtil.gd
@@ -1,0 +1,55 @@
+extends Node
+class_name DialogicDefinitionsUtil
+
+static func get_definition_key(config: ConfigFile, section: String, key: String, default):
+	if config.has_section(section):
+		return config.get_value(section, key, default)
+	else:
+		return default
+
+
+static func set_definition_variable(config: ConfigFile, section: String, name: String,  value):
+	config.set_value(section, 'name', name)
+	config.set_value(section, 'type', 0)
+	config.set_value(section, 'value', str(value))
+
+
+static func set_definition_glossary(config: ConfigFile, section: String, name: String,  extra_title: String,  extra_text: String,  extra_extra: String):
+	config.set_value(section, 'name', name)
+	config.set_value(section, 'type', 1)
+	config.set_value(section, 'extra_title', extra_title)
+	config.set_value(section, 'extra_text', extra_text)
+	config.set_value(section, 'extra_extra', extra_extra)
+
+
+static func add_definition_variable(config: ConfigFile, section: String, name: String, type: int, value):
+	config.set_value(section, 'name', name)
+	config.set_value(section, 'type', type)
+	config.set_value(section, 'value', str(value))
+
+
+static func delete_definition(config: ConfigFile, section: String):
+	config.erase_section(section)
+
+
+static func definitions_config_to_array(config: ConfigFile) -> Array:
+	var array := []
+	for section in config.get_sections():
+		var type = config.get_value(section, 'type', 0);
+		if type == 0:
+			array.append({
+				'section': section,
+				'name': config.get_value(section, 'name', section),
+				'value': config.get_value(section, 'value', ''),
+				'type': type,
+			})
+		else:
+			array.append({
+				'section': section,
+				'name': config.get_value(section, 'name', section),
+				'title': config.get_value(section, 'extra_title', section),
+				'text': config.get_value(section, 'extra_text', section),
+				'extra': config.get_value(section, 'extra_extra', section),
+				'type': type,
+			})
+	return array

--- a/addons/dialogic/Other/DialogicDefinitionsUtil.gd
+++ b/addons/dialogic/Other/DialogicDefinitionsUtil.gd
@@ -1,55 +1,71 @@
 extends Node
 class_name DialogicDefinitionsUtil
 
-static func get_definition_key(config: ConfigFile, section: String, key: String, default):
-	if config.has_section(section):
-		return config.get_value(section, key, default)
-	else:
-		return default
+
+static func get_definition_by_key(data: Dictionary, key: String, value: String):
+	var variables : Array = data['variables']
+	var glossary : Array = data['glossary']
+	for v in variables:
+		if v[key] == value:
+			return v
+	for g in glossary:
+		if g[key] == value:
+			return g
+	return null
 
 
-static func set_definition_variable(config: ConfigFile, section: String, name: String,  value):
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', 0)
-	config.set_value(section, 'value', str(value))
+static func get_definition_by_id(data: Dictionary, id: String):
+	return get_definition_by_key(data, 'id', id)
 
 
-static func set_definition_glossary(config: ConfigFile, section: String, name: String,  extra_title: String,  extra_text: String,  extra_extra: String):
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', 1)
-	config.set_value(section, 'extra_title', extra_title)
-	config.set_value(section, 'extra_text', extra_text)
-	config.set_value(section, 'extra_extra', extra_extra)
+static func get_definition_by_name(data: Dictionary, id: String):
+	return get_definition_by_key(data, 'name', id)
 
 
-static func add_definition_variable(config: ConfigFile, section: String, name: String, type: int, value):
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', type)
-	config.set_value(section, 'value', str(value))
+static func set_definition(section: String, data: Dictionary, elem: Dictionary):
+	delete_definition(data, elem['id'])
+	var array: Array = data[section]
+	var found = false;
+	for e in array:
+		if e['id'] == elem['id']:
+			found = true
+			array.erase(e)
+			array.append(elem)
+			break
+	if not found:
+		array.append(elem)
 
 
-static func delete_definition(config: ConfigFile, section: String):
-	config.erase_section(section)
+static func set_definition_variable(data: Dictionary, id: String, name: String, value):
+	set_definition('variables', data, {
+		'id': id,
+		'name': name,
+		'value': value,
+		'type': 0
+	})
 
 
-static func definitions_config_to_array(config: ConfigFile) -> Array:
-	var array := []
-	for section in config.get_sections():
-		var type = config.get_value(section, 'type', 0);
-		if type == 0:
-			array.append({
-				'section': section,
-				'name': config.get_value(section, 'name', section),
-				'value': config.get_value(section, 'value', ''),
-				'type': type,
-			})
+static func set_definition_glossary(data: Dictionary, id: String, name: String,  title: String,  text: String,  extra: String):
+	set_definition('glossary', data, {
+		'id': id,
+		'name': name,
+		'title': title,
+		'text': text,
+		'extra': extra,
+		'type': 1
+	})
+
+
+static func delete_definition(data: Dictionary, id: String):
+	var variables : Array = data['variables']
+	var glossary : Array = data['glossary']
+	var item = get_definition_by_id(data, id);
+	if item != null:
+		if (item['type'] == 0):
+			variables.erase(item)
 		else:
-			array.append({
-				'section': section,
-				'name': config.get_value(section, 'name', section),
-				'title': config.get_value(section, 'extra_title', section),
-				'text': config.get_value(section, 'extra_text', section),
-				'extra': config.get_value(section, 'extra_extra', section),
-				'type': type,
-			})
-	return array
+			glossary.erase(item)
+
+
+static func definitions_json_to_array(data: Dictionary) -> Array:
+	return data['variables'] + data['glossary']

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -61,7 +61,7 @@ static func get_config_files_paths() -> Dictionary:
 		'SETTINGS_FILE': RESOURCES_DIR + "/settings.cfg",
 		'DEFAULT_DEFINITIONS_FILE': RESOURCES_DIR + "/definitions.json",
 		'SAVED_DEFINITIONS_FILE': WORKING_DIR + "/definitions.json",
-		'SAVED_STATE_FILE': WORKING_DIR + "/state.cfg",
+		'SAVED_STATE_FILE': WORKING_DIR + "/state.json",
 	}
 
 
@@ -280,23 +280,26 @@ static func set_settings_value(section: String, key: String, value):
 # STATE
 
 
-static func get_saved_state_config() -> ConfigFile:
-	return get_config('SAVED_STATE_FILE')
+static func get_saved_state() -> Dictionary:
+	return load_json(get_config_files_paths()['SAVED_STATE_FILE'], {'general': {}})
 
 
-static func save_saved_state_config(config: ConfigFile):
-	return config.save(get_config_files_paths()['SAVED_STATE_FILE'])
+static func save_saved_state_config(data: Dictionary):
+	set_json(get_config_files_paths()['SAVED_STATE_FILE'], data)
 
 
 static func get_saved_state_general_key(key: String) -> String:
-	var config = get_saved_state_config()
-	return config.get_value('general', key, '')
+	var data = get_saved_state()
+	if key in data['general'].keys():
+		return data['general'][key]
+	else:
+		return ''
 
 
 static func set_saved_state_general_key(key: String, value):
-	var config = get_saved_state_config()
-	config.set_value('general', key, str(value))
-	return save_saved_state_config(config)
+	var data = get_saved_state()
+	data['general'][key] = str(value)
+	save_saved_state_config(data)
 
 
 # DEFAULT DEFINITIONS

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -179,6 +179,8 @@ static func set_json(dir_id: String, path: String, data: Dictionary):
 
 
 # TIMELINE
+# Can only be edited in the editor
+
 
 static func get_timeline_json(path: String):
 	return get_json('TIMELINE_DIR', path)
@@ -195,6 +197,7 @@ static func delete_timeline(filename: String):
 
 
 # CHARACTER
+# Can only be edited in the editor
 
 
 static func get_character_json(path: String):
@@ -212,6 +215,7 @@ static func delete_character(filename: String):
 
 
 # THEME
+# Can only be edited in the editor
 
 
 static func get_theme_config(filename: String):
@@ -240,6 +244,7 @@ static func add_theme(filename: String):
 
 
 # SETTINGS
+# Can only be edited in the editor
 
 
 static func get_settings_config():
@@ -252,79 +257,49 @@ static func set_settings_value(section: String, key: String, value):
 	config.save(get_config_files_paths()['SETTINGS_FILE'])
 
 
-# DEFINITIONS UTIL
-# used by default and saved definitions
-
-static func get_definition_key(config_id: String, section: String, key: String, default):
-	var config = get_config(config_id)
-	if config.has_section(section):
-		return config.get_value(section, key, default)
-	else:
-		return default
-
-
-static func set_definition_variable(config_id: String, section: String, name: String,  value):
-	var config = get_config(config_id)
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', 0)
-	config.set_value(section, 'value', str(value))
-	return config.save(get_config_files_paths()[config_id])
-
-
-static func set_definition_glossary(config_id: String, section: String, name: String,  extra_title: String,  extra_text: String,  extra_extra: String):
-	var config = get_config(config_id)
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', 1)
-	config.set_value(section, 'extra_title', extra_title)
-	config.set_value(section, 'extra_text', extra_text)
-	config.set_value(section, 'extra_extra', extra_extra)
-	return config.save(get_config_files_paths()[config_id])
-
-
-static func add_definition_variable(config_id: String, section: String, name: String, type: int, value):
-	var config = get_config(config_id)
-	config.set_value(section, 'name', name)
-	config.set_value(section, 'type', type)
-	config.set_value(section, 'value', str(value))
-	return config.save(get_config_files_paths()[config_id])
-
-
-static func delete_definition(config_id: String, section: String):
-	var config = get_config(config_id)
-	config.erase_section(section)
-	return config.save(get_config_files_paths()[config_id])
-
-
-
 # DEFAULT DEFINITIONS
 # Can only be edited in the editor
+
 
 static func get_default_definitions_config():
 	return get_config('DEFAULT_DEFINITIONS_FILE')
 
 
+static func save_default_definitions_config(config: ConfigFile):
+	return config.save(get_config_files_paths()['DEFAULT_DEFINITIONS_FILE'])
+
+
 static func get_default_definition_key(section: String, key: String, default):
-	return get_definition_key('DEFAULT_DEFINITIONS_FILE', section, key, default)
+	var config = get_default_definitions_config()
+	return DialogicDefinitionsUtil.get_definition_key(config, section, key, default)
 
 
 static func set_default_definition_variable(section: String, name: String,  value):
 	# WARNING: For use in the editor only
-	return set_definition_variable('DEFAULT_DEFINITIONS_FILE', section, name, value)
+	var config = get_default_definitions_config()
+	DialogicDefinitionsUtil.set_definition_variable(config, section, name, value)
+	return save_default_definitions_config(config)
 
 
 static func set_default_definition_glossary(section: String, name: String,  extra_title: String,  extra_text: String,  extra_extra: String):
 	# WARNING: For use in the editor only
-	return set_definition_glossary('DEFAULT_DEFINITIONS_FILE', section, name, extra_title, extra_text, extra_extra)
+	var config = get_default_definitions_config()
+	DialogicDefinitionsUtil.set_definition_glossary(config, section, name, extra_title, extra_text, extra_extra)
+	return save_default_definitions_config(config)
 
 
 static func add_default_definition_variable(section: String, name: String, type: int, value):
 	# WARNING: For use in the editor only
-	return add_definition_variable('DEFAULT_DEFINITIONS_FILE', section, name, type, value)
+	var config = get_default_definitions_config()
+	DialogicDefinitionsUtil.add_definition_variable(config, section, name, type, value)
+	return save_default_definitions_config(config)
 
 
 static func delete_default_definition(section: String):
 	# WARNING: For use in the editor only
-	return delete_definition('DEFAULT_DEFINITIONS_FILE', section)
+	var config = get_default_definitions_config()
+	DialogicDefinitionsUtil.delete_definition(config, section)
+	return save_default_definitions_config(config)
 
 
 # SAVED DEFINITIONS
@@ -332,18 +307,8 @@ static func delete_default_definition(section: String):
 
 
 static func get_saved_definitions_config():
-	return get_config("SAVED_DEFINITIONS_FILE")
+	return get_config('SAVED_DEFINITIONS_FILE')
 
 
-static func set_saved_definition_variable(section: String, name: String,  value):
-	return set_definition_variable('SAVED_DEFINITIONS_FILE', section, name, value)
-
-
-static func set_saved_definition_variable_value(section: String, value):
-	var config = get_saved_definitions_config()
-	return set_definition_variable('SAVED_DEFINITIONS_FILE', section, config.get_value(section, 'name', section), value)
-
-
-static func set_saved_definition_glossary(section: String, name: String,  extra_title: String,  extra_text: String,  extra_extra: String):
-	return set_definition_glossary('SAVED_DEFINITIONS_FILE', section, name, extra_title, extra_text, extra_extra)
-
+static func save_saved_definitions(config: ConfigFile):
+	return config.save(get_config_files_paths()['SAVED_DEFINITIONS_FILE'])

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -345,7 +345,7 @@ static func delete_default_definition(id: String):
 
 
 static func get_saved_definitions() -> Dictionary:
-	return load_json(get_config_files_paths()['SAVED_DEFINITIONS_FILE'])
+	return load_json(get_config_files_paths()['SAVED_DEFINITIONS_FILE'], {'variables': [], 'glossary': []})
 
 
 static func save_saved_definitions(data: Dictionary):

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -1,17 +1,23 @@
 extends Node
 
-var current_definitions: Array
-var default_definitions: Array
+var current_definitions := []
+var default_definitions := []
+
+var current_timeline := ''
+
+func _init() -> void:
+	init(false)
 
 
 func init(reset: bool=false) -> void:
 	# Loads saved definitions into memory
-	DialogicResources.init_definitions_saves(reset)
+	DialogicResources.init_saves(reset)
 	current_definitions = []
-	var config = DialogicResources.get_saved_definitions_config()
+	var config := DialogicResources.get_saved_definitions_config()
 	current_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
 	config = DialogicResources.get_default_definitions_config()
 	default_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
+	current_timeline = DialogicResources.get_saved_state_general_key('timeline')
 
 
 func get_definitions_list() -> Array:
@@ -69,3 +75,15 @@ func set_glossary(name: String, title: String, text: String, extra: String) -> v
 			d['title'] = title
 			d['text'] = text
 			d['extra'] = extra
+
+
+func set_current_timeline(timeline: String):
+	print('====> saving timeline ' + timeline)
+	current_timeline = timeline
+	DialogicResources.set_saved_state_general_key('timeline', timeline)
+
+
+func get_current_timeline() -> String:
+	return current_timeline
+
+

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -1,7 +1,7 @@
 extends Node
 
-var current_definitions := []
-var default_definitions := []
+var current_definitions := {}
+var default_definitions := {}
 
 var current_timeline := ''
 
@@ -12,55 +12,53 @@ func _init() -> void:
 func init(reset: bool=false) -> void:
 	# Loads saved definitions into memory
 	DialogicResources.init_saves(reset)
-	current_definitions = []
-	var config := DialogicResources.get_saved_definitions_config()
-	current_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
-	config = DialogicResources.get_default_definitions_config()
-	default_definitions = DialogicDefinitionsUtil.definitions_config_to_array(config)
+	current_definitions = DialogicResources.get_saved_definitions()
+	default_definitions = DialogicResources.get_default_definitions()
 	current_timeline = DialogicResources.get_saved_state_general_key('timeline')
 
 
 func get_definitions_list() -> Array:
+	return DialogicDefinitionsUtil.definitions_json_to_array(current_definitions)
+
+
+func get_definitions() -> Dictionary:
 	return current_definitions
 
 
-func get_default_definitions_list() -> Array:
+func get_default_definitions() -> Dictionary:
 	return default_definitions
 
 
+func get_default_definitions_list() -> Array:
+	return DialogicDefinitionsUtil.definitions_json_to_array(default_definitions)
+
+
 func save_definitions():
-	var config = ConfigFile.new()
-	for d in current_definitions:
-		var s = d['section'];
-		if d['type'] == 0:
-			DialogicDefinitionsUtil.set_definition_variable(config, s, d['name'], d['value'])
-		else:
-			DialogicDefinitionsUtil.set_definition_glossary(config, s, d['name'], d['title'], d['text'], d['extra'])
-	
-	return DialogicResources.save_saved_definitions(config)
+	return DialogicResources.save_saved_definitions(current_definitions)
 
 
 func get_variable(name: String) -> String:
-	for d in current_definitions:
-		if d['type'] == 0 and d['name'] == name:
+	for d in current_definitions['variables']:
+		if d['name'] == name:
 			return d['value']
 	return ''
 
 
 func set_variable(name: String, value) -> void:
-	for d in current_definitions:
-		if d['type'] == 0 and d['name'] == name:
+	for d in current_definitions['variables']:
+		if d['name'] == name:
 			d['value'] = str(value)
 
 
-func set_variable_from_id(section: String, value) -> void:
-	for d in current_definitions:
-		if d['type'] == 0 and d['section'] == section:
+func set_variable_from_id(id: String, value) -> void:
+	for d in current_definitions['variables']:
+		if d['id'] == id:
 			d['value'] = str(value)
+
 
 func get_glossary(name: String) -> Dictionary:
-	for d in current_definitions:
-		if d['type'] == 1 and d['name'] == name:
+	for d in current_definitions['glossary']:
+		if d['name'] == name:
 			return d
 	return { 
 		'title': '',
@@ -70,15 +68,14 @@ func get_glossary(name: String) -> Dictionary:
 
 
 func set_glossary(name: String, title: String, text: String, extra: String) -> void:
-	for d in current_definitions:
-		if d['type'] == 1 and d['name'] == name:
+	for d in current_definitions['glossary']:
+		if d['name'] == name:
 			d['title'] = title
 			d['text'] = text
 			d['extra'] = extra
 
 
 func set_current_timeline(timeline: String):
-	print('====> saving timeline ' + timeline)
 	current_timeline = timeline
 	DialogicResources.set_saved_state_general_key('timeline', timeline)
 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -68,11 +68,6 @@ static func get_theme_list() -> Array:
 	return themes
 
 
-static func get_default_definitions_list() -> Array:
-	var config = DialogicResources.get_default_definitions_config()
-	return DialogicDefinitionsUtil.definitions_config_to_array(config)
-
-
 static func generate_random_id() -> String:
 	return str(OS.get_unix_time()) + '-' + str(100 + randi()%899+1)
 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -68,6 +68,10 @@ static func get_theme_list() -> Array:
 	return themes
 
 
+static func get_default_definitions_list() -> Array:
+	return DialogicDefinitionsUtil.definitions_json_to_array(DialogicResources.get_default_definitions())
+
+
 static func generate_random_id() -> String:
 	return str(OS.get_unix_time()) + '-' + str(100 + randi()%899+1)
 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -68,43 +68,9 @@ static func get_theme_list() -> Array:
 	return themes
 
 
-static func get_default_definition_list() -> Array:
-	var definitions: Array = []
+static func get_default_definitions_list() -> Array:
 	var config = DialogicResources.get_default_definitions_config()
-	for section in config.get_sections():
-		definitions.append({
-			'section': section,
-			'name': config.get_value(section, 'name', section),
-			'config': config,
-			'type': config.get_value(section, 'type', 0),
-		})
-	return definitions
-
-
-static func get_definition_list() -> Array:
-	var definitions: Array = []
-	var config = DialogicResources.get_saved_definitions_config()
-	for section in config.get_sections():
-		definitions.append({
-			'section': section,
-			'name': config.get_value(section, 'name', section),
-			'config': config,
-			'type': config.get_value(section, 'type', 0),
-		})
-	return definitions
-
-
-static func get_var(variable: String) -> String:
-	for d in get_definition_list():
-		if d['name'] == variable:
-			return d['config'].get_value(d['section'], 'value')
-	return ''
-
-
-static func set_var(variable: String, value) -> void:
-	for d in get_definition_list():
-		if d['name'] == variable:
-			DialogicResources.set_saved_definition_variable(d['section'], d['name'], value)
+	return DialogicDefinitionsUtil.definitions_config_to_array(config)
 
 
 static func generate_random_id() -> String:

--- a/addons/dialogic/Other/timeline_picker.gd
+++ b/addons/dialogic/Other/timeline_picker.gd
@@ -36,7 +36,7 @@ func _about_to_show_menu():
 func _on_timeline_selected(index):
 	var text = timelines_dropdown.get_popup().get_item_text(index)
 	var metadata = timelines_dropdown.get_popup().get_item_metadata(index)
-	current_value = metadata['file'].replace('.json', '')
+	current_value = metadata['file']
 	timelines_dropdown.text = text
 	emit_changed(get_edited_property(), current_value)
 
@@ -52,6 +52,6 @@ func update_property():
 	current_value = new_value
 	# Checking for the display name
 	for c in DialogicUtil.get_timeline_list():
-		if c['file'].replace('.json', '') == current_value:
+		if c['file'] == current_value:
 			timelines_dropdown.text = c['name']
 	updating = false

--- a/addons/dialogic/dialogic.gd
+++ b/addons/dialogic/dialogic.gd
@@ -8,7 +8,7 @@ func _init():
 	if Engine.editor_hint:
 		# Make sure the core files exist 
 		DialogicResources.init_dialogic_files()
-	add_autoload_singleton('DialogicDefinitionsSingleton', "res://addons/dialogic/Other/DialogicDefinitionsSingleton.gd")
+	add_autoload_singleton('DialogicSingleton', "res://addons/dialogic/Other/DialogicSingleton.gd")
 
 
 func _enter_tree() -> void:

--- a/addons/dialogic/dialogic.gd
+++ b/addons/dialogic/dialogic.gd
@@ -4,6 +4,13 @@ extends EditorPlugin
 var _editor_view
 var _parts_inspector
 
+func _init():
+	if Engine.editor_hint:
+		# Make sure the core files exist 
+		DialogicResources.init_dialogic_files()
+	add_autoload_singleton('DialogicDefinitionsSingleton', "res://addons/dialogic/Other/DialogicDefinitionsSingleton.gd")
+
+
 func _enter_tree() -> void:
 	_parts_inspector = load("res://addons/dialogic/Other/inspector_timeline_picker.gd").new()
 	add_inspector_plugin(_parts_inspector)
@@ -14,8 +21,6 @@ func _enter_tree() -> void:
 
 func _ready():
 	if Engine.editor_hint:
-		# Make sure the core files exist 
-		DialogicResources.init_dialogic_files()
 		# Force Godot to show the dialogic folder
 		get_editor_interface().get_resource_filesystem().scan()
 	


### PR DESCRIPTION
Definitions and current timeline are kept in memory inside a singleton, and saved to disk when needed.

This data is only saved to the config file on timeline end/start.

While in the editor, default values are loaded as I can't seem to make the saves singleton load.

User can request a definitions reset either by a dedicated function, or by passing an argument to the start method.

Current timeline is saved so user can read it while running or load it back on next run. This feature combined with definitions saving makes a complete save/restore system, in which users can exit mid-timeline without negative effects.

I also added a lot of utility functions in `DialogicClass.gd`, to allow the user to edit and query variables and glossary definitions. It only repeats functions in the singleton, but this way the user only has one class to worry about and it prevents him from accessing unsafe methods.

Closes #102 