### PR TITLE
Improve timeline editor controls

### DIFF
--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -6,6 +6,7 @@ var editor_file_dialog # EditorFileDialog
 var file_picker_data: Dictionary = {'method': '', 'node': self}
 var current_editor_view: String = 'Master'
 var version_string: String 
+onready var master_tree = $MainPanel/MasterTree
 onready var timeline_editor = $MainPanel/TimelineEditor
 onready var character_editor = $MainPanel/CharacterEditor
 onready var definition_editor = $MainPanel/DefinitionEditor
@@ -24,6 +25,8 @@ func _ready():
 	definition_editor.editor_reference = self
 	theme_editor.editor_reference = self
 
+	master_tree.connect("editor_selected", self, 'on_master_tree_editor_selected')
+
 	# Toolbar
 	$ToolBar/NewTimelineButton.connect('pressed', $MainPanel/TimelineEditor, 'new_timeline')
 	$ToolBar/NewCharactersButton.connect('pressed', $MainPanel/CharacterEditor, 'new_character')
@@ -31,8 +34,8 @@ func _ready():
 	$ToolBar/NewDefinitionButton.connect('pressed', $MainPanel/DefinitionEditor, 'new_definition')
 	$ToolBar/Docs.icon = get_icon("Instance", "EditorIcons")
 	$ToolBar/Docs.connect('pressed', OS, "shell_open", ["https://dialogic.coppolaemilio.com"])
-	#$ToolBar/FoldTools/ButtonFold.connect('pressed', $EditorTimeline, 'fold_all_nodes')
-	#$ToolBar/FoldTools/ButtonUnfold.connect('pressed', $EditorTimeline, 'unfold_all_nodes')
+	$ToolBar/FoldTools/ButtonFold.connect('pressed', timeline_editor, 'fold_all_nodes')
+	$ToolBar/FoldTools/ButtonUnfold.connect('pressed', timeline_editor, 'unfold_all_nodes')
 	
 	
 	# Connecting context menus
@@ -53,6 +56,10 @@ func _ready():
 	if err == OK:
 		version_string = config.get_value("plugin", "version", "?")
 		$ToolBar/Version.text = 'v' + version_string
+
+
+func on_master_tree_editor_selected(editor: String):
+	$ToolBar/FoldTools.visible = editor == 'timeline'
 
 
 # Timeline context menu

--- a/addons/dialogic/Editor/EditorView.tscn
+++ b/addons/dialogic/Editor/EditorView.tscn
@@ -298,5 +298,4 @@ dialog_text = "Are you sure you want to remove this timeline?
 __meta__ = {
 "_edit_use_anchors_": false
 }
-
 [connection signal="gui_input" from="ToolBar/Logo" to="." method="_on_Logo_gui_input"]

--- a/addons/dialogic/Editor/MasterTree/MasterTree.gd
+++ b/addons/dialogic/Editor/MasterTree/MasterTree.gd
@@ -18,6 +18,8 @@ var definitions_tree
 var themes_tree
 var settings_tree
 
+signal editor_selected(selected)
+
 func _ready():
 	allow_rmb_select = true
 	var root = tree.create_item()
@@ -150,21 +152,27 @@ func _on_item_selected():
 	if metadata['editor'] == 'Timeline':
 		timeline_editor.visible = true
 		timeline_editor.load_timeline(metadata['file'])
+		emit_signal("editor_selected", 'timeline')
 	if metadata['editor'] == 'Character':
 		character_editor.visible = true
 		character_editor.load_character(metadata['file'])
+		emit_signal("editor_selected", 'character')
 	if metadata['editor'] == 'Definition':
 		definition_editor.visible = true
 		definition_editor.load_definition(metadata['id'])
+		emit_signal("editor_selected", 'definition')
 	if metadata['editor'] == 'Theme':
 		theme_editor.load_theme(metadata['file'])
 		theme_editor.visible = true
+		emit_signal("editor_selected", 'theme')
 	if metadata['editor'] == 'Settings':
 		settings_editor.update_data()
 		settings_editor.visible = true
+		emit_signal("editor_selected", 'settings')
 
 
 func hide_all_editors(show_empty = false):
+	emit_signal("editor_selected", 'none')
 	character_editor.visible = false
 	timeline_editor.visible = false
 	definition_editor.visible = false

--- a/addons/dialogic/Editor/Pieces/AudioBlock.tscn
+++ b/addons/dialogic/Editor/Pieces/AudioBlock.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/AudioBlock.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Images/audio-event.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Images/play.svg" type="Texture" id=5]
@@ -98,11 +99,10 @@ margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 157.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 1739.0
@@ -113,7 +113,6 @@ items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", 
 [node name="AudioPreview" type="AudioStreamPlayer" parent="PanelContainer"]
 
 [node name="DragController" parent="." instance=ExtResource( 6 )]
-
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonAudio" to="." method="_on_ButtonAudio_pressed"]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonPreviewPlay" to="." method="_on_ButtonPreviewPlay_pressed"]
 [connection signal="finished" from="PanelContainer/AudioPreview" to="." method="_on_AudioPreview_finished"]

--- a/addons/dialogic/Editor/Pieces/ChangeScene.tscn
+++ b/addons/dialogic/Editor/Pieces/ChangeScene.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/ChangeScene.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Images/change-scene.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=6]
@@ -90,11 +91,10 @@ margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 170.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 1739.0
@@ -105,6 +105,5 @@ items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", 
 [node name="AudioPreview" type="AudioStreamPlayer" parent="PanelContainer"]
 
 [node name="DragController" parent="." instance=ExtResource( 6 )]
-
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonScenePicker" to="." method="_on_ButtonScenePicker_pressed"]
 [connection signal="finished" from="PanelContainer/AudioPreview" to="." method="_on_AudioPreview_finished"]

--- a/addons/dialogic/Editor/Pieces/ChangeTimeline.tscn
+++ b/addons/dialogic/Editor/Pieces/ChangeTimeline.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/ChangeTimeline.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Images/change-timeline.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
@@ -80,11 +81,10 @@ margin_right = 267.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 271.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 1739.0
@@ -93,5 +93,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="about_to_show" from="PanelContainer/VBoxContainer/Header/MenuButton" to="." method="_on_MenuButton_about_to_show"]

--- a/addons/dialogic/Editor/Pieces/CharacterJoinBlock.tscn
+++ b/addons/dialogic/Editor/Pieces/CharacterJoinBlock.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/CharacterJoinBlock.gd" type="Script" id=3]
 [ext_resource path="res://addons/dialogic/Images/character-join.svg" type="Texture" id=4]
@@ -124,11 +125,10 @@ margin_right = 186.0
 margin_bottom = 30.0
 icon = ExtResource( 5 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 1 )]
 margin_left = 502.0
 margin_right = 1735.0
 margin_bottom = 30.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 1739.0

--- a/addons/dialogic/Editor/Pieces/CharacterLeaveBlock.tscn
+++ b/addons/dialogic/Editor/Pieces/CharacterLeaveBlock.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/CharacterLeaveBlock.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Images/character-leave.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
@@ -88,11 +89,10 @@ margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 243.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 1739.0
@@ -101,5 +101,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="about_to_show" from="PanelContainer/VBoxContainer/Header/CharacterDropdown" to="." method="_on_CharacterDropdown_about_to_show"]

--- a/addons/dialogic/Editor/Pieces/Choice.tscn
+++ b/addons/dialogic/Editor/Pieces/Choice.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/choice.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Choice.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Images/warning.svg" type="Texture" id=6]
@@ -98,11 +99,10 @@ margin_right = 102.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 106.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0
@@ -111,5 +111,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="visibility_changed" from="Indent" to="." method="_on_Indent_visibility_changed"]

--- a/addons/dialogic/Editor/Pieces/CloseDialog.tscn
+++ b/addons/dialogic/Editor/Pieces/CloseDialog.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Images/end-dialog.svg" type="Texture" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/CloseDialog.gd" type="Script" id=4]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=5]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -74,11 +75,10 @@ margin_right = 117.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 5 )]
 margin_left = 121.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 1739.0

--- a/addons/dialogic/Editor/Pieces/Common/Spacer.tscn
+++ b/addons/dialogic/Editor/Pieces/Common/Spacer.tscn
@@ -1,0 +1,8 @@
+[gd_scene format=2]
+
+[node name="Spacer" type="Control"]
+mouse_filter = 1
+size_flags_horizontal = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/addons/dialogic/Editor/Pieces/EmitSignal.tscn
+++ b/addons/dialogic/Editor/Pieces/EmitSignal.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/signal.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/EmitSignal.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 
@@ -104,11 +105,10 @@ margin_right = 180.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 184.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0
@@ -117,5 +117,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/Header/LineEdit" to="." method="_on_LineEdit_text_changed"]

--- a/addons/dialogic/Editor/Pieces/EndBranch.tscn
+++ b/addons/dialogic/Editor/Pieces/EndBranch.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/EndBranch.gd" type="Script" id=4]
 [ext_resource path="res://addons/dialogic/Images/end-choice.svg" type="Texture" id=5]
@@ -77,11 +78,10 @@ margin_right = 109.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 113.0
 margin_right = 961.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 1 )]
 margin_left = 965.0

--- a/addons/dialogic/Editor/Pieces/IfCondition.tscn
+++ b/addons/dialogic/Editor/Pieces/IfCondition.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/condition.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/IfCondition.gd" type="Script" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/CustomLineEdit.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DefinitionPicker.tscn" type="PackedScene" id=7]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=8]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -85,11 +86,10 @@ margin_right = 308.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 8 )]
 margin_left = 312.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0

--- a/addons/dialogic/Editor/Pieces/Question.tscn
+++ b/addons/dialogic/Editor/Pieces/Question.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/question.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Question.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 
@@ -87,11 +88,10 @@ margin_right = 305.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 309.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0
@@ -100,5 +100,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/Header/LineEdit" to="." method="_on_LineEdit_text_changed"]

--- a/addons/dialogic/Editor/Pieces/SceneEvent.tscn
+++ b/addons/dialogic/Editor/Pieces/SceneEvent.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/scene.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/VisibleToggle.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/SceneEvent.gd" type="Script" id=5]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=6]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -37,7 +38,7 @@ margin_bottom = 74.0
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 margin_right = 1024.0
-margin_bottom = 74.0
+margin_bottom = 78.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -47,7 +48,7 @@ custom_styles/panel = SubResource( 1 )
 margin_left = 16.0
 margin_top = 6.0
 margin_right = 1018.0
-margin_bottom = 68.0
+margin_bottom = 72.0
 size_flags_horizontal = 3
 
 [node name="Header" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
@@ -80,12 +81,10 @@ margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 6 )]
 margin_left = 169.0
 margin_right = 961.0
 margin_bottom = 30.0
-mouse_filter = 1
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 965.0
@@ -126,12 +125,11 @@ size_flags_horizontal = 3
 [node name="TextureRect" type="TextureRect" parent="PanelContainer/VBoxContainer"]
 margin_top = 62.0
 margin_right = 1002.0
-margin_bottom = 62.0
+margin_bottom = 66.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 expand = true
 stretch_mode = 5
 
 [node name="DragController" parent="." instance=ExtResource( 3 )]
-
 [connection signal="pressed" from="PanelContainer/VBoxContainer/HBoxContainer/ImageButton" to="." method="_on_ImageButton_pressed"]

--- a/addons/dialogic/Editor/Pieces/SetTheme.tscn
+++ b/addons/dialogic/Editor/Pieces/SetTheme.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/SetTheme.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Images/theme.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
@@ -80,11 +81,10 @@ margin_right = 217.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 221.0
 margin_right = 1735.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 1739.0
@@ -93,5 +93,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="about_to_show" from="PanelContainer/VBoxContainer/Header/MenuButton" to="." method="_on_MenuButton_about_to_show"]

--- a/addons/dialogic/Editor/Pieces/SetValue.tscn
+++ b/addons/dialogic/Editor/Pieces/SetValue.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/SetValue.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Images/Events/set-value.svg" type="Texture" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DefinitionPicker.tscn" type="PackedScene" id=6]
@@ -117,11 +118,10 @@ margin_right = 389.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 393.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0
@@ -130,5 +130,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/Header/LineEdit" to="." method="_on_LineEdit_text_changed"]

--- a/addons/dialogic/Editor/Pieces/TextBlock.tscn
+++ b/addons/dialogic/Editor/Pieces/TextBlock.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/TextBlock.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/VisibleToggle.tscn" type="PackedScene" id=2]
@@ -7,6 +7,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/CharacterPicker.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PortraitPicker.tscn" type="PackedScene" id=7]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=8]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 6.0
@@ -100,19 +101,17 @@ margin_right = 183.0
 
 [node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
 visible = false
-margin_left = 234.0
+margin_left = 187.0
 margin_top = 8.0
-margin_right = 246.0
+margin_right = 199.0
 margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "..."
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 8 )]
 margin_left = 187.0
 margin_right = 971.0
 margin_bottom = 30.0
-mouse_filter = 1
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 975.0
@@ -131,5 +130,4 @@ smooth_scrolling = true
 wrap_enabled = true
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/TextEdit" to="." method="_on_TextEdit_text_changed"]

--- a/addons/dialogic/Editor/Pieces/WaitSeconds.tscn
+++ b/addons/dialogic/Editor/Pieces/WaitSeconds.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/Wait.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/WaitSeconds.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 
@@ -93,11 +94,10 @@ margin_right = 222.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
-[node name="Spacer" type="Control" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
 margin_left = 226.0
 margin_right = 941.0
 margin_bottom = 28.0
-size_flags_horizontal = 3
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 945.0
@@ -106,5 +106,4 @@ margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-
 [connection signal="value_changed" from="PanelContainer/VBoxContainer/Header/SpinBox" to="." method="_on_SpinBox_value_changed"]

--- a/addons/dialogic/Editor/Pieces/selected_styleboxflat.tres
+++ b/addons/dialogic/Editor/Pieces/selected_styleboxflat.tres
@@ -1,0 +1,17 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+content_margin_left = 16.0
+content_margin_right = 6.0
+content_margin_top = 6.0
+content_margin_bottom = 6.0
+bg_color = Color( 0.0980392, 0.329412, 0.509804, 1 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.0901961, 0.560784, 0.937255, 1 )
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -31,20 +31,25 @@ func _ready():
 				b.connect('pressed', self, "_create_event_button_pressed", [b.name])
 
 
-func _select_item(item: Node):
+func _clear_selection():
 	if selected_item != null and saved_style != null:
 		var selected_panel: PanelContainer = selected_item.get_node("PanelContainer")
 		if selected_panel != null:
 			selected_panel.set('custom_styles/panel', saved_style)
+	selected_item = null
+	saved_style = null
+
+
+func _select_item(item: Node):
 	if item != selected_item:
+		_clear_selection()
 		var panel: PanelContainer = item.get_node("PanelContainer")
 		if panel != null:
 			saved_style = panel.get('custom_styles/panel')
 			selected_item = item
 			panel.set('custom_styles/panel', selected_style)
 	else:
-		selected_item = null
-		saved_style = null
+		_clear_selection()
 
 
 func _on_gui_input(event, item: Node):
@@ -202,6 +207,7 @@ func load_timeline(filename: String):
 
 
 func clear_timeline():
+	_clear_selection()
 	for event in timeline.get_children():
 		event.free()
 

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -23,10 +23,6 @@ func _ready():
 				b.connect('pressed', self, "_on_ButtonQuestion_pressed", [])
 			elif b.name == 'IfCondition':
 				b.connect('pressed', self, "_on_ButtonCondition_pressed", [])
-			elif b.name == 'Fold':
-				b.connect('pressed', self, "_on_ButtonFold_pressed", [])
-			elif b.name == 'Unfold':
-				b.connect('pressed', self, "_on_ButtonUnfold_pressed", [])
 			else:
 				b.connect('pressed', self, "_create_event_button_pressed", [b.name])
 
@@ -87,14 +83,6 @@ func _on_ButtonCondition_pressed() -> void:
 	else:
 		create_event("IfCondition", {'no-data': true}, true)
 		create_event("EndBranch", {'no-data': true}, true)
-
-
-func _on_ButtonFold_pressed() -> void:
-	fold_all_nodes()
-
-
-func _on_ButtonUnfold_pressed() -> void:
-	unfold_all_nodes()
 
 
 # Adding an event to the timeline

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -18,6 +18,10 @@ func _ready():
 				b.connect('pressed', self, "_on_ButtonQuestion_pressed", [])
 			elif b.name == 'IfCondition':
 				b.connect('pressed', self, "_on_ButtonCondition_pressed", [])
+			elif b.name == 'Fold':
+				b.connect('pressed', self, "_on_ButtonFold_pressed", [])
+			elif b.name == 'Unfold':
+				b.connect('pressed', self, "_on_ButtonUnfold_pressed", [])
 			else:
 				b.connect('pressed', self, "_create_event_button_pressed", [b.name])
 
@@ -38,6 +42,14 @@ func _on_ButtonQuestion_pressed() -> void:
 func _on_ButtonCondition_pressed() -> void:
 	create_event("IfCondition", {'no-data': true}, true)
 	create_event("EndBranch", {'no-data': true}, true)
+
+
+func _on_ButtonFold_pressed() -> void:
+	fold_all_nodes()
+
+
+func _on_ButtonUnfold_pressed() -> void:
+	unfold_all_nodes()
 
 
 # Adding an event to the timeline
@@ -220,9 +232,11 @@ func save_timeline() -> void:
 # Utilities
 func fold_all_nodes():
 	for event in timeline.get_children():
-		event.get_node("PanelContainer/VBoxContainer/Header/VisibleToggle").set_pressed(false)
+		if event.has_node("PanelContainer/VBoxContainer/Header/VisibleToggle"):
+			event.get_node("PanelContainer/VBoxContainer/Header/VisibleToggle").set_pressed(false)
 
 
 func unfold_all_nodes():
 	for event in timeline.get_children():
-		event.get_node("PanelContainer/VBoxContainer/Header/VisibleToggle").set_pressed(true)
+		if event.has_node("PanelContainer/VBoxContainer/Header/VisibleToggle"):
+			event.get_node("PanelContainer/VBoxContainer/Header/VisibleToggle").set_pressed(true)

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -64,15 +64,29 @@ func _create_event_button_pressed(button_name):
 
 
 func _on_ButtonQuestion_pressed() -> void:
-	create_event("Question", {'no-data': true}, true)
-	create_event("Choice", {'no-data': true}, true)
-	create_event("Choice", {'no-data': true}, true)
-	create_event("EndBranch", {'no-data': true}, true)
+	if selected_item != null:
+		# Events are added bellow the selected node
+		# So we must reverse the adding order
+		create_event("EndBranch", {'no-data': true}, true)
+		create_event("Choice", {'no-data': true}, true)
+		create_event("Choice", {'no-data': true}, true)
+		create_event("Question", {'no-data': true}, true)
+	else:
+		create_event("Question", {'no-data': true}, true)
+		create_event("Choice", {'no-data': true}, true)
+		create_event("Choice", {'no-data': true}, true)
+		create_event("EndBranch", {'no-data': true}, true)
 
 
 func _on_ButtonCondition_pressed() -> void:
-	create_event("IfCondition", {'no-data': true}, true)
-	create_event("EndBranch", {'no-data': true}, true)
+	if selected_item != null:
+		# Events are added bellow the selected node
+		# So we must reverse the adding order
+		create_event("EndBranch", {'no-data': true}, true)
+		create_event("IfCondition", {'no-data': true}, true)
+	else:
+		create_event("IfCondition", {'no-data': true}, true)
+		create_event("EndBranch", {'no-data': true}, true)
 
 
 func _on_ButtonFold_pressed() -> void:

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -10,6 +10,11 @@ onready var master_tree = get_node('../MasterTree')
 onready var timeline = $TimelineArea/TimeLine
 onready var events_warning = $ScrollContainer/EventContainer/EventsWarning
 
+var hovered_item = null
+var selected_style : StyleBoxFlat = load("res://addons/dialogic/Editor/Pieces/selected_styleboxflat.tres")
+var saved_style : StyleBoxFlat
+var selected_item : Node
+
 func _ready():
 	# We connect all the event buttons to the event creation functions
 	for b in $ScrollContainer/EventContainer.get_children():
@@ -24,6 +29,27 @@ func _ready():
 				b.connect('pressed', self, "_on_ButtonUnfold_pressed", [])
 			else:
 				b.connect('pressed', self, "_create_event_button_pressed", [b.name])
+
+
+func _select_item(item: Node):
+	if selected_item != null and saved_style != null:
+		var selected_panel: PanelContainer = selected_item.get_node("PanelContainer")
+		if selected_panel != null:
+			selected_panel.set('custom_styles/panel', saved_style)
+	if item != selected_item:
+		var panel: PanelContainer = item.get_node("PanelContainer")
+		if panel != null:
+			saved_style = panel.get('custom_styles/panel')
+			selected_item = item
+			panel.set('custom_styles/panel', selected_style)
+	else:
+		selected_item = null
+		saved_style = null
+
+
+func _on_gui_input(event, item: Node):
+	if event is InputEventMouseButton and event.button_index == 1 and event.is_pressed():
+		_select_item(item)
 
 
 # Event Creation signal for buttons
@@ -57,9 +83,14 @@ func create_event(scene: String, data: Dictionary = {'no-data': true} , indent: 
 	# This function will create an event in the timeline.
 	var piece = load("res://addons/dialogic/Editor/Pieces/" + scene + ".tscn").instance()
 	piece.editor_reference = editor_reference
-	timeline.add_child(piece)
+	if selected_item != null:
+		timeline.add_child_below_node(selected_item, piece)
+	else:
+		timeline.add_child(piece)
 	if data.has('no-data') == false:
 		piece.load_data(data)
+	
+	piece.connect("gui_input", self, '_on_gui_input', [piece])
 	events_warning.visible = false
 	# Indent on create
 	if indent:

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/character-join.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Images/dialog.svg" type="Texture" id=2]
@@ -18,6 +18,8 @@
 [ext_resource path="res://addons/dialogic/Images/signal.svg" type="Texture" id=16]
 [ext_resource path="res://addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd" type="Script" id=17]
 [ext_resource path="res://addons/dialogic/Images/theme.svg" type="Texture" id=18]
+[ext_resource path="res://addons/dialogic/Images/closed-icon.svg" type="Texture" id=19]
+[ext_resource path="res://addons/dialogic/Images/open-icon.svg" type="Texture" id=20]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -81,7 +83,7 @@ rect_min_size = Vector2( 190, 0 )
 
 [node name="EventContainer" type="VBoxContainer" parent="ScrollContainer"]
 margin_right = 178.0
-margin_bottom = 664.0
+margin_bottom = 746.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {
@@ -121,10 +123,42 @@ custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "Add an event to start building your timeline"
 autowrap = true
 
-[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
+[node name="HBoxContainer7" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
 margin_top = 72.0
 margin_right = 178.0
 margin_bottom = 86.0
+
+[node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer7"]
+margin_right = 47.0
+margin_bottom = 14.0
+text = "Display"
+
+[node name="HSeparator2" type="HSeparator" parent="ScrollContainer/EventContainer/HBoxContainer7"]
+margin_left = 51.0
+margin_right = 178.0
+margin_bottom = 14.0
+size_flags_horizontal = 3
+
+[node name="Fold" type="Button" parent="ScrollContainer/EventContainer"]
+margin_top = 90.0
+margin_right = 178.0
+margin_bottom = 118.0
+text = "Fold All"
+icon = ExtResource( 20 )
+align = 0
+
+[node name="Unfold" type="Button" parent="ScrollContainer/EventContainer"]
+margin_top = 122.0
+margin_right = 178.0
+margin_bottom = 150.0
+text = "Unfold All"
+icon = ExtResource( 19 )
+align = 0
+
+[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
+margin_top = 154.0
+margin_right = 178.0
+margin_bottom = 168.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer6"]
 margin_right = 77.0
@@ -138,33 +172,33 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="TextBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 90.0
+margin_top = 172.0
 margin_right = 178.0
-margin_bottom = 118.0
+margin_bottom = 200.0
 text = "  Text Event"
 icon = ExtResource( 2 )
 align = 0
 
 [node name="CharacterJoinBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 122.0
+margin_top = 204.0
 margin_right = 178.0
-margin_bottom = 150.0
+margin_bottom = 232.0
 text = "  Character Join"
 icon = ExtResource( 1 )
 align = 0
 
 [node name="CharacterLeaveBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 154.0
+margin_top = 236.0
 margin_right = 178.0
-margin_bottom = 182.0
+margin_bottom = 264.0
 text = "  Character Leave"
 icon = ExtResource( 7 )
 align = 0
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 186.0
+margin_top = 268.0
 margin_right = 178.0
-margin_bottom = 200.0
+margin_bottom = 282.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer5"]
 margin_right = 33.0
@@ -178,49 +212,49 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="ButtonQuestion" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 204.0
+margin_top = 286.0
 margin_right = 178.0
-margin_bottom = 232.0
+margin_bottom = 314.0
 text = "  Question"
 icon = ExtResource( 8 )
 align = 0
 
 [node name="Choice" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 236.0
+margin_top = 318.0
 margin_right = 178.0
-margin_bottom = 264.0
+margin_bottom = 346.0
 text = "  Choice"
 icon = ExtResource( 12 )
 align = 0
 
 [node name="IfCondition" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 268.0
+margin_top = 350.0
 margin_right = 178.0
-margin_bottom = 296.0
+margin_bottom = 378.0
 text = " Condition"
 icon = ExtResource( 5 )
 align = 0
 
 [node name="EndBranch" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 300.0
+margin_top = 382.0
 margin_right = 178.0
-margin_bottom = 328.0
+margin_bottom = 410.0
 text = "  End Branch"
 icon = ExtResource( 9 )
 align = 0
 
 [node name="SetValue" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 332.0
+margin_top = 414.0
 margin_right = 178.0
-margin_bottom = 354.0
+margin_bottom = 436.0
 text = "  Set Value"
 icon = ExtResource( 11 )
 align = 0
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 358.0
+margin_top = 440.0
 margin_right = 178.0
-margin_bottom = 372.0
+margin_bottom = 454.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer3"]
 margin_right = 56.0
@@ -234,50 +268,50 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="ChangeTimeline" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 376.0
+margin_top = 458.0
 margin_right = 178.0
-margin_bottom = 404.0
+margin_bottom = 486.0
 hint_tooltip = "This will instantly teleport you to the start of the desired timeline."
 text = "  Change Timeline"
 icon = ExtResource( 10 )
 align = 0
 
 [node name="SceneEvent" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 408.0
+margin_top = 490.0
 margin_right = 178.0
-margin_bottom = 436.0
+margin_bottom = 518.0
 text = "  Scene Event"
 icon = ExtResource( 4 )
 align = 0
 
 [node name="CloseDialog" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 440.0
+margin_top = 522.0
 margin_right = 178.0
-margin_bottom = 468.0
+margin_bottom = 550.0
 text = "  Close Dialog"
 icon = ExtResource( 6 )
 align = 0
 
 [node name="WaitSeconds" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 472.0
+margin_top = 554.0
 margin_right = 178.0
-margin_bottom = 500.0
+margin_bottom = 582.0
 text = "  Wait Seconds"
 icon = ExtResource( 14 )
 align = 0
 
 [node name="SetTheme" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 504.0
+margin_top = 586.0
 margin_right = 178.0
-margin_bottom = 532.0
+margin_bottom = 614.0
 text = "  Set Theme"
 icon = ExtResource( 18 )
 align = 0
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 536.0
+margin_top = 618.0
 margin_right = 178.0
-margin_bottom = 550.0
+margin_bottom = 632.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer4"]
 margin_right = 37.0
@@ -291,17 +325,17 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="AudioBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 554.0
+margin_top = 636.0
 margin_right = 178.0
-margin_bottom = 582.0
+margin_bottom = 664.0
 text = "  Audio Event"
 icon = ExtResource( 3 )
 align = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 586.0
+margin_top = 668.0
 margin_right = 178.0
-margin_bottom = 600.0
+margin_bottom = 682.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer"]
 margin_right = 39.0
@@ -315,17 +349,17 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="EmitSignal" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 604.0
+margin_top = 686.0
 margin_right = 178.0
-margin_bottom = 632.0
+margin_bottom = 714.0
 text = "  Emit Signal"
 icon = ExtResource( 16 )
 align = 0
 
 [node name="ChangeScene" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 636.0
+margin_top = 718.0
 margin_right = 178.0
-margin_bottom = 664.0
+margin_bottom = 746.0
 hint_tooltip = "This will instantly change
 the current scene."
 text = "  Change Scene"

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=23 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/character-join.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Images/dialog.svg" type="Texture" id=2]
@@ -18,8 +18,6 @@
 [ext_resource path="res://addons/dialogic/Images/signal.svg" type="Texture" id=16]
 [ext_resource path="res://addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd" type="Script" id=17]
 [ext_resource path="res://addons/dialogic/Images/theme.svg" type="Texture" id=18]
-[ext_resource path="res://addons/dialogic/Images/closed-icon.svg" type="Texture" id=19]
-[ext_resource path="res://addons/dialogic/Images/open-icon.svg" type="Texture" id=20]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -83,7 +81,7 @@ rect_min_size = Vector2( 190, 0 )
 
 [node name="EventContainer" type="VBoxContainer" parent="ScrollContainer"]
 margin_right = 178.0
-margin_bottom = 746.0
+margin_bottom = 664.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {
@@ -123,42 +121,10 @@ custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "Add an event to start building your timeline"
 autowrap = true
 
-[node name="HBoxContainer7" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
+[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
 margin_top = 72.0
 margin_right = 178.0
 margin_bottom = 86.0
-
-[node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer7"]
-margin_right = 47.0
-margin_bottom = 14.0
-text = "Display"
-
-[node name="HSeparator2" type="HSeparator" parent="ScrollContainer/EventContainer/HBoxContainer7"]
-margin_left = 51.0
-margin_right = 178.0
-margin_bottom = 14.0
-size_flags_horizontal = 3
-
-[node name="Fold" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 90.0
-margin_right = 178.0
-margin_bottom = 118.0
-text = "Fold All"
-icon = ExtResource( 20 )
-align = 0
-
-[node name="Unfold" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 122.0
-margin_right = 178.0
-margin_bottom = 150.0
-text = "Unfold All"
-icon = ExtResource( 19 )
-align = 0
-
-[node name="HBoxContainer6" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 154.0
-margin_right = 178.0
-margin_bottom = 168.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer6"]
 margin_right = 77.0
@@ -172,33 +138,33 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="TextBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 172.0
+margin_top = 90.0
 margin_right = 178.0
-margin_bottom = 200.0
+margin_bottom = 118.0
 text = "  Text Event"
 icon = ExtResource( 2 )
 align = 0
 
 [node name="CharacterJoinBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 204.0
+margin_top = 122.0
 margin_right = 178.0
-margin_bottom = 232.0
+margin_bottom = 150.0
 text = "  Character Join"
 icon = ExtResource( 1 )
 align = 0
 
 [node name="CharacterLeaveBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 236.0
+margin_top = 154.0
 margin_right = 178.0
-margin_bottom = 264.0
+margin_bottom = 182.0
 text = "  Character Leave"
 icon = ExtResource( 7 )
 align = 0
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 268.0
+margin_top = 186.0
 margin_right = 178.0
-margin_bottom = 282.0
+margin_bottom = 200.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer5"]
 margin_right = 33.0
@@ -212,49 +178,49 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="ButtonQuestion" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 286.0
+margin_top = 204.0
 margin_right = 178.0
-margin_bottom = 314.0
+margin_bottom = 232.0
 text = "  Question"
 icon = ExtResource( 8 )
 align = 0
 
 [node name="Choice" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 318.0
+margin_top = 236.0
 margin_right = 178.0
-margin_bottom = 346.0
+margin_bottom = 264.0
 text = "  Choice"
 icon = ExtResource( 12 )
 align = 0
 
 [node name="IfCondition" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 350.0
+margin_top = 268.0
 margin_right = 178.0
-margin_bottom = 378.0
+margin_bottom = 296.0
 text = " Condition"
 icon = ExtResource( 5 )
 align = 0
 
 [node name="EndBranch" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 382.0
+margin_top = 300.0
 margin_right = 178.0
-margin_bottom = 410.0
+margin_bottom = 328.0
 text = "  End Branch"
 icon = ExtResource( 9 )
 align = 0
 
 [node name="SetValue" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 414.0
+margin_top = 332.0
 margin_right = 178.0
-margin_bottom = 436.0
+margin_bottom = 354.0
 text = "  Set Value"
 icon = ExtResource( 11 )
 align = 0
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 440.0
+margin_top = 358.0
 margin_right = 178.0
-margin_bottom = 454.0
+margin_bottom = 372.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer3"]
 margin_right = 56.0
@@ -268,50 +234,50 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="ChangeTimeline" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 458.0
+margin_top = 376.0
 margin_right = 178.0
-margin_bottom = 486.0
+margin_bottom = 404.0
 hint_tooltip = "This will instantly teleport you to the start of the desired timeline."
 text = "  Change Timeline"
 icon = ExtResource( 10 )
 align = 0
 
 [node name="SceneEvent" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 490.0
+margin_top = 408.0
 margin_right = 178.0
-margin_bottom = 518.0
+margin_bottom = 436.0
 text = "  Scene Event"
 icon = ExtResource( 4 )
 align = 0
 
 [node name="CloseDialog" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 522.0
+margin_top = 440.0
 margin_right = 178.0
-margin_bottom = 550.0
+margin_bottom = 468.0
 text = "  Close Dialog"
 icon = ExtResource( 6 )
 align = 0
 
 [node name="WaitSeconds" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 554.0
+margin_top = 472.0
 margin_right = 178.0
-margin_bottom = 582.0
+margin_bottom = 500.0
 text = "  Wait Seconds"
 icon = ExtResource( 14 )
 align = 0
 
 [node name="SetTheme" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 586.0
+margin_top = 504.0
 margin_right = 178.0
-margin_bottom = 614.0
+margin_bottom = 532.0
 text = "  Set Theme"
 icon = ExtResource( 18 )
 align = 0
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 618.0
+margin_top = 536.0
 margin_right = 178.0
-margin_bottom = 632.0
+margin_bottom = 550.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer4"]
 margin_right = 37.0
@@ -325,17 +291,17 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="AudioBlock" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 636.0
+margin_top = 554.0
 margin_right = 178.0
-margin_bottom = 664.0
+margin_bottom = 582.0
 text = "  Audio Event"
 icon = ExtResource( 3 )
 align = 0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
-margin_top = 668.0
+margin_top = 586.0
 margin_right = 178.0
-margin_bottom = 682.0
+margin_bottom = 600.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer"]
 margin_right = 39.0
@@ -349,17 +315,17 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="EmitSignal" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 686.0
+margin_top = 604.0
 margin_right = 178.0
-margin_bottom = 714.0
+margin_bottom = 632.0
 text = "  Emit Signal"
 icon = ExtResource( 16 )
 align = 0
 
 [node name="ChangeScene" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 718.0
+margin_top = 636.0
 margin_right = 178.0
-margin_bottom = 746.0
+margin_bottom = 664.0
 hint_tooltip = "This will instantly change
 the current scene."
 text = "  Change Scene"


### PR DESCRIPTION
This PR adds buttons to fold/unfold all nodes in a timeline. It also adds the possibility to select pieces. When selecting a piece, it will change color and adding a node will add it just bellow the selected piece. Clicking again a node will deselect it.

I did all the logic inside `TimelineEditor.gd`, so this will work on any piece as long as it has a `PanelContainer` node just bellow the root.

I think we could do the same for the `DragController`: instead of adding the node on each piece, control everything from `TimelineEditor.gd`, this will be easier to maintain.

If you want to change how selected items appear, you can edit the style in `res://addons/dialogic/Editor/Pieces/selected_styleboxflat.tres`


This does not touch resources handling so it is not breaking.