### PR TITLE
align portraits to the bottom of the screen

### DIFF
--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -7,11 +7,11 @@ var character_data = {
 	'file': ''
 }
 var positions = {
-	'left': Vector2(-400,-130),
-	'right': Vector2(+400,-130),
-	'center': Vector2(0,-130),
-	'center_right': Vector2(200,-130),
-	'center_left': Vector2(-200,-130)}
+	'left': Vector2(-400, 0),
+	'right': Vector2(+400, 0),
+	'center': Vector2(0, 0),
+	'center_right': Vector2(200, 0),
+	'center_left': Vector2(-200, 0)}
 var direction = 'left'
 var debug = false
 


### PR DESCRIPTION
Removed the hardcoded offset of -130 and replaced it by 0. This makes it easier to use custom offsets.

Closes #101 