### PR TITLE
Add setting to control input propagating

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -6,6 +6,7 @@ onready var nodes = {
 	'new_lines': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer2/NewLines,
 	'remove_empty_messages': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer/RemoveEmptyMessages,
 	'auto_color_names': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer3/AutoColorNames,
+	'propagate_input': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer4/PropagateInput,
 }
 func _ready():
 	update_data()
@@ -14,6 +15,7 @@ func _ready():
 	nodes['new_lines'].connect('toggled', self, '_on_new_line_toggled')
 	nodes['remove_empty_messages'].connect('toggled', self, '_on_remove_empty_message_toggled')
 	nodes['auto_color_names'].connect('toggled', self, '_on_auto_color_names_toggled')
+	nodes['propagate_input'].connect('toggled', self, '_on_propagate_input_toggled')
 
 
 func update_data():
@@ -27,6 +29,10 @@ func dialog_options(settings):
 		nodes['remove_empty_messages'].pressed = settings.get_value('dialog', 'remove_empty_messages')
 	if settings.has_section_key('dialog', 'new_lines'):
 		nodes['new_lines'].pressed = settings.get_value('dialog', 'new_lines')
+	if settings.has_section_key('dialog', 'auto_color_names'):
+		nodes['auto_color_names'].pressed = settings.get_value('dialog', 'auto_color_names')
+	if settings.has_section_key('dialog', 'propagate_input'):
+		nodes['propagate_input'].pressed = settings.get_value('dialog', 'propagate_input')
 
 
 func refresh_themes(settings):
@@ -67,6 +73,9 @@ func _on_new_line_toggled(value):
 
 func _on_auto_color_names_toggled(value):
 	set_value('dialog', 'auto_color_names', value)
+
+func _on_propagate_input_toggled(value):
+	set_value('dialog', 'propagate_input', value)
 
 
 # Reading and saving data to the settings file

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -18,11 +18,11 @@ size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1024.0
-margin_bottom = 184.0
+margin_bottom = 212.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_right = 288.0
-margin_bottom = 184.0
+margin_bottom = 212.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
@@ -59,20 +59,16 @@ margin_left = 50.0
 margin_right = 190.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 140, 0 )
-text = "Default"
-items = [ "Default", null, false, 0, {
-"file": "theme-1614997416.cfg"
-}, "Alternative", null, false, 1, {
-"file": "theme-1614997426.cfg"
-}, "Small", null, false, 2, {
-"file": "theme-1615080820.cfg"
+text = "test"
+items = [ "test", null, false, 0, {
+"file": "theme-1616687382.cfg"
 } ]
 selected = 0
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 70.0
 margin_right = 288.0
-margin_bottom = 184.0
+margin_bottom = 212.0
 
 [node name="Panel2" type="Panel" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_right = 288.0
@@ -139,5 +135,22 @@ text = "Auto color character names in messages"
 [node name="AutoColorNames" type="CheckBox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer3"]
 margin_left = 264.0
 margin_right = 288.0
+margin_bottom = 24.0
+pressed = true
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+margin_top = 118.0
+margin_right = 288.0
+margin_bottom = 142.0
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer4"]
+margin_top = 5.0
+margin_right = 219.0
+margin_bottom = 19.0
+text = "Propagate input to rest of the Tree"
+
+[node name="PropagateInput" type="CheckBox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer4"]
+margin_left = 223.0
+margin_right = 247.0
 margin_bottom = 24.0
 pressed = true

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -279,6 +279,10 @@ func _input(event: InputEvent) -> void:
 		else:
 			if waiting_for_answer == false and waiting_for_input == false:
 				load_dialog()
+		if settings.has_section_key('dialog', 'propagate_input'):
+			var propagate_input: bool = settings.get_value('dialog', 'propagate_input')
+			if not propagate_input:
+				get_tree().set_input_as_handled()
 
 
 func show_dialog():

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -260,23 +260,25 @@ func _insert_glossary_definitions(text: String):
 	return final_text;
 
 
-func _process(_delta):
+func _process(delta):
 	$TextBubble/NextIndicator.visible = finished
-	if Engine.is_editor_hint() == false:
+	if not Engine.is_editor_hint():
 		# Multiple choices
 		if waiting_for_answer:
 			$Options.visible = finished
 		else:
 			$Options.visible = false
 
-		if Input.is_action_just_pressed(input_next) and waiting == false:
-			if $TextBubble/Tween.is_active():
-				# Skip to end if key is pressed during the text animation
-				$TextBubble/Tween.seek(999)
-				finished = true
-			else:
-				if waiting_for_answer == false and waiting_for_input == false:
-					load_dialog()
+
+func _input(event: InputEvent) -> void:
+	if not Engine.is_editor_hint() and event.is_action_pressed(input_next) and not waiting:
+		if $TextBubble/Tween.is_active():
+			# Skip to end if key is pressed during the text animation
+			$TextBubble/Tween.seek(999)
+			finished = true
+		else:
+			if waiting_for_answer == false and waiting_for_input == false:
+				load_dialog()
 
 
 func show_dialog():


### PR DESCRIPTION
This PR moves input handling inside the `_input(event)` function, and adds a setting to control propagating to the rest of the tree (on by default).

Closes #47