### PR TITLE
add basic background music controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The plugin is not production ready, this means that it will not work in your gam
     - Add offset to the portrait
   - Timeline Editor:
     - New `Theme event` to change the theme in the middle of a timeline
+    - New `Background Music Event` to play music in your dialog. Music can crossfade when changing track and fade in/out when starting/stopping.
     - Re-enabled the `Scene Event`
   - Theme Editor:
     - You can now add multiple themes

--- a/addons/dialogic/BackgroundMusic.gd
+++ b/addons/dialogic/BackgroundMusic.gd
@@ -1,0 +1,24 @@
+extends Control
+class_name DialogicBackgroundMusic
+
+onready var _anim_player := $AnimationPlayer
+onready var _track1 := $Track1
+onready var _track2 := $Track2
+
+
+func crossfade_to(audio_stream: AudioStream) -> void:
+	if _track1.playing and _track2.playing:
+		return
+	
+	if _track2.playing:
+		_track1.stream = audio_stream
+		_track1.play()
+		_anim_player.play("FadeToTrack1")
+	else:
+		_track2.stream = audio_stream
+		_track2.play()
+		_anim_player.play("FadeToTrack2")
+
+
+func fade_out() -> void:
+	_anim_player.play("FadeOut")

--- a/addons/dialogic/BackgroundMusic.tscn
+++ b/addons/dialogic/BackgroundMusic.tscn
@@ -1,0 +1,151 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://addons/dialogic/BackgroundMusic.gd" type="Script" id=1]
+
+[sub_resource type="Animation" id=3]
+resource_name = "FadeOut"
+tracks/0/type = "value"
+tracks/0/path = NodePath("Track1:volume_db")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ 0.0, -80.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Track2:volume_db")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ 0.0, -80.0 ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("Track2:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0.5 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/3/type = "value"
+tracks/3/path = NodePath("Track1:playing")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/keys = {
+"times": PoolRealArray( 0.5 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+
+[sub_resource type="Animation" id=1]
+resource_name = "FadeToTrack1"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/path = NodePath("Track1:volume_db")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ -80.0, 0.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Track2:volume_db")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ 0.0, -80.0 ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("Track2:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0.5 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+
+[sub_resource type="Animation" id=2]
+resource_name = "FadeToTrack2"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/path = NodePath("Track1:volume_db")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ 0.0, -80.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("Track1:playing")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0.5 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/2/type = "value"
+tracks/2/path = NodePath("Track2:volume_db")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/keys = {
+"times": PoolRealArray( 0, 0.5 ),
+"transitions": PoolRealArray( 5.66, 1 ),
+"update": 0,
+"values": [ -80.0, 0.0 ]
+}
+
+[node name="BackgroundMusic" type="Control"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Track1" type="AudioStreamPlayer" parent="."]
+
+[node name="Track2" type="AudioStreamPlayer" parent="."]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+anims/FadeOut = SubResource( 3 )
+anims/FadeToTrack1 = SubResource( 1 )
+anims/FadeToTrack2 = SubResource( 2 )

--- a/addons/dialogic/Dialog.tscn
+++ b/addons/dialogic/Dialog.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/next-indicator.png" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Images/background/background-2.png" type="Texture" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://addons/dialogic/Fonts/GlossaryFont.tres" type="DynamicFont" id=4]
 [ext_resource path="res://addons/dialogic/Nodes/glossary_info.gd" type="Script" id=5]
 [ext_resource path="res://addons/dialogic/Nodes/dialog_node.gd" type="Script" id=6]
+[ext_resource path="res://addons/dialogic/BackgroundMusic.tscn" type="PackedScene" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0 )
@@ -98,8 +99,8 @@ margin_bottom = -10.0
 rect_clip_content = false
 custom_styles/normal = SubResource( 1 )
 custom_fonts/normal_font = ExtResource( 3 )
-custom_colors/default_color = Color( 0.756863, 0.172549, 0.172549, 1 )
-custom_colors/font_color_shadow = Color( 0, 0, 0, 0.619608 )
+custom_colors/default_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 1, 1, 1, 0 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
 bbcode_enabled = true
@@ -140,14 +141,13 @@ margin_right = 369.0
 rect_clip_content = false
 custom_styles/normal = SubResource( 1 )
 custom_fonts/normal_font = ExtResource( 3 )
-custom_colors/default_color = Color( 0.756863, 0.172549, 0.172549, 1 )
-custom_colors/font_color_shadow = Color( 0, 0, 0, 0.619608 )
+custom_colors/default_color = Color( 1, 1, 1, 1 )
+custom_colors/font_color_shadow = Color( 1, 1, 1, 0 )
 custom_constants/shadow_offset_x = 2
 custom_constants/shadow_offset_y = 2
 custom_constants/shadow_as_outline = 10
 bbcode_enabled = true
 bbcode_text = "Name Here"
-text = "Name Here"
 scroll_active = false
 __meta__ = {
 "_edit_use_anchors_": false
@@ -212,6 +212,8 @@ __meta__ = {
 [node name="Tween" type="Tween" parent="FX/FadeInNode"]
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="FX"]
+
+[node name="BackgroundMusic" parent="FX" instance=ExtResource( 7 )]
 
 [node name="DefinitionInfo" type="PanelContainer" parent="."]
 visible = false
@@ -288,7 +290,6 @@ __meta__ = {
 [node name="Timer" type="Timer" parent="DefinitionInfo"]
 
 [node name="WaitSeconds" type="Timer" parent="."]
-
 [connection signal="meta_hover_ended" from="TextBubble/RichTextLabel" to="." method="_on_RichTextLabel_meta_hover_ended"]
 [connection signal="meta_hover_started" from="TextBubble/RichTextLabel" to="." method="_on_RichTextLabel_meta_hover_started"]
 [connection signal="tween_completed" from="TextBubble/Tween" to="." method="_on_Tween_tween_completed"]

--- a/addons/dialogic/Editor/Pieces/AudioBlock.gd
+++ b/addons/dialogic/Editor/Pieces/AudioBlock.gd
@@ -1,5 +1,5 @@
 tool
-extends Control
+extends HBoxContainer
 
 var editor_reference
 var editorPopup
@@ -9,10 +9,13 @@ var stop_icon = load("res://addons/dialogic/Images/stop.svg")
 
 # This is the information of this event and it will get parsed and saved to the JSON file.
 var event_data = {
-	'audio': 'play',
+	'audio': 'stop',
 	'file': ''
 }
 
+
+func _ready():
+	load_audio('')
 
 func _on_ButtonAudio_pressed():
 	editor_reference.godot_dialog("*.wav, *.ogg, *.mp3")
@@ -23,16 +26,24 @@ func _on_file_selected(path, target):
 	target.load_audio(path)
 
 
-func load_audio(path):
-	$PanelContainer/VBoxContainer/Header/Name.text = path
-	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = false
-	event_data['file'] = path
+func load_audio(path: String):
+	if not path.empty():
+		$PanelContainer/VBoxContainer/Header/Name.text = path
+		$PanelContainer/VBoxContainer/Header/ButtonClear.disabled = false
+		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = false
+		event_data['file'] = path
+		event_data['audio'] = 'play'
+	else:
+		$PanelContainer/VBoxContainer/Header/Name.text = 'No sound (will stop previous audio event)'
+		$PanelContainer/VBoxContainer/Header/ButtonClear.disabled = true
+		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = true
+		event_data['file'] = ''
+		event_data['audio'] = 'stop'
 
 
 func load_data(data):
 	event_data = data
-	if data['file'] != '':
-		load_audio(data['file'])
+	load_audio(data['file'])
 
 
 func _on_ButtonPreviewPlay_pressed():
@@ -46,3 +57,7 @@ func _on_ButtonPreviewPlay_pressed():
 
 func _on_AudioPreview_finished():
 	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.icon = play_icon
+
+
+func _on_ButtonClear_pressed():
+	load_audio('')

--- a/addons/dialogic/Editor/Pieces/AudioBlock.tscn
+++ b/addons/dialogic/Editor/Pieces/AudioBlock.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/AudioBlock.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Images/play.svg" type="Texture" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=6]
+[ext_resource path="res://addons/dialogic/Images/Remove.svg" type="Texture" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -83,9 +84,16 @@ margin_right = 115.0
 margin_bottom = 28.0
 text = "..."
 
-[node name="ButtonPreviewPlay" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+[node name="ButtonClear" type="Button" parent="PanelContainer/VBoxContainer/Header"]
 margin_left = 119.0
-margin_right = 153.0
+margin_right = 147.0
+margin_bottom = 28.0
+disabled = true
+icon = ExtResource( 7 )
+
+[node name="ButtonPreviewPlay" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 151.0
+margin_right = 185.0
 margin_bottom = 28.0
 disabled = true
 icon = ExtResource( 5 )
@@ -100,7 +108,7 @@ custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
 [node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
-margin_left = 157.0
+margin_left = 189.0
 margin_right = 1735.0
 margin_bottom = 28.0
 
@@ -114,5 +122,6 @@ items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", 
 
 [node name="DragController" parent="." instance=ExtResource( 6 )]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonAudio" to="." method="_on_ButtonAudio_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonClear" to="." method="_on_ButtonClear_pressed"]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonPreviewPlay" to="." method="_on_ButtonPreviewPlay_pressed"]
 [connection signal="finished" from="PanelContainer/AudioPreview" to="." method="_on_AudioPreview_finished"]

--- a/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
+++ b/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
@@ -34,7 +34,7 @@ func load_audio(path: String):
 		event_data['file'] = path
 		event_data['background-music'] = 'play'
 	else:
-		$PanelContainer/VBoxContainer/Header/Name.text = 'None'
+		$PanelContainer/VBoxContainer/Header/Name.text = 'No music (will stop with fade out)'
 		$PanelContainer/VBoxContainer/Header/ButtonClear.disabled = true
 		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = true
 		event_data['file'] = ''

--- a/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
+++ b/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
@@ -1,0 +1,49 @@
+tool
+extends HBoxContainer
+
+var editor_reference
+var editorPopup
+
+var play_icon = load("res://addons/dialogic/Images/play.svg")
+var stop_icon = load("res://addons/dialogic/Images/stop.svg")
+
+# This is the information of this event and it will get parsed and saved to the JSON file.
+var event_data = {
+	'background-music': 'stop',
+	'file': ''
+}
+
+
+func _on_ButtonAudio_pressed():
+	editor_reference.godot_dialog("*.wav, *.ogg, *.mp3")
+	editor_reference.godot_dialog_connect(self, "_on_file_selected")
+
+
+func _on_file_selected(path, target):
+	target.load_audio(path)
+
+
+func load_audio(path):
+	$PanelContainer/VBoxContainer/Header/Name.text = path
+	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = false
+	event_data['file'] = path
+	event_data['background-music'] = 'play'
+
+
+func load_data(data):
+	event_data = data
+	if data['file'] != '':
+		load_audio(data['file'])
+
+
+func _on_ButtonPreviewPlay_pressed():
+	if $PanelContainer/AudioPreview.is_playing():
+		$PanelContainer/AudioPreview.stop()
+	else:
+		$PanelContainer/AudioPreview.stream = load(event_data['file'])
+		$PanelContainer/AudioPreview.play()
+		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.icon = stop_icon
+
+
+func _on_AudioPreview_finished():
+	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.icon = play_icon

--- a/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
+++ b/addons/dialogic/Editor/Pieces/BackgroundMusic.gd
@@ -14,6 +14,9 @@ var event_data = {
 }
 
 
+func _ready():
+	load_audio('')
+
 func _on_ButtonAudio_pressed():
 	editor_reference.godot_dialog("*.wav, *.ogg, *.mp3")
 	editor_reference.godot_dialog_connect(self, "_on_file_selected")
@@ -23,17 +26,24 @@ func _on_file_selected(path, target):
 	target.load_audio(path)
 
 
-func load_audio(path):
-	$PanelContainer/VBoxContainer/Header/Name.text = path
-	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = false
-	event_data['file'] = path
-	event_data['background-music'] = 'play'
+func load_audio(path: String):
+	if not path.empty():
+		$PanelContainer/VBoxContainer/Header/Name.text = path
+		$PanelContainer/VBoxContainer/Header/ButtonClear.disabled = false
+		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = false
+		event_data['file'] = path
+		event_data['background-music'] = 'play'
+	else:
+		$PanelContainer/VBoxContainer/Header/Name.text = 'None'
+		$PanelContainer/VBoxContainer/Header/ButtonClear.disabled = true
+		$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.disabled = true
+		event_data['file'] = ''
+		event_data['background-music'] = 'stop'
 
 
 func load_data(data):
 	event_data = data
-	if data['file'] != '':
-		load_audio(data['file'])
+	load_audio(data['file'])
 
 
 func _on_ButtonPreviewPlay_pressed():
@@ -47,3 +57,7 @@ func _on_ButtonPreviewPlay_pressed():
 
 func _on_AudioPreview_finished():
 	$PanelContainer/VBoxContainer/Header/ButtonPreviewPlay.icon = play_icon
+
+
+func _on_ButtonClear_pressed():
+	load_audio('')

--- a/addons/dialogic/Editor/Pieces/BackgroundMusic.tscn
+++ b/addons/dialogic/Editor/Pieces/BackgroundMusic.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/BackgroundMusic.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
@@ -6,13 +6,14 @@
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Images/play.svg" type="Texture" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=6]
+[ext_resource path="res://addons/dialogic/Images/Remove.svg" type="Texture" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
 content_margin_right = 6.0
 content_margin_top = 6.0
 content_margin_bottom = 6.0
-bg_color = Color( 0.580392, 0.286275, 0.227451, 0.447059 )
+bg_color = Color( 0.298039, 0.172549, 0.14902, 0.447059 )
 border_width_left = 2
 border_width_top = 2
 border_width_right = 2
@@ -74,18 +75,26 @@ text = "  Background Music"
 [node name="Name" type="Label" parent="PanelContainer/VBoxContainer/Header"]
 margin_left = 154.0
 margin_top = 7.0
-margin_right = 154.0
+margin_right = 188.0
 margin_bottom = 21.0
+text = "None"
 
 [node name="ButtonAudio" type="Button" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 158.0
-margin_right = 182.0
+margin_left = 192.0
+margin_right = 216.0
 margin_bottom = 28.0
 text = "..."
 
+[node name="ButtonClear" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 220.0
+margin_right = 248.0
+margin_bottom = 28.0
+disabled = true
+icon = ExtResource( 7 )
+
 [node name="ButtonPreviewPlay" type="Button" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 186.0
-margin_right = 220.0
+margin_left = 252.0
+margin_right = 286.0
 margin_bottom = 28.0
 disabled = true
 icon = ExtResource( 5 )
@@ -100,7 +109,7 @@ custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
 [node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
-margin_left = 224.0
+margin_left = 290.0
 margin_right = 1735.0
 margin_bottom = 28.0
 
@@ -114,5 +123,6 @@ items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", 
 
 [node name="DragController" parent="." instance=ExtResource( 6 )]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonAudio" to="." method="_on_ButtonAudio_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonClear" to="." method="_on_ButtonClear_pressed"]
 [connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonPreviewPlay" to="." method="_on_ButtonPreviewPlay_pressed"]
 [connection signal="finished" from="PanelContainer/AudioPreview" to="." method="_on_AudioPreview_finished"]

--- a/addons/dialogic/Editor/Pieces/BackgroundMusic.tscn
+++ b/addons/dialogic/Editor/Pieces/BackgroundMusic.tscn
@@ -1,0 +1,118 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Pieces/BackgroundMusic.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/dialogic/Images/audio-event.svg" type="Texture" id=3]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/dialogic/Images/play.svg" type="Texture" id=5]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=6]
+
+[sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 16.0
+content_margin_right = 6.0
+content_margin_top = 6.0
+content_margin_bottom = 6.0
+bg_color = Color( 0.580392, 0.286275, 0.227451, 0.447059 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.12549, 0.12549, 0.12549, 1 )
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="BackgroundMusic" type="HBoxContainer"]
+margin_right = 1798.0
+margin_bottom = 42.0
+size_flags_horizontal = 3
+size_flags_vertical = 9
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Indent" type="Control" parent="."]
+visible = false
+margin_left = 6.0
+margin_top = 6.0
+margin_right = 1792.0
+margin_bottom = 36.0
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+margin_right = 1798.0
+margin_bottom = 42.0
+mouse_filter = 1
+size_flags_horizontal = 3
+custom_styles/panel = SubResource( 1 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
+margin_left = 16.0
+margin_top = 6.0
+margin_right = 1792.0
+margin_bottom = 36.0
+size_flags_horizontal = 3
+
+[node name="Header" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+margin_right = 1776.0
+margin_bottom = 28.0
+
+[node name="TextureRect" type="TextureRect" parent="PanelContainer/VBoxContainer/Header"]
+margin_right = 22.0
+margin_bottom = 28.0
+texture = ExtResource( 3 )
+stretch_mode = 6
+
+[node name="Title" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 26.0
+margin_top = 7.0
+margin_right = 150.0
+margin_bottom = 21.0
+text = "  Background Music"
+
+[node name="Name" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 154.0
+margin_top = 7.0
+margin_right = 154.0
+margin_bottom = 21.0
+
+[node name="ButtonAudio" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 158.0
+margin_right = 182.0
+margin_bottom = 28.0
+text = "..."
+
+[node name="ButtonPreviewPlay" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 186.0
+margin_right = 220.0
+margin_bottom = 28.0
+disabled = true
+icon = ExtResource( 5 )
+
+[node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+visible = false
+margin_left = 103.0
+margin_top = 8.0
+margin_right = 131.0
+margin_bottom = 22.0
+custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
+text = "    ..."
+
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
+margin_left = 224.0
+margin_right = 1735.0
+margin_bottom = 28.0
+
+[node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
+margin_left = 1739.0
+margin_right = 1776.0
+margin_bottom = 28.0
+items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
+
+[node name="AudioPreview" type="AudioStreamPlayer" parent="PanelContainer"]
+
+[node name="DragController" parent="." instance=ExtResource( 6 )]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonAudio" to="." method="_on_ButtonAudio_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ButtonPreviewPlay" to="." method="_on_ButtonPreviewPlay_pressed"]
+[connection signal="finished" from="PanelContainer/AudioPreview" to="." method="_on_AudioPreview_finished"]

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -172,6 +172,8 @@ func load_timeline(filename: String):
 				create_event("CharacterJoinBlock", i)
 			{'audio', 'file'}:
 				create_event("AudioBlock", i)
+			{'background-music', 'file'}:
+				create_event("BackgroundMusic", i)
 			{'question', 'options'}:
 				create_event("Question", i)
 			{'choice'}:

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -81,7 +81,7 @@ rect_min_size = Vector2( 190, 0 )
 
 [node name="EventContainer" type="VBoxContainer" parent="ScrollContainer"]
 margin_right = 178.0
-margin_bottom = 664.0
+margin_bottom = 696.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 __meta__ = {
@@ -298,10 +298,18 @@ text = "  Audio Event"
 icon = ExtResource( 3 )
 align = 0
 
-[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
+[node name="BackgroundMusic" type="Button" parent="ScrollContainer/EventContainer"]
 margin_top = 586.0
 margin_right = 178.0
-margin_bottom = 600.0
+margin_bottom = 614.0
+text = "Background Music"
+icon = ExtResource( 3 )
+align = 0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="ScrollContainer/EventContainer"]
+margin_top = 618.0
+margin_right = 178.0
+margin_bottom = 632.0
 
 [node name="Label" type="Label" parent="ScrollContainer/EventContainer/HBoxContainer"]
 margin_right = 39.0
@@ -315,17 +323,17 @@ margin_bottom = 14.0
 size_flags_horizontal = 3
 
 [node name="EmitSignal" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 604.0
+margin_top = 636.0
 margin_right = 178.0
-margin_bottom = 632.0
+margin_bottom = 664.0
 text = "  Emit Signal"
 icon = ExtResource( 16 )
 align = 0
 
 [node name="ChangeScene" type="Button" parent="ScrollContainer/EventContainer"]
-margin_top = 636.0
+margin_top = 668.0
 margin_right = 178.0
-margin_bottom = 664.0
+margin_bottom = 696.0
 hint_tooltip = "This will instantly change
 the current scene."
 text = "  Change Scene"

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -302,7 +302,7 @@ align = 0
 margin_top = 586.0
 margin_right = 178.0
 margin_bottom = 614.0
-text = "Background Music"
+text = "  Background Music"
 icon = ExtResource( 3 )
 align = 0
 

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -458,10 +458,11 @@ func event_handler(event: Dictionary):
 			go_to_next_event()
 		{'audio'}, {'audio', 'file'}:
 			emit_signal("event_start", "audio", event)
-			if event['audio'] == 'play':
+			if event['audio'] == 'play' and 'file' in event.keys() and not event['file'].empty():
 				$FX/AudioStreamPlayer.stream = load(event['file'])
 				$FX/AudioStreamPlayer.play()
-			# Todo: audio stop
+			else:
+				$FX/AudioStreamPlayer.stop()
 			go_to_next_event()
 		{'background-music'}, {'background-music', 'file'}:
 			emit_signal("event_start", "background-music", event)

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -455,6 +455,14 @@ func event_handler(event: Dictionary):
 				$FX/AudioStreamPlayer.play()
 			# Todo: audio stop
 			go_to_next_event()
+		{'background-music'}, {'background-music', 'file'}:
+			emit_signal("event_start", "background-music", event)
+			if event['background-music'] == 'play' and 'file' in event.keys() and not event['file'].empty():
+				var stream: AudioStream = load(event['file'])
+				$FX/BackgroundMusic.crossfade_to(stream)
+			else:
+				$FX/BackgroundMusic.fade_out()
+			go_to_next_event()
 		{'endbranch', ..}:
 			emit_signal("event_start", "endbranch", event)
 			go_to_next_event()


### PR DESCRIPTION
This adds a new timeline piece allowing to set background music.

Music crossfade on change, and fade out on stop.

To stop music, simply put a BackgroundMusic node without a file selected.

Closes #117