### PR TITLE
Set value operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The plugin is not production ready, this means that it will not work in your gam
     - Add offset to the portrait
   - Timeline Editor:
     - New `Theme event` to change the theme in the middle of a timeline
+    - Allow making basic calculations such as `+`, `-`, `*`, `/` in `Set value events`.
     - Re-enabled the `Scene Event`
   - Theme Editor:
     - You can now add multiple themes

--- a/addons/dialogic/Editor/Pieces/Common/OperationPicker.gd
+++ b/addons/dialogic/Editor/Pieces/Common/OperationPicker.gd
@@ -1,0 +1,54 @@
+tool
+extends MenuButton
+
+var options = [
+	{
+		"text": "[ To be ]",
+		"operation": "="
+	},
+	{
+		"text": "[ add ]",
+		"operation": "+"
+	},
+	{
+		"text": "[ remove ]",
+		"operation": "-"
+	},
+	{
+		"text": "[ multiply ]",
+		"operation": "*"
+	},
+	{
+		"text": "[ divide ]",
+		"operation": "/"
+	},
+]
+
+func _ready():
+	get_popup().connect("index_pressed", self, '_on_entry_selected')
+	get_popup().clear()
+	connect("about_to_show", self, "_on_MenuButton_about_to_show")
+
+
+func _on_MenuButton_about_to_show():
+	get_popup().clear()
+	var index = 0
+	for o in options:
+		get_popup().add_item(o['text'])
+		get_popup().set_item_metadata(index, o)
+		index += 1
+
+
+func _on_entry_selected(index):
+	var _text = get_popup().get_item_text(index)
+	var metadata = get_popup().get_item_metadata(index)
+	text = _text
+
+
+func load_condition(condition):
+	if condition != '':
+		for o in options:
+			if (o['operation'] == condition):
+				text = o['text']
+	else:
+		text = options[0]['text']

--- a/addons/dialogic/Editor/Pieces/Common/OperationPicker.tscn
+++ b/addons/dialogic/Editor/Pieces/Common/OperationPicker.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/OperationPicker.gd" type="Script" id=1]
+
+[node name="OperationPicker" type="MenuButton"]
+margin_left = 284.0
+margin_right = 296.0
+margin_bottom = 28.0
+text = "[ To be ]"
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/addons/dialogic/Editor/Pieces/SetValue.gd
+++ b/addons/dialogic/Editor/Pieces/SetValue.gd
@@ -7,27 +7,38 @@ var editorPopup
 
 # This is the information of this event and it will get parsed and saved to the JSON file.
 var event_data = {
+	'definition': '',
+	'operation': '=',
 	'set_value': '',
-	'definition': ''
 }
 
 onready var nodes = {
 	'definition_picker': $PanelContainer/VBoxContainer/Header/DefinitionPicker,
+	'operation_picker': $PanelContainer/VBoxContainer/Header/OperationPicker,
 }
 
 func _ready():
 	nodes['definition_picker'].get_popup().connect("index_pressed", self, '_on_definition_entry_selected')
+	nodes['operation_picker'].get_popup().connect("index_pressed", self, '_on_operation_entry_selected')
 
 
 func _on_definition_entry_selected(index):
 	var metadata = nodes['definition_picker'].get_popup().get_item_metadata(index)
 	event_data['definition'] = metadata['id']
 
+func _on_operation_entry_selected(index):
+	var metadata = nodes['operation_picker'].get_popup().get_item_metadata(index)
+	event_data['operation'] = metadata['operation']
+
 
 func load_data(data):
 	event_data = data
 	$PanelContainer/VBoxContainer/Header/LineEdit.text = event_data['set_value']
 	nodes['definition_picker'].load_definition(data['definition'])
+	var operation = ''
+	if 'operation' in data:
+		operation = data['operation']
+	nodes['operation_picker'].load_condition(operation)
 
 
 func _on_LineEdit_text_changed(new_text):

--- a/addons/dialogic/Editor/Pieces/SetValue.tscn
+++ b/addons/dialogic/Editor/Pieces/SetValue.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Pieces/SetValue.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Images/Events/set-value.svg" type="Texture" id=2]
@@ -6,6 +6,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DefinitionPicker.tscn" type="PackedScene" id=6]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/OperationPicker.tscn" type="PackedScene" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -86,16 +87,12 @@ margin_left = 137.0
 margin_right = 280.0
 margin_bottom = 28.0
 
-[node name="Title2" type="Label" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 284.0
-margin_top = 7.0
-margin_right = 333.0
-margin_bottom = 21.0
-text = "to be    "
+[node name="OperationPicker" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 7 )]
+margin_right = 347.0
 
 [node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 337.0
-margin_right = 385.0
+margin_left = 351.0
+margin_right = 399.0
 margin_bottom = 28.0
 custom_styles/read_only = SubResource( 2 )
 custom_styles/focus = SubResource( 2 )
@@ -112,14 +109,14 @@ caret_blink = true
 caret_blink_speed = 0.5
 
 [node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 389.0
+margin_left = 403.0
 margin_top = 7.0
-margin_right = 389.0
+margin_right = 403.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
 [node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
-margin_left = 393.0
+margin_left = 407.0
 margin_right = 941.0
 margin_bottom = 28.0
 

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -192,7 +192,7 @@ func load_timeline(filename: String):
 				create_event("WaitSeconds", i)
 			{'condition', 'definition', 'value'}:
 				create_event("IfCondition", i)
-			{'set_value', 'definition'}:
+			{'set_value', 'definition', ..}:
 				create_event("SetValue", i)
 			{'set_theme'}:
 				create_event("SetTheme", i)

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -508,9 +508,12 @@ func event_handler(event: Dictionary):
 			else:
 				# condition met, entering branch
 				go_to_next_event()
-		{'set_value', 'definition'}:
+		{'set_value', 'definition', ..}:
 			emit_signal("event_start", "set_value", event)
-			DialogicSingleton.set_variable_from_id(event['definition'], event['set_value'])
+			var operation = '='
+			if 'operation' in event and not event['operation'].empty():
+				operation = event["operation"]
+			DialogicSingleton.set_variable_from_id(event['definition'], event['set_value'], operation)
 			go_to_next_event()
 		_:
 			visible = false

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -50,10 +50,35 @@ func set_variable(name: String, value) -> void:
 			d['value'] = str(value)
 
 
-func set_variable_from_id(id: String, value) -> void:
+func set_variable_from_id(id: String, value: String, operation: String) -> void:
+	var target_def: Dictionary;
 	for d in current_definitions['variables']:
 		if d['id'] == id:
-			d['value'] = str(value)
+			target_def = d;
+	if target_def != null:
+		var converted_set_value = value
+		var converted_target_value = target_def['value']
+		var is_number = converted_set_value.is_valid_float() and converted_target_value.is_valid_float()
+		if is_number:
+			converted_set_value = float(value)
+			converted_target_value = float(target_def['value'])
+		var result = target_def['value']
+		# Do nothing for -, * and / operations on string
+		match operation:
+			'=':
+				result = converted_set_value
+			'+':
+				result = converted_target_value + converted_set_value
+			'-':
+				if is_number:
+					result = converted_target_value - converted_set_value
+			'*':
+				if is_number:
+					result = converted_target_value * converted_set_value
+			'/':
+				if is_number:
+					result = converted_target_value / converted_set_value
+		target_def['value'] = str(result)
 
 
 func get_glossary(name: String) -> Dictionary:


### PR DESCRIPTION
This PR adds the possibility to make basic calculations between a variable and a constant.

Supported operations are `=`, `+`, `-`, `*`, `/`.

Values are converted to numbers before the operation. If both values cannot be converted to number, only `=` and `+` operations are allowed, the others are ignored.

This is not breaking, all previous `Set value` events should be converted as simple `=` events.


Closes #119