### PR TITLE
do not reload saves on node init unless forced

### DIFF
--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -68,8 +68,8 @@ func _ready():
 
 func load_config_files():
 	if not Engine.is_editor_hint():
-		# Make sure saves are ready
-		DialogicSingleton.init(reset_saves)
+		if reset_saves:
+			DialogicSingleton.init(reset_saves)
 		definitions = DialogicSingleton.get_definitions()
 	else:
 		definitions = DialogicResources.get_default_definitions()

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -6,6 +6,7 @@ var default_definitions := {}
 var current_timeline := ''
 
 func _init() -> void:
+	# Load saves on script init
 	init(false)
 
 


### PR DESCRIPTION
We only reload saves if the user wants to reset them.
This allows editing definitions before adding the node to the tree

Closes #125