### PR TITLE
Added call-node feature

### DIFF
--- a/addons/dialogic/Editor/Pieces/CallNode.gd
+++ b/addons/dialogic/Editor/Pieces/CallNode.gd
@@ -25,9 +25,9 @@ func load_data(data):
 		if (event_data['call_node']['arguments'][i] == null):
 			event_data['call_node']['arguments'][i] = ''
 	
-	$PanelContainer/VBoxContainer/Target/LineEdit.text = event_data['call_node']['target_node_path']
-	$PanelContainer/VBoxContainer/Method/LineEdit.text = event_data['call_node']['method_name']
-	$PanelContainer/VBoxContainer/Method/ArgumentsSpinBox.value = event_data['call_node']['arguments'].size()
+	$PanelContainer/VBoxContainer/Properties/TargetNodeEdit.text = event_data['call_node']['target_node_path']
+	$PanelContainer/VBoxContainer/Properties/CallMethodEdit.text = event_data['call_node']['method_name']
+	$PanelContainer/VBoxContainer/Properties/ArgumentsSpinBox.value = event_data['call_node']['arguments'].size()
 	
 	_create_argument_controls()
 
@@ -76,13 +76,14 @@ func _create_argument_controls():
 		var label = Label.new()
 		label.name = "ArgumentLabel"
 		label.text = "Argument %s:" % index
+		label.rect_min_size.x = 100
 		container.add_child(label)
 		
 		var edit = LineEdit.new()
 		edit.name = "ArgumentValue"
 		edit.text = str(a)
 		edit.connect("text_changed", self, "_on_argument_value_changed", [ index ])
-		edit.rect_min_size.x = 200
+		edit.rect_min_size.x = 250
 		container.add_child(edit)
 		
 		$PanelContainer/VBoxContainer/Arguments.add_child(container)

--- a/addons/dialogic/Editor/Pieces/CallNode.gd
+++ b/addons/dialogic/Editor/Pieces/CallNode.gd
@@ -1,0 +1,92 @@
+tool
+extends Control
+
+var editor_reference
+var editorPopup
+
+
+# This is the information of this event and it will get parsed and saved to the JSON file.
+var event_data = {
+	'call_node': {
+		'target_node_path': '',
+		'method_name': '',
+		'arguments': []
+	}
+}
+
+
+func load_data(data):
+	event_data = data
+	
+	if (not event_data['call_node']['arguments'] is Array):
+		event_data['call_node']['arguments'] = []
+	
+	for i in range(event_data['call_node']['arguments'].size()):
+		if (event_data['call_node']['arguments'][i] == null):
+			event_data['call_node']['arguments'][i] = ''
+	
+	$PanelContainer/VBoxContainer/Target/LineEdit.text = event_data['call_node']['target_node_path']
+	$PanelContainer/VBoxContainer/Method/LineEdit.text = event_data['call_node']['method_name']
+	$PanelContainer/VBoxContainer/Method/ArgumentsSpinBox.value = event_data['call_node']['arguments'].size()
+	
+	_create_argument_controls()
+
+
+# signal callbacks
+
+func _on_Target_LineEdit_text_changed(new_text):
+	event_data['call_node']['target_node_path'] = new_text
+	
+func _on_Method_LineEdit_text_changed(new_text):
+	event_data['call_node']['method_name'] = new_text
+
+func _on_ArgumentsSpinBox_value_changed(value):
+	event_data['call_node']['arguments'].resize(max(0, value))
+	
+	for i in range(event_data['call_node']['arguments'].size()):
+		if (event_data['call_node']['arguments'][i] == null):
+			event_data['call_node']['arguments'][i] = ''
+			
+	_create_argument_controls()
+	pass
+	
+func _on_argument_value_changed(value, arg_index):
+	if (arg_index < 0 or arg_index >= event_data['call_node']['arguments'].size()):
+		return
+		
+	event_data['call_node']['arguments'][arg_index] = str(value)
+	pass
+	
+# helpers
+func _create_argument_controls():
+	if (not event_data['call_node']['arguments'] is Array):
+		return
+		
+	# clear old
+	for c in $PanelContainer/VBoxContainer/Arguments.get_children():
+		$PanelContainer/VBoxContainer/Arguments.remove_child(c)
+		c.queue_free()
+		
+	# create controls
+	var index = 0
+	for a in event_data['call_node']['arguments']:
+		var container = HBoxContainer.new()
+		container.name = "Argument%s" % index
+		
+		var label = Label.new()
+		label.name = "ArgumentLabel"
+		label.text = "Argument %s:" % index
+		container.add_child(label)
+		
+		var edit = LineEdit.new()
+		edit.name = "ArgumentValue"
+		edit.text = str(a)
+		edit.connect("text_changed", self, "_on_argument_value_changed", [ index ])
+		edit.rect_min_size.x = 200
+		container.add_child(edit)
+		
+		$PanelContainer/VBoxContainer/Arguments.add_child(container)
+		
+		index += 1
+		
+	pass

--- a/addons/dialogic/Editor/Pieces/CallNode.tscn
+++ b/addons/dialogic/Editor/Pieces/CallNode.tscn
@@ -1,0 +1,149 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://addons/dialogic/Images/Script.svg" type="Texture" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/CallNode.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=3]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/dialogic/Editor/Pieces/Common/DragController.tscn" type="PackedScene" id=5]
+
+[sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 16.0
+content_margin_right = 6.0
+content_margin_top = 6.0
+content_margin_bottom = 6.0
+bg_color = Color( 0.14902, 0.333333, 0.509804, 0.4 )
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.12549, 0.12549, 0.12549, 1 )
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="CallNode" type="HBoxContainer"]
+margin_right = 1004.0
+margin_bottom = 100.0
+size_flags_horizontal = 3
+size_flags_vertical = 9
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Indent" type="Control" parent="."]
+visible = false
+margin_bottom = 42.0
+
+[node name="PanelContainer" type="PanelContainer" parent="."]
+margin_right = 1004.0
+margin_bottom = 100.0
+mouse_filter = 1
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_styles/panel = SubResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer"]
+margin_left = 16.0
+margin_top = 6.0
+margin_right = 998.0
+margin_bottom = 94.0
+size_flags_horizontal = 3
+
+[node name="Header" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+margin_right = 982.0
+margin_bottom = 28.0
+
+[node name="TextureRect" type="TextureRect" parent="PanelContainer/VBoxContainer/Header"]
+margin_right = 22.0
+margin_bottom = 28.0
+texture = ExtResource( 1 )
+stretch_mode = 6
+
+[node name="Title" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 26.0
+margin_top = 7.0
+margin_right = 87.0
+margin_bottom = 21.0
+text = "Call Node"
+
+[node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 91.0
+margin_top = 7.0
+margin_right = 91.0
+margin_bottom = 21.0
+custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
+
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
+margin_left = 95.0
+margin_right = 941.0
+margin_bottom = 28.0
+
+[node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
+margin_left = 945.0
+margin_right = 982.0
+margin_bottom = 28.0
+items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
+
+[node name="Target" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+margin_top = 32.0
+margin_right = 982.0
+margin_bottom = 56.0
+custom_constants/separation = 20
+
+[node name="Title" type="Label" parent="PanelContainer/VBoxContainer/Target"]
+margin_top = 5.0
+margin_right = 81.0
+margin_bottom = 19.0
+text = "Target Node:"
+
+[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Target"]
+margin_left = 101.0
+margin_right = 471.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 370, 0 )
+
+[node name="Method" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+margin_top = 60.0
+margin_right = 982.0
+margin_bottom = 84.0
+custom_constants/separation = 20
+
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/Method"]
+margin_top = 5.0
+margin_right = 80.0
+margin_bottom = 19.0
+text = "Call Method:"
+
+[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Method"]
+margin_left = 100.0
+margin_right = 300.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 200, 0 )
+
+[node name="Label2" type="Label" parent="PanelContainer/VBoxContainer/Method"]
+margin_left = 320.0
+margin_top = 5.0
+margin_right = 394.0
+margin_bottom = 19.0
+text = "Arguments:"
+
+[node name="ArgumentsSpinBox" type="SpinBox" parent="PanelContainer/VBoxContainer/Method"]
+margin_left = 414.0
+margin_right = 488.0
+margin_bottom = 24.0
+max_value = 99.0
+
+[node name="Arguments" type="VBoxContainer" parent="PanelContainer/VBoxContainer"]
+margin_top = 88.0
+margin_right = 982.0
+margin_bottom = 88.0
+
+[node name="DragController" parent="." instance=ExtResource( 5 )]
+[connection signal="text_changed" from="PanelContainer/VBoxContainer/Target/LineEdit" to="." method="_on_Target_LineEdit_text_changed"]
+[connection signal="text_changed" from="PanelContainer/VBoxContainer/Method/LineEdit" to="." method="_on_Method_LineEdit_text_changed"]
+[connection signal="value_changed" from="PanelContainer/VBoxContainer/Method/ArgumentsSpinBox" to="." method="_on_ArgumentsSpinBox_value_changed"]

--- a/addons/dialogic/Editor/Pieces/CallNode.tscn
+++ b/addons/dialogic/Editor/Pieces/CallNode.tscn
@@ -89,61 +89,57 @@ margin_right = 982.0
 margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
-[node name="Target" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
+[node name="Properties" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
 margin_top = 32.0
 margin_right = 982.0
 margin_bottom = 56.0
-custom_constants/separation = 20
+custom_constants/separation = 8
 
-[node name="Title" type="Label" parent="PanelContainer/VBoxContainer/Target"]
+[node name="TargetNodeLabel" type="Label" parent="PanelContainer/VBoxContainer/Properties"]
 margin_top = 5.0
 margin_right = 81.0
 margin_bottom = 19.0
 text = "Target Node:"
 
-[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Target"]
-margin_left = 101.0
-margin_right = 471.0
+[node name="TargetNodeEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Properties"]
+margin_left = 89.0
+margin_right = 339.0
 margin_bottom = 24.0
-rect_min_size = Vector2( 370, 0 )
+rect_min_size = Vector2( 250, 0 )
 
-[node name="Method" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
-margin_top = 60.0
-margin_right = 982.0
-margin_bottom = 84.0
-custom_constants/separation = 20
-
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/Method"]
+[node name="CallMethodLabel" type="Label" parent="PanelContainer/VBoxContainer/Properties"]
+margin_left = 347.0
 margin_top = 5.0
-margin_right = 80.0
+margin_right = 427.0
 margin_bottom = 19.0
 text = "Call Method:"
 
-[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Method"]
-margin_left = 100.0
-margin_right = 300.0
+[node name="CallMethodEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Properties"]
+margin_left = 435.0
+margin_right = 635.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 200, 0 )
 
-[node name="Label2" type="Label" parent="PanelContainer/VBoxContainer/Method"]
-margin_left = 320.0
+[node name="ArgumentsLabel" type="Label" parent="PanelContainer/VBoxContainer/Properties"]
+margin_left = 643.0
 margin_top = 5.0
-margin_right = 394.0
+margin_right = 717.0
 margin_bottom = 19.0
 text = "Arguments:"
 
-[node name="ArgumentsSpinBox" type="SpinBox" parent="PanelContainer/VBoxContainer/Method"]
-margin_left = 414.0
-margin_right = 488.0
+[node name="ArgumentsSpinBox" type="SpinBox" parent="PanelContainer/VBoxContainer/Properties"]
+margin_left = 725.0
+margin_right = 799.0
 margin_bottom = 24.0
 max_value = 99.0
 
 [node name="Arguments" type="VBoxContainer" parent="PanelContainer/VBoxContainer"]
-margin_top = 88.0
+margin_top = 60.0
 margin_right = 982.0
-margin_bottom = 88.0
+margin_bottom = 60.0
+custom_constants/separation = 5
 
 [node name="DragController" parent="." instance=ExtResource( 5 )]
-[connection signal="text_changed" from="PanelContainer/VBoxContainer/Target/LineEdit" to="." method="_on_Target_LineEdit_text_changed"]
-[connection signal="text_changed" from="PanelContainer/VBoxContainer/Method/LineEdit" to="." method="_on_Method_LineEdit_text_changed"]
-[connection signal="value_changed" from="PanelContainer/VBoxContainer/Method/ArgumentsSpinBox" to="." method="_on_ArgumentsSpinBox_value_changed"]
+[connection signal="text_changed" from="PanelContainer/VBoxContainer/Properties/TargetNodeEdit" to="." method="_on_Target_LineEdit_text_changed"]
+[connection signal="text_changed" from="PanelContainer/VBoxContainer/Properties/CallMethodEdit" to="." method="_on_Method_LineEdit_text_changed"]
+[connection signal="value_changed" from="PanelContainer/VBoxContainer/Properties/ArgumentsSpinBox" to="." method="_on_ArgumentsSpinBox_value_changed"]

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -206,6 +206,8 @@ func load_timeline(filename: String):
 				create_event("SetValue", i)
 			{'set_theme'}:
 				create_event("SetTheme", i)
+			{'call_node'}:
+				create_event("CallNode", i)
 
 	if data.size() < 1:
 		events_warning.visible = true

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -347,6 +347,6 @@ align = 0
 margin_top = 698.0
 margin_right = 200.0
 margin_bottom = 726.0
-text = "Call Node"
+text = "  Call Node"
 icon = ExtResource( 20 )
 align = 0

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=2]
+[gd_scene load_steps=23 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/character-join.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Images/dialog.svg" type="Texture" id=2]
@@ -19,6 +19,7 @@
 [ext_resource path="res://addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd" type="Script" id=17]
 [ext_resource path="res://addons/dialogic/Images/theme.svg" type="Texture" id=18]
 [ext_resource path="res://addons/dialogic/Images/Events/background-music.svg" type="Texture" id=19]
+[ext_resource path="res://addons/dialogic/Images/Script.svg" type="Texture" id=20]
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 5.0
@@ -340,4 +341,12 @@ hint_tooltip = "This will instantly change
 the current scene."
 text = "  Change Scene"
 icon = ExtResource( 15 )
+align = 0
+
+[node name="CallNode" type="Button" parent="ScrollContainer/EventContainer"]
+margin_top = 698.0
+margin_right = 200.0
+margin_bottom = 726.0
+text = "Call Node"
+icon = ExtResource( 20 )
 align = 0

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -360,7 +360,9 @@ func load_dialog(skip_add = false):
 	# This will load the next entry in the dialog_script array.
 	if dialog_script.has('events'):
 		if dialog_index < dialog_script['events'].size():
-			event_handler(dialog_script['events'][dialog_index])
+			var func_state = event_handler(dialog_script['events'][dialog_index])
+			if (func_state is GDScriptFunctionState):
+				yield(func_state, "completed")
 		else:
 			if Engine.is_editor_hint() == false:
 				queue_free()
@@ -524,6 +526,31 @@ func event_handler(event: Dictionary):
 			if 'operation' in event and not event['operation'].empty():
 				operation = event["operation"]
 			DialogicSingleton.set_variable_from_id(event['definition'], event['set_value'], operation)
+			go_to_next_event()
+		{'call_node', ..}:
+			dprint('[!] Call Node signal: dialogic_signal(call_node) ', var2str(event['call_node']))
+			emit_signal("event_start", "call_node", event)
+			$TextBubble.visible = false
+			waiting = true
+			var target = get_node_or_null(event['call_node']['target_node_path'])
+			var method_name = event['call_node']['method_name']
+			var args = event['call_node']['arguments']
+			if (not args is Array):
+				args = []
+
+			if (target != null):
+				if (target.has_method(method_name)):
+					if (args.empty()):
+						var func_result = target.call(method_name)
+						if (func_result is GDScriptFunctionState):
+							yield(func_result, "completed")
+					else:
+						var func_result = target.call(method_name, args)
+						if (func_result is GDScriptFunctionState):
+							yield(func_result, "completed")
+
+			waiting = false
+			$TextBubble.visible = true
 			go_to_next_event()
 		_:
 			visible = false


### PR DESCRIPTION
Hi guys, I hope you are not mad at me, but I created a new event node for the timeline to call arbitrary node methods, because I needed it badly. I couldn't decide if I just create a workaround or just contribute instead. I do not want to take over your project, but maybe you find this handy and are considering to add it? It was not hard to do, so I am not mad if you decline it.

**Summary**:
I created a new event node call "Call Node". You can setup the node to call with a default Godot NodePath and a method name. In addition you can add arguments as well. The Timeline will execute those methods and even wait for completion, if the method in question is async and/or yielding.

**Usage**:
Add "Call Node" to your timeline. Change "Target Node" in GodotNodePath format. (e.g. `/root/Level/Player` or `./Triggers/DoorTrigger`) depending on your Scene setup. Add the name of the method to call as a string, as you would with Godots builtin `call` function. Optionally, add up to 99 arguments. Arguments get stored as strings, but you can cast them in your scripts like you do with defitinions. 

**Important**:
If you add arguments, the method in question gets called with an array, containing the arguments, as first parameter. But if you ommit the arguments, the method gets called without (an empty) arguments array. This is due to the way Godots `call` methods work. This way you can call parameterless builtin functions as well. As a future improvement, if I find a way to dynamically to spread the args instead of passing an array, I would prefer doing it that way (like the `...` operator in JavaScript). For now you cannot call builtin functions with paramters (e.g. `set_visible(true)`) and have to built a wrapper function to do so `func set_visible_arr(args): set_visible(bool(args[0]))` Does anybody know a way around this with the current state of GDScript?
I know there is the callv method (or the FuncRef.call_funcv) that kind of does what I mean, but this still leads to casting issues.

If you want to wait to complete a stack of tasks in sequence, just create a yielding method like this, and just call it. The timeline will yield until the called yielding function completes:

```
func do_craft_animation():
    $AnimationPlayer.play("crafting")
    yield($AnimationPlayer, "animation_finished")
    $Hat.hide()
    yield(get_tree().create_timer(4.0), "timeout")
    $AnimationPlayer.play("crafting")
    yield($AnimationPlayer, "animation_finished")
    $Hat.show()
```
I provided an example video that shows the new feature in question (Sorry for the odd video aspect ratio. OBS kind of dislikes me today):

https://streamable.com/s79dsk

Here is an example of the timeline:

![image](https://user-images.githubusercontent.com/22261975/113137458-dd0c9780-9224-11eb-92fc-e2b5437b4153.png)
![image](https://user-images.githubusercontent.com/22261975/113137520-ee55a400-9224-11eb-9533-7f93ee4de583.png)

I tried to follow your conventions as much as possible, and tried to not alter any existing stuff. However, I needed to change a small piece of the dialog_node.gd in order to make yield-waiting work. This change should not have any sideeffects.

Please let me know what you think and if I need to change something. 
