### PR TITLE
edit timeline button in timeline inspector plugin

### DIFF
--- a/addons/dialogic/Editor/MasterTree/MasterTree.gd
+++ b/addons/dialogic/Editor/MasterTree/MasterTree.gd
@@ -336,3 +336,55 @@ func save_current_resource():
 			if metadata['editor'] == 'Definition':
 				definition_editor.save_definition()
 			# Note: Theme files auto saves on change
+
+
+func select_timeline_item(timeline_name):
+	if (timeline_name == ''):
+		return
+
+	var main_item = tree.get_root().get_children()
+	
+	# wow, godots tree traversal is extremly odd, or I just don't get it
+	while (main_item):
+		
+		if (main_item == null):
+			break
+			
+		if (main_item.has_method("get_text") && main_item.get_text(0) == "Timelines"):
+			var item = main_item.get_children()
+			while (item):
+							
+				if (not item.has_method("get_metadata")):
+					item = item.get_next()
+					continue
+			
+				var meta = item.get_metadata(0)
+		
+				if (meta == null):
+					item = item.get_next()
+					continue
+		
+				if (not meta.has("editor") or meta["editor"] != "Timeline"):
+					item = item.get_next()
+					continue
+			
+				# search for filename
+				if (meta.has("file") and meta["file"] == timeline_name):
+					# select this one
+					item.select(0)
+					return;
+			
+				# search for name
+				if (meta.has("name") and meta["name"] == timeline_name):
+					# select this one
+					item.select(0)
+					return;
+	
+				item = item.get_next()
+			break
+		else:
+			main_item = main_item.get_next()
+			
+	# fallback
+	hide_all_editors()
+	pass

--- a/addons/dialogic/Other/inspector_timeline_picker.gd
+++ b/addons/dialogic/Other/inspector_timeline_picker.gd
@@ -1,6 +1,8 @@
 extends EditorInspectorPlugin
 
 var TimelinePicker = preload("res://addons/dialogic/Other/timeline_picker.gd")
+var dialogic_editor_plugin = null
+var dialogic_editor_view = null
 
 
 func can_handle(object):
@@ -15,8 +17,21 @@ func parse_property(object, type, path, hint, hint_text, usage):
 		if type == TYPE_STRING:
 			# Create an instance of the custom property editor and register
 			# it to a specific property path.
-			add_property_editor(path, TimelinePicker.new())
+			var picker = TimelinePicker.new()
+			picker.editor_inspector_plugin = self
+			add_property_editor(path, picker)
 			# Inform the editor to remove the default property editor for
 			# this property type.
 			return true
 		return false
+
+
+func switch_to_dialogic_timeline(timeline: String):
+	prints("switchting", timeline, dialogic_editor_plugin, dialogic_editor_view)
+	if (dialogic_editor_plugin != null):
+		dialogic_editor_plugin.get_editor_interface().set_main_screen_editor("Dialogic")
+		
+	if (dialogic_editor_view != null and dialogic_editor_view.master_tree != null):
+		dialogic_editor_view.master_tree.show_timeline_editor()
+		dialogic_editor_view.master_tree.select_timeline_item(timeline)
+	pass

--- a/addons/dialogic/Other/timeline_picker.gd
+++ b/addons/dialogic/Other/timeline_picker.gd
@@ -1,9 +1,14 @@
 tool
 extends EditorProperty
 
-
-# The main control for editing the property.
+# The main controls for editing the property.
 var timelines_dropdown = MenuButton.new()
+var container = HBoxContainer.new()
+var edit_button = Button.new()
+
+# reference to the inspector plugin
+var editor_inspector_plugin = null
+
 # An internal value of the property.
 var current_value = ''
 # A guard against internal changes when the property is updated.
@@ -11,14 +16,25 @@ var updating = false
 
 
 func _init():
-	# Add the control as a direct child of EditorProperty node.
-	add_child(timelines_dropdown)
+	# setup controls
+	timelines_dropdown.rect_min_size.x = 80
+	timelines_dropdown.set_h_size_flags(SIZE_EXPAND_FILL)
+	timelines_dropdown.clip_text = true
+	container.add_child(timelines_dropdown)
+	container.add_child(edit_button)
+	edit_button.hint_tooltip = "Edit Timeline"	
+	edit_button.icon = preload("res://addons/dialogic/Images/Tools.svg")
+	
+	# Add the container as a direct child
+	add_child(container)
+	
 	# Make sure the control is able to retain the focus.
 	add_focusable(timelines_dropdown)
+	
 	# Setup the initial state and connect to the signal to track changes.
 	timelines_dropdown.connect("about_to_show", self, "_about_to_show_menu")
 	timelines_dropdown.get_popup().connect("index_pressed", self, '_on_timeline_selected')
-
+	edit_button.connect("pressed", self, "_on_editTimelineButton_pressed")
 
 func _about_to_show_menu():
 	# Ignore the signal if the property is currently being updated.
@@ -39,6 +55,11 @@ func _on_timeline_selected(index):
 	current_value = metadata['file']
 	timelines_dropdown.text = text
 	emit_changed(get_edited_property(), current_value)
+	
+	
+func _on_editTimelineButton_pressed():
+	if (current_value != '' and editor_inspector_plugin != null):
+		editor_inspector_plugin.switch_to_dialogic_timeline(current_value)
 
 
 func update_property():
@@ -54,4 +75,5 @@ func update_property():
 	for c in DialogicUtil.get_timeline_list():
 		if c['file'] == current_value:
 			timelines_dropdown.text = c['name']
+			timelines_dropdown.hint_tooltip = c['name']
 	updating = false

--- a/addons/dialogic/Other/timeline_picker.gd
+++ b/addons/dialogic/Other/timeline_picker.gd
@@ -14,6 +14,9 @@ var current_value = ''
 # A guard against internal changes when the property is updated.
 var updating = false
 
+# @Override
+func get_tooltip_text():
+	return "Click to select a Dialogic timeline.\nPress the tool button to directly switch to the editor"
 
 func _init():
 	# setup controls
@@ -24,6 +27,7 @@ func _init():
 	container.add_child(edit_button)
 	edit_button.hint_tooltip = "Edit Timeline"	
 	edit_button.icon = preload("res://addons/dialogic/Images/Tools.svg")
+	edit_button.disabled = true
 	
 	# Add the container as a direct child
 	add_child(container)
@@ -35,6 +39,7 @@ func _init():
 	timelines_dropdown.connect("about_to_show", self, "_about_to_show_menu")
 	timelines_dropdown.get_popup().connect("index_pressed", self, '_on_timeline_selected')
 	edit_button.connect("pressed", self, "_on_editTimelineButton_pressed")
+
 
 func _about_to_show_menu():
 	# Ignore the signal if the property is currently being updated.
@@ -49,11 +54,14 @@ func _about_to_show_menu():
 		timelines_dropdown.get_popup().set_item_metadata(index, {'file': c['file'], 'color': c['color']})
 		index += 1
 
+
 func _on_timeline_selected(index):
 	var text = timelines_dropdown.get_popup().get_item_text(index)
 	var metadata = timelines_dropdown.get_popup().get_item_metadata(index)
 	current_value = metadata['file']
 	timelines_dropdown.text = text
+	timelines_dropdown.hint_tooltip = text
+	_update_edit_button(current_value)
 	emit_changed(get_edited_property(), current_value)
 	
 	
@@ -65,15 +73,32 @@ func _on_editTimelineButton_pressed():
 func update_property():
 	# Read the current value from the property.
 	var new_value = get_edited_object()[get_edited_property()]
+	_update_edit_button(new_value)
+	
 	if (new_value == current_value):
 		return
-
+		
 	# Update the control with the new value.
 	updating = true
 	current_value = new_value
 	# Checking for the display name
+	timelines_dropdown.text = ''
+	
+	if (current_value == ''):
+		timelines_dropdown.hint_tooltip = 'Click to select a timeline'
+		
 	for c in DialogicUtil.get_timeline_list():
 		if c['file'] == current_value:
 			timelines_dropdown.text = c['name']
 			timelines_dropdown.hint_tooltip = c['name']
+			
 	updating = false
+	
+	_update_edit_button(current_value)
+	
+	
+func _update_edit_button(value):
+	if (value == ''):
+		edit_button.disabled = true
+	else:
+		edit_button.disabled = false

--- a/addons/dialogic/dialogic.gd
+++ b/addons/dialogic/dialogic.gd
@@ -17,6 +17,8 @@ func _enter_tree() -> void:
 	_add_custom_editor_view()
 	get_editor_interface().get_editor_viewport().add_child(_editor_view)
 	make_visible(false)
+	_parts_inspector.dialogic_editor_plugin = self
+	_parts_inspector.dialogic_editor_view = _editor_view
 
 
 func _ready():


### PR DESCRIPTION
This PR for #144 implements a button next to the timeline selection inspector plugin
to directly jump to the timeline editor and selecting the corresponding timeline.

This addon as well adjusts some visual/sizing issues with the original timeline selection MenuButton

Please check that this plugin does not interfere and works as you like before mergin.

Showcase: 
https://streamable.com/yggbm7