### PR TITLE
allow scenes as backgrounds [Feature #9]

### DIFF
--- a/addons/dialogic/Editor/Pieces/SceneEvent.gd
+++ b/addons/dialogic/Editor/Pieces/SceneEvent.gd
@@ -33,8 +33,8 @@ func load_data(data):
 
 func load_image(img_src):
 	event_data['background'] = img_src
-	if event_data['background'] != '':
-		$PanelContainer/VBoxContainer/HBoxContainer/LineEdit.text = event_data['background']
+	$PanelContainer/VBoxContainer/HBoxContainer/LineEdit.text = event_data['background']
+	if event_data['background'] != '' and not event_data['background'].ends_with('.tscn'):
 		$PanelContainer/VBoxContainer/TextureRect.texture = load(event_data['background'])
 		$PanelContainer/VBoxContainer/TextureRect.rect_min_size = Vector2(200,200)
 		preview = event_data['background']

--- a/addons/dialogic/Editor/Pieces/SceneEvent.gd
+++ b/addons/dialogic/Editor/Pieces/SceneEvent.gd
@@ -18,7 +18,7 @@ func _ready():
 
 
 func _on_ImageButton_pressed():
-	editor_reference.godot_dialog("*.png, *.jpg, *.jpeg, *.tga, *.svg, *.svgz, *.bmp, *.webp;Image")
+	editor_reference.godot_dialog("*.png, *.jpg, *.jpeg, *.tga, *.svg, *.svgz, *.bmp, *.webp, *.tscn")
 	editor_reference.godot_dialog_connect(self, "_on_file_selected")
 
 

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -462,7 +462,18 @@ func event_handler(event: Dictionary):
 		{'background'}:
 			emit_signal("event_start", "background", event)
 			$Background.visible = true
-			$Background.texture = load(event['background'])
+			$Background.texture = null
+			if ($Background.get_child_count() > 0):
+				for c in $Background.get_children():
+					c.get_parent().remove_child(c)
+					c.queue_free()
+			if (event['background'].ends_with('.tscn')):
+				var bg_scene = load(event['background'])
+				if (bg_scene):
+					bg_scene = bg_scene.instance()
+					$Background.add_child(bg_scene)
+			elif (event['background'] != ''):
+				$Background.texture = load(event['background'])
 			go_to_next_event()
 		{'audio'}, {'audio', 'file'}:
 			emit_signal("event_start", "audio", event)


### PR DESCRIPTION
This PR implements issue #9

You can now select a tscn file as a background in the Scene Event node.
The scene gets attached as a child of the original background, and removed if you reset it

Showcase:
https://streamable.com/tctp9w