### PR TITLE
duplicating themes [Feature #66]

### DIFF
--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -134,7 +134,7 @@ func _on_ThemePopupMenu_id_pressed(id):
 	if id == 2:
 		var filename = $MainPanel/MasterTreeContainer/MasterTree.get_selected().get_metadata(0)['file']
 		if (filename.begins_with('theme-')):
-			theme_editor.duplidate_theme(filename)
+			theme_editor.duplicate_theme(filename)
 
 
 # Definition context menu

--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -131,6 +131,10 @@ func _on_ThemePopupMenu_id_pressed(id):
 		OS.shell_open(ProjectSettings.globalize_path(DialogicResources.get_path('THEME_DIR')))
 	if id == 1:
 		$RemoveThemeConfirmation.popup_centered()
+	if id == 2:
+		var filename = $MainPanel/MasterTreeContainer/MasterTree.get_selected().get_metadata(0)['file']
+		if (filename.begins_with('theme-')):
+			theme_editor.duplidate_theme(filename)
 
 
 # Definition context menu

--- a/addons/dialogic/Editor/EditorView.tscn
+++ b/addons/dialogic/Editor/EditorView.tscn
@@ -146,11 +146,11 @@ __meta__ = {
 }
 
 [node name="MasterTreeContainer" type="VBoxContainer" parent="MainPanel"]
-margin_right = 180.0
+margin_right = 150.0
 margin_bottom = 562.0
 
 [node name="FilterMasterTreeEdit" type="LineEdit" parent="MainPanel/MasterTreeContainer"]
-margin_right = 180.0
+margin_right = 150.0
 margin_bottom = 26.0
 clear_button_enabled = true
 right_icon = SubResource( 2 )
@@ -160,9 +160,9 @@ placeholder_text = "Filter"
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 30.0
-margin_right = 180.0
+margin_right = 150.0
 margin_bottom = 562.0
-rect_min_size = Vector2( 180, 0 )
+rect_min_size = Vector2( 150, 0 )
 size_flags_vertical = 3
 
 [node name="TimelineEditor" parent="MainPanel" instance=ExtResource( 2 )]
@@ -186,14 +186,14 @@ margin_right = 1253.0
 margin_bottom = 661.0
 
 [node name="Empty" type="CenterContainer" parent="MainPanel"]
-margin_left = 192.0
+margin_left = 162.0
 margin_right = 1024.0
 margin_bottom = 562.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="MainPanel/Empty"]
-margin_left = 276.0
+margin_left = 291.0
 margin_top = 274.0
-margin_right = 556.0
+margin_right = 571.0
 margin_bottom = 288.0
 
 [node name="Label" type="Label" parent="MainPanel/Empty/VBoxContainer"]
@@ -226,7 +226,7 @@ margin_left = 171.799
 margin_top = 209.0
 margin_right = 267.799
 margin_bottom = 229.0
-items = [ "Show in File Manager", ExtResource( 26 ), 0, false, false, 0, 0, null, "", false, "Remove Theme", ExtResource( 22 ), 0, false, false, 1, 0, null, "", false ]
+items = [ "Show in File Manager", ExtResource( 26 ), 0, false, false, 0, 0, null, "", false, "Remove Theme", ExtResource( 22 ), 0, false, false, 1, 0, null, "", false, "Duplicate Theme", ExtResource( 11 ), 0, false, false, 2, 0, null, "", false ]
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -173,7 +173,15 @@ func new_theme():
 	if DialogicUtil.get_theme_list().size() == 1:
 		#print('only theme, setting as default')
 		settings_editor.set_value('theme', 'default', theme_file)
+		
 
+func duplidate_theme(from_filename):
+	var duplicate_theme = 'theme-' + str(OS.get_unix_time()) + '.cfg'
+	DialogicResources.duplicate_theme(from_filename, duplicate_theme)
+	DialogicResources.set_theme_value(duplicate_theme, 'settings', 'name', duplicate_theme)
+	master_tree.build_themes(duplicate_theme)
+	load_theme(duplicate_theme)
+	
 
 func _on_BackgroundTextureButton_pressed():
 	editor_reference.godot_dialog("*.png")

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -175,7 +175,7 @@ func new_theme():
 		settings_editor.set_value('theme', 'default', theme_file)
 		
 
-func duplidate_theme(from_filename):
+func duplicate_theme(from_filename):
 	var duplicate_theme = 'theme-' + str(OS.get_unix_time()) + '.cfg'
 	DialogicResources.duplicate_theme(from_filename, duplicate_theme)
 	DialogicResources.set_theme_value(duplicate_theme, 'settings', 'name', duplicate_theme)

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -164,7 +164,34 @@ static func create_empty_file(path):
 	file.open(path, File.WRITE)
 	file.store_string('')
 	file.close()
-
+	
+	
+static func copy_file(path_from, path_to):
+	if (path_from == ''):
+		push_error("[Dialogic] Could not copy empty filename")
+		return ERR_FILE_BAD_PATH
+		
+	if (path_to == ''):
+		push_error("[Dialogic] Could not copy to empty filename")
+		return ERR_FILE_BAD_PATH
+	
+	var dir = Directory.new()
+	if (not dir.file_exists(path_from)):
+		push_error("[Dialogic] Could not copy file %s, File does not exists" % [ path_from ])
+		return ERR_FILE_NOT_FOUND
+		
+	if (dir.file_exists(path_to)):
+		push_error("[Dialogic] Could not copy file to %s, file already exists" % [ path_to ])
+		return ERR_ALREADY_EXISTS
+		
+	var error = dir.copy(path_from, path_to)
+	if (error):
+		push_error("[Dialogic] Error while copying %s to %s" % [ path_from, path_to ])
+		push_error(error)
+		return error
+		
+	return OK
+	pass
 
 # CONFIG UTIL
 
@@ -269,6 +296,10 @@ static func add_theme(filename: String):
 
 static func delete_theme(filename: String):
 	remove_file(get_path('THEME_DIR', filename))
+	
+	
+static func duplicate_theme(from_filename: String, to_filename: String):
+	copy_file(get_path('THEME_DIR', from_filename), get_path('THEME_DIR', to_filename))
 
 # SETTINGS
 # Can only be edited in the editor


### PR DESCRIPTION
This PR draft implements Milestone Issue #66

You can now duplicate a theme while rightclicking and pressing: duplicate theme
