### PR TITLE
[Fix #162] indent after dragging a piece #followup

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -238,6 +238,8 @@ func _on_gui_input(event, item: Node):
 		if (not event.is_pressed()):
 			if (not piece_was_dragged and moving_piece != null):
 				_clear_selection()
+			if (moving_piece != null):
+				indent_events()
 			moving_piece = null
 		elif event.is_pressed():
 			moving_piece = item


### PR DESCRIPTION
This PR fixes the second part of #162
I chose to only trigger the indent **after** the dragging is done and not on every dragging step to reduce the load on slow computers as @coppolaemilio pointed out