### PR TITLE
Make the left Sidebar in the Timelineeditor resizable

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn
@@ -51,7 +51,6 @@ anchor_bottom = 1.0
 margin_bottom = 138.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_constants/separation = 0
 split_offset = 7
 script = ExtResource( 17 )
 __meta__ = {


### PR DESCRIPTION
This makes the left sidebar in the Timeline editor reziseable. It fixes #123. I don't know why the separation was there in the first place so maybe it's wrong. This is my first pull request ever, so please correct me if I'm doing something wrong.