### PR TITLE
Updating the theme-editor design

### DIFF
--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -18,62 +18,62 @@ var loading = true
 # a way to set an id and then access that node via id...
 # Here you have paths in all its glory. Praise the paths (っ´ω`c)♡
 onready var n = {
-	# Text
-	'theme_text_shadow': $VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2/CheckBoxShadow,
-	'theme_text_shadow_color': $VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2/ColorPickerButtonShadow,
-	'theme_text_color': $VBoxContainer/TabContainer/Text/Column/GridContainer/ColorPickerButton,
-	'theme_font': $VBoxContainer/TabContainer/Text/Column/GridContainer/FontButton,
-	'theme_shadow_offset_x': $VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer/ShadowOffsetX,
-	'theme_shadow_offset_y': $VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer/ShadowOffsetY,
-	'theme_text_speed': $VBoxContainer/TabContainer/Text/Column/GridContainer/TextSpeed,
-	'alignment': $VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer3/Alignment,
+	# Dialog Text
+	'theme_text_shadow': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2/CheckBoxShadow",
+	'theme_text_shadow_color': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2/ColorPickerButtonShadow",
+	'theme_text_color': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/ColorPickerButton",
+	'theme_font': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/FontButton",
+	'theme_shadow_offset_x': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer/ShadowOffsetX",
+	'theme_shadow_offset_y': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer/ShadowOffsetY",
+	'theme_text_speed': $"VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer/TextSpeed",
+	'alignment': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer3/Alignment",
 	
 	# Dialog box
 	'background_texture_button_visible': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3/CheckBox",
 	'theme_background_image': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3/BackgroundTextureButton",
 	'theme_next_image': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/NextIndicatorButton",
 	'next_animation': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/NextAnimation",
-	'theme_action_key': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/BoxContainer/ActionOptionButton",
+	'theme_action_key': $"VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer/BoxContainer/ActionOptionButton",
 	'theme_background_color_visible': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2/CheckBox",
 	'theme_background_color': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2/ColorPickerButton",
-	'theme_text_margin': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer/TextOffsetV",
-	'theme_text_margin_h': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer/TextOffsetH",
-	'size_w': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4/BoxSizeW",
-	'size_h': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4/BoxSizeH", 
-	'bottom_gap': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer5/BottomGap",
+	'theme_text_margin': $"VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer/TextOffsetV",
+	'theme_text_margin_h': $"VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer/TextOffsetH",
+	'size_w': $"VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4/BoxSizeW",
+	'size_h': $"VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4/BoxSizeH", 
+	'bottom_gap': $"VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer5/BottomGap",
 	'background_modulation': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6/CheckBox",
 	'background_modulation_color': $"VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6/ColorPickerButton",
 	
+	# Character Names
+	'name_auto_color': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/CharacterColor",
+	'name_background_visible': $"VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2/CheckBox",
+	'name_background': $"VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2/ColorPickerButton",
+	'name_image': $"VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3/BackgroundTextureButton",
+	'name_image_visible': $"VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3/CheckBox",
+	'name_shadow': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/ColorPickerButtonShadow",
+	'name_shadow_visible': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/CheckBoxShadow",
+	'name_shadow_offset_x': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetX",
+	'name_shadow_offset_y': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetY",
+	'name_bottom_gap': $"VBoxContainer/TabContainer/Name Label/Column3/GridContainer/HBoxContainer5/BottomGap",
 	
-	# Buttons
+	# Choice Buttons
 	'button_text_color_enabled': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4/CheckBox2",
 	'button_text_color': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4/ButtonTextColor",
 	'button_background': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2/ColorPickerButton",
 	'button_background_visible': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2/CheckBox",
 	'button_image': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3/BackgroundTextureButton",
 	'button_image_visible': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3/CheckBox",
-	'button_offset_x': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer/TextOffsetH",
-	'button_offset_y': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer/TextOffsetV",
-	'button_separation': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/VerticalSeparation",
+	'button_offset_x': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH",
+	'button_offset_y': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV",
+	'button_separation': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation",
 	
-	# Definitions
+	# Glossary
 	'glossary_font': $VBoxContainer/TabContainer/Glossary/Column/GridContainer/FontButton,
 	'glossary_color': $VBoxContainer/TabContainer/Glossary/Column/GridContainer/ColorPickerButton,
 	
 	# Text preview
 	'text_preview': $VBoxContainer/HBoxContainer3/TextEdit,
 	
-	# Character Names
-	'name_auto_color': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/CheckBox",
-	'name_background_visible': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2/CheckBox",
-	'name_background': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2/ColorPickerButton",
-	'name_image': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3/BackgroundTextureButton",
-	'name_image_visible': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3/CheckBox",
-	'name_shadow': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/ColorPickerButtonShadow",
-	'name_shadow_visible': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/CheckBoxShadow",
-	'name_shadow_offset_x': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetX",
-	'name_shadow_offset_y': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetY",
-	'name_bottom_gap': $"VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer5/BottomGap",
 }
 
 func _ready():

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -1,39 +1,45 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/Plugin/plugin-editor-icon-light-theme.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd" type="Script" id=2]
 
+[sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 4.0
+content_margin_right = 4.0
+content_margin_top = 4.0
+content_margin_bottom = 4.0
+bg_color = Color( 0.6, 0.6, 0.6, 0.196078 )
+
 [node name="ThemeEditor" type="ScrollContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_right = 261.0
-margin_bottom = 232.0
+margin_right = -6.0
+margin_bottom = -17.0
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
-margin_right = 1285.0
-margin_bottom = 832.0
+margin_right = 1018.0
+margin_bottom = 583.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 custom_constants/separation = 15
 
+[node name="Panel" type="Panel" parent="VBoxContainer"]
+margin_right = 1018.0
+margin_bottom = 300.0
+rect_min_size = Vector2( 0, 300 )
+
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 1285.0
-margin_bottom = 60.0
+margin_top = 315.0
+margin_right = 1018.0
+margin_bottom = 375.0
 custom_constants/separation = 10
 
-[node name="PreviewButton" type="Button" parent="VBoxContainer/HBoxContainer3"]
-margin_right = 152.0
-margin_bottom = 60.0
-text = "  Preview changes  "
-icon = ExtResource( 1 )
-
 [node name="TextEdit" type="TextEdit" parent="VBoxContainer/HBoxContainer3"]
-margin_left = 162.0
-margin_right = 1285.0
+margin_right = 856.0
 margin_bottom = 60.0
 rect_min_size = Vector2( 400, 60 )
 size_flags_horizontal = 3
@@ -41,86 +47,119 @@ text = "This is preview text. You can use  [color=#A5EFAC]BBCode[/color] to styl
 [wave amp=50 freq=2]You can even use effects![/wave]"
 wrap_enabled = true
 
-[node name="Panel" type="Panel" parent="VBoxContainer"]
-margin_top = 75.0
-margin_right = 1285.0
-margin_bottom = 375.0
-rect_min_size = Vector2( 0, 300 )
+[node name="PreviewButton" type="Button" parent="VBoxContainer/HBoxContainer3"]
+margin_left = 866.0
+margin_right = 1018.0
+margin_bottom = 60.0
+text = "  Preview changes  "
+icon = ExtResource( 1 )
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
 margin_top = 390.0
-margin_right = 1285.0
-margin_bottom = 594.0
+margin_right = 1018.0
+margin_bottom = 583.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
 tab_align = 0
 
-[node name="Text" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
+[node name="Dialog Text" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
+custom_constants/separation = 10
 
-[node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Text"]
-margin_right = 316.0
-margin_bottom = 168.0
+[node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text"]
+margin_right = 270.0
+margin_bottom = 166.0
+rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Text/Column"]
-margin_right = 316.0
-margin_bottom = 168.0
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Visuals"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 166.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
 
-[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
+[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
 margin_top = 3.0
-margin_right = 148.0
+margin_right = 102.0
 margin_bottom = 17.0
 size_flags_horizontal = 3
 text = "Font"
 
-[node name="FontButton" type="Button" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
-margin_right = 316.0
+[node name="FontButton" type="Button" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_left = 112.0
+margin_right = 270.0
 margin_bottom = 20.0
 size_flags_vertical = 4
 text = "DefaultFont"
 
-[node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
+[node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
 margin_top = 32.0
-margin_right = 148.0
+margin_right = 102.0
 margin_bottom = 46.0
 text = "Color"
 
-[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
+[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_left = 112.0
 margin_top = 24.0
-margin_right = 316.0
+margin_right = 270.0
 margin_bottom = 54.0
 rect_min_size = Vector2( 50, 30 )
 color = Color( 1, 1, 1, 1 )
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_top = 66.0
-margin_right = 148.0
-margin_bottom = 80.0
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_top = 61.0
+margin_right = 102.0
+margin_bottom = 75.0
+text = "Alignment"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_left = 112.0
+margin_top = 58.0
+margin_right = 270.0
+margin_bottom = 78.0
+
+[node name="Alignment" type="OptionButton" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer3"]
+margin_right = 158.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
+text = "Left"
+items = [ "Left", null, false, 0, null, "Center", null, false, 1, null, "Right", null, false, 2, null ]
+selected = 0
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_top = 90.0
+margin_right = 102.0
+margin_bottom = 104.0
 text = "Shadow"
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
-margin_top = 58.0
-margin_right = 316.0
-margin_bottom = 88.0
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_left = 112.0
+margin_top = 82.0
+margin_right = 270.0
+margin_bottom = 112.0
 
-[node name="CheckBoxShadow" type="CheckBox" parent="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2"]
+[node name="CheckBoxShadow" type="CheckBox" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2"]
 margin_right = 24.0
 margin_bottom = 30.0
 
-[node name="ColorPickerButtonShadow" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2"]
+[node name="ColorPickerButtonShadow" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2"]
 margin_left = 28.0
 margin_right = 158.0
 margin_bottom = 30.0
@@ -128,20 +167,20 @@ rect_min_size = Vector2( 50, 30 )
 size_flags_horizontal = 3
 color = Color( 0, 0, 0, 0.619608 )
 
-[node name="Label4" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_top = 97.0
-margin_right = 148.0
-margin_bottom = 111.0
+[node name="Label4" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_top = 121.0
+margin_right = 102.0
+margin_bottom = 135.0
 text = "Shadow Offset"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
-margin_top = 92.0
-margin_right = 316.0
-margin_bottom = 116.0
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer"]
+margin_left = 112.0
+margin_top = 116.0
+margin_right = 270.0
+margin_bottom = 140.0
 custom_constants/separation = 10
 
-[node name="ShadowOffsetX" type="SpinBox" parent="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer"]
+[node name="ShadowOffsetX" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer"]
 margin_right = 74.0
 margin_bottom = 24.0
 value = 2.0
@@ -149,7 +188,7 @@ rounded = true
 allow_lesser = true
 prefix = "X"
 
-[node name="ShadowOffsetY" type="SpinBox" parent="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer"]
+[node name="ShadowOffsetY" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer"]
 margin_left = 84.0
 margin_right = 158.0
 margin_bottom = 24.0
@@ -158,40 +197,49 @@ rounded = true
 allow_lesser = true
 prefix = "Y"
 
-[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_top = 125.0
-margin_right = 148.0
-margin_bottom = 139.0
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Text"]
+margin_left = 280.0
+margin_right = 284.0
+margin_bottom = 166.0
+
+[node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text"]
+margin_left = 294.0
+margin_right = 564.0
+margin_bottom = 166.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column2"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Behavior"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column2"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 50.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer"]
+margin_top = 5.0
+margin_right = 186.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
 text = "Speed (bigger = slower)"
 
-[node name="TextSpeed" type="SpinBox" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
-margin_top = 120.0
-margin_right = 316.0
-margin_bottom = 144.0
+[node name="TextSpeed" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer"]
+margin_left = 196.0
+margin_right = 270.0
+margin_bottom = 24.0
 max_value = 10.0
 value = 2.0
 rounded = true
-
-[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_top = 151.0
-margin_right = 148.0
-margin_bottom = 165.0
-text = "Alignment"
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Text/Column/GridContainer"]
-margin_left = 158.0
-margin_top = 148.0
-margin_right = 316.0
-margin_bottom = 168.0
-
-[node name="Alignment" type="OptionButton" parent="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer3"]
-margin_right = 158.0
-margin_bottom = 20.0
-size_flags_horizontal = 3
-text = "Left"
-items = [ "Left", null, false, 0, null, "Center", null, false, 1, null, "Right", null, false, 2, null ]
-selected = 0
 
 [node name="Dialog Box" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
@@ -201,32 +249,41 @@ margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
+custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box"]
-margin_right = 1277.0
-margin_bottom = 236.0
-size_flags_horizontal = 3
+margin_right = 270.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Visuals"
+
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column"]
-margin_right = 1277.0
-margin_bottom = 236.0
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 154.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
 
 [node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
 margin_top = 5.0
-margin_right = 126.0
+margin_right = 134.0
 margin_bottom = 19.0
+size_flags_horizontal = 3
 text = "Background Color"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
-margin_right = 288.0
+margin_left = 144.0
+margin_right = 270.0
 margin_bottom = 24.0
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2"]
@@ -235,20 +292,20 @@ margin_bottom = 24.0
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2"]
 margin_left = 28.0
-margin_right = 152.0
+margin_right = 126.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
 margin_top = 33.0
-margin_right = 126.0
+margin_right = 134.0
 margin_bottom = 47.0
 text = "Background Texture"
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
+margin_left = 144.0
 margin_top = 28.0
-margin_right = 288.0
+margin_right = 270.0
 margin_bottom = 52.0
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3"]
@@ -258,21 +315,21 @@ pressed = true
 
 [node name="BackgroundTextureButton" type="Button" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3"]
 margin_left = 28.0
-margin_right = 152.0
+margin_right = 126.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 text = "background-2"
 
 [node name="Label9" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
 margin_top = 61.0
-margin_right = 126.0
+margin_right = 134.0
 margin_bottom = 75.0
 text = "Texture Modulation"
 
 [node name="HBoxContainer6" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
+margin_left = 144.0
 margin_top = 56.0
-margin_right = 288.0
+margin_right = 270.0
 margin_bottom = 80.0
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6"]
@@ -281,51 +338,80 @@ margin_bottom = 24.0
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6"]
 margin_left = 28.0
-margin_right = 152.0
+margin_right = 126.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
 margin_top = 87.0
-margin_right = 126.0
+margin_right = 134.0
 margin_bottom = 101.0
 text = "Next indicator"
 
 [node name="NextIndicatorButton" type="Button" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
+margin_left = 144.0
 margin_top = 84.0
-margin_right = 288.0
+margin_right = 270.0
 margin_bottom = 104.0
 text = "next-indicator"
 
 [node name="Label4" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
 margin_top = 111.0
-margin_right = 126.0
+margin_right = 134.0
 margin_bottom = 125.0
 text = "Next animation"
 
 [node name="NextAnimation" type="OptionButton" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
+margin_left = 144.0
 margin_top = 108.0
-margin_right = 288.0
+margin_right = 270.0
 margin_bottom = 128.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_top = 137.0
-margin_right = 126.0
-margin_bottom = 151.0
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Box"]
+margin_left = 280.0
+margin_right = 284.0
+margin_bottom = 157.0
+
+[node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box"]
+margin_left = 294.0
+margin_right = 564.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column2"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Placement"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column2"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_top = 5.0
+margin_right = 108.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
 text = "Box padding"
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 132.0
-margin_right = 288.0
-margin_bottom = 156.0
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_left = 118.0
+margin_right = 270.0
+margin_bottom = 24.0
 
-[node name="TextOffsetV" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer"]
+[node name="TextOffsetV" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer"]
 margin_right = 74.0
 margin_bottom = 24.0
 max_value = 1e+07
@@ -334,7 +420,7 @@ rounded = true
 allow_greater = true
 allow_lesser = true
 
-[node name="TextOffsetH" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer"]
+[node name="TextOffsetH" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer"]
 margin_left = 78.0
 margin_right = 152.0
 margin_bottom = 24.0
@@ -344,19 +430,19 @@ rounded = true
 allow_greater = true
 allow_lesser = true
 
-[node name="Label7" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_top = 165.0
-margin_right = 126.0
-margin_bottom = 179.0
-text = "Box Size (pixels)"
+[node name="Label7" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_top = 33.0
+margin_right = 108.0
+margin_bottom = 47.0
+text = "Box size (pixels)"
 
-[node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 160.0
-margin_right = 288.0
-margin_bottom = 184.0
+[node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_left = 118.0
+margin_top = 28.0
+margin_right = 270.0
+margin_bottom = 52.0
 
-[node name="BoxSizeW" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4"]
+[node name="BoxSizeW" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4"]
 margin_right = 74.0
 margin_bottom = 24.0
 value = 100.0
@@ -364,7 +450,7 @@ rounded = true
 allow_greater = true
 allow_lesser = true
 
-[node name="BoxSizeH" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4"]
+[node name="BoxSizeH" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4"]
 margin_left = 78.0
 margin_right = 152.0
 margin_bottom = 24.0
@@ -374,19 +460,19 @@ rounded = true
 allow_greater = true
 allow_lesser = true
 
-[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_top = 193.0
-margin_right = 126.0
-margin_bottom = 207.0
+[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_top = 61.0
+margin_right = 108.0
+margin_bottom = 75.0
 text = "Bottom gap"
 
-[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 188.0
-margin_right = 288.0
-margin_bottom = 212.0
+[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer"]
+margin_left = 118.0
+margin_top = 56.0
+margin_right = 270.0
+margin_bottom = 80.0
 
-[node name="BottomGap" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer5"]
+[node name="BottomGap" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer5"]
 margin_right = 74.0
 margin_bottom = 24.0
 max_value = 999.0
@@ -395,173 +481,55 @@ rounded = true
 allow_greater = true
 allow_lesser = true
 
-[node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_top = 216.0
-margin_right = 126.0
-margin_bottom = 236.0
+[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Box"]
+margin_left = 574.0
+margin_right = 578.0
+margin_bottom = 157.0
+
+[node name="Column3" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box"]
+margin_left = 588.0
+margin_right = 858.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column3"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Behavior"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column3"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 46.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer"]
+margin_right = 139.0
+margin_bottom = 20.0
+size_flags_horizontal = 3
 size_flags_vertical = 5
 text = "Action key"
 
-[node name="BoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 216.0
-margin_right = 288.0
-margin_bottom = 236.0
+[node name="BoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer"]
+margin_left = 149.0
+margin_right = 270.0
+margin_bottom = 20.0
 
-[node name="ActionOptionButton" type="OptionButton" parent="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/BoxContainer"]
-margin_right = 152.0
+[node name="ActionOptionButton" type="OptionButton" parent="VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer/BoxContainer"]
+margin_right = 121.0
 margin_bottom = 20.0
 hint_tooltip = "To add/remove actions go to Project > Project Settings > Input Map"
 size_flags_horizontal = 3
 text = "[Select Action]"
 items = [ "[Select Action]", null, false, 0, null, "ui_accept", null, false, 1, null, "ui_select", null, false, 2, null, "ui_cancel", null, false, 3, null, "ui_focus_next", null, false, 4, null, "ui_focus_prev", null, false, 5, null, "ui_left", null, false, 6, null, "ui_right", null, false, 7, null, "ui_up", null, false, 8, null, "ui_down", null, false, 9, null, "ui_page_up", null, false, 10, null, "ui_page_down", null, false, 11, null, "ui_home", null, false, 12, null, "ui_end", null, false, 13, null ]
 selected = 0
-
-[node name="Choice Buttons" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
-visible = false
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 4.0
-margin_top = 32.0
-margin_right = -4.0
-margin_bottom = -4.0
-
-[node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 953.0
-margin_top = 187.0
-margin_right = 945.0
-margin_bottom = 189.0
-size_flags_horizontal = 3
-size_flags_vertical = 3
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column"]
-margin_top = 34.0
-margin_right = 316.0
-margin_bottom = 170.0
-size_flags_horizontal = 3
-custom_constants/hseparation = 10
-columns = 2
-
-[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 5.0
-margin_right = 126.0
-margin_bottom = 19.0
-text = "Text Color "
-
-[node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 136.0
-margin_right = 288.0
-margin_bottom = 24.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="CheckBox2" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4"]
-margin_right = 24.0
-margin_bottom = 24.0
-pressed = true
-
-[node name="ButtonTextColor" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4"]
-margin_left = 28.0
-margin_right = 152.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-color = Color( 1, 1, 1, 1 )
-
-[node name="Label7" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 33.0
-margin_right = 126.0
-margin_bottom = 47.0
-text = "Background Color"
-
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 28.0
-margin_right = 288.0
-margin_bottom = 52.0
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2"]
-margin_right = 24.0
-margin_bottom = 24.0
-
-[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2"]
-margin_left = 28.0
-margin_right = 152.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 61.0
-margin_right = 126.0
-margin_bottom = 75.0
-text = "Background Texture"
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 56.0
-margin_right = 288.0
-margin_bottom = 80.0
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3"]
-margin_right = 24.0
-margin_bottom = 24.0
-pressed = true
-
-[node name="BackgroundTextureButton" type="Button" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3"]
-margin_left = 28.0
-margin_right = 152.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-text = "background-2"
-
-[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 89.0
-margin_right = 126.0
-margin_bottom = 103.0
-text = "Box padding"
-
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 84.0
-margin_right = 288.0
-margin_bottom = 108.0
-
-[node name="TextOffsetV" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer"]
-margin_right = 74.0
-margin_bottom = 24.0
-value = 5.0
-rounded = true
-allow_lesser = true
-prefix = "V"
-
-[node name="TextOffsetH" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer"]
-margin_left = 78.0
-margin_right = 152.0
-margin_bottom = 24.0
-value = 5.0
-rounded = true
-allow_lesser = true
-prefix = "H"
-
-[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 117.0
-margin_right = 126.0
-margin_bottom = 131.0
-text = "Vertical separation"
-
-[node name="VerticalSeparation" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 136.0
-margin_top = 112.0
-margin_right = 288.0
-margin_bottom = 136.0
-value = 5.0
-rounded = true
-allow_lesser = true
 
 [node name="Name Label" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
@@ -571,82 +539,52 @@ margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
+custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Name Label"]
-anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 315.0
-margin_top = 187.0
-margin_right = 307.0
-margin_bottom = 315.0
-size_flags_horizontal = 3
+margin_right = 287.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column"]
+margin_right = 287.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Text"
+
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Name Label/Column"]
-margin_top = 34.0
-margin_right = 315.0
-margin_bottom = 204.0
+margin_top = 26.0
+margin_right = 287.0
+margin_bottom = 112.0
 columns = 2
 
-[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
 margin_top = 5.0
-margin_right = 126.0
+margin_right = 125.0
 margin_bottom = 19.0
-text = "Background Color"
-
-[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_right = 288.0
-margin_bottom = 24.0
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2"]
-margin_right = 24.0
-margin_bottom = 24.0
-
-[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2"]
-margin_left = 28.0
-margin_right = 158.0
-margin_bottom = 24.0
 size_flags_horizontal = 3
+text = "Use character Color"
 
-[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_top = 33.0
-margin_right = 126.0
-margin_bottom = 47.0
-text = "Background Texture"
-
-[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_top = 28.0
-margin_right = 288.0
-margin_bottom = 52.0
-
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3"]
-margin_right = 24.0
+[node name="CharacterColor" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
+margin_left = 129.0
+margin_right = 287.0
 margin_bottom = 24.0
-pressed = true
-
-[node name="BackgroundTextureButton" type="Button" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3"]
-margin_left = 28.0
-margin_right = 158.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-text = "background-2"
 
 [node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_top = 64.0
-margin_right = 126.0
-margin_bottom = 78.0
+margin_top = 36.0
+margin_right = 125.0
+margin_bottom = 50.0
 text = "Shadow"
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_top = 56.0
-margin_right = 288.0
-margin_bottom = 86.0
+margin_left = 129.0
+margin_top = 28.0
+margin_right = 287.0
+margin_bottom = 58.0
 
 [node name="CheckBoxShadow" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4"]
 margin_right = 24.0
@@ -661,16 +599,16 @@ size_flags_horizontal = 3
 color = Color( 0, 0, 0, 0.619608 )
 
 [node name="Label4" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_top = 95.0
-margin_right = 126.0
-margin_bottom = 109.0
+margin_top = 67.0
+margin_right = 125.0
+margin_bottom = 81.0
 text = "Shadow Offset"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_top = 90.0
-margin_right = 288.0
-margin_bottom = 114.0
+margin_left = 129.0
+margin_top = 62.0
+margin_right = 287.0
+margin_bottom = 86.0
 custom_constants/separation = 10
 
 [node name="ShadowOffsetX" type="SpinBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer"]
@@ -690,19 +628,119 @@ rounded = true
 allow_lesser = true
 prefix = "Y"
 
-[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_top = 123.0
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Name Label"]
+margin_left = 297.0
+margin_right = 301.0
+margin_bottom = 157.0
+
+[node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Name Label"]
+margin_left = 311.0
+margin_right = 581.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column2"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Box"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Name Label/Column2"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 78.0
+columns = 2
+
+[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer"]
+margin_top = 5.0
+margin_right = 140.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Background Color"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer"]
+margin_left = 144.0
+margin_right = 270.0
+margin_bottom = 24.0
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2"]
+margin_right = 24.0
+margin_bottom = 24.0
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2"]
+margin_left = 28.0
 margin_right = 126.0
-margin_bottom = 137.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer"]
+margin_top = 33.0
+margin_right = 140.0
+margin_bottom = 47.0
+text = "Background Texture"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer"]
+margin_left = 144.0
+margin_top = 28.0
+margin_right = 270.0
+margin_bottom = 52.0
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3"]
+margin_right = 24.0
+margin_bottom = 24.0
+pressed = true
+
+[node name="BackgroundTextureButton" type="Button" parent="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3"]
+margin_left = 28.0
+margin_right = 126.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+text = "background-2"
+
+[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/TabContainer/Name Label"]
+margin_left = 591.0
+margin_right = 595.0
+margin_bottom = 157.0
+
+[node name="Column3" type="VBoxContainer" parent="VBoxContainer/TabContainer/Name Label"]
+margin_left = 605.0
+margin_right = 875.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column3"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Placement"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Name Label/Column3"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 50.0
+columns = 2
+
+[node name="Label8" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column3/GridContainer"]
+margin_top = 5.0
+margin_right = 192.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
 text = "Bottom gap"
 
-[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_top = 118.0
-margin_right = 288.0
-margin_bottom = 142.0
+[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Name Label/Column3/GridContainer"]
+margin_left = 196.0
+margin_right = 270.0
+margin_bottom = 24.0
 
-[node name="BottomGap" type="SpinBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer5"]
+[node name="BottomGap" type="SpinBox" parent="VBoxContainer/TabContainer/Name Label/Column3/GridContainer/HBoxContainer5"]
 margin_right = 74.0
 margin_bottom = 24.0
 max_value = 999.0
@@ -710,17 +748,183 @@ value = 48.0
 allow_greater = true
 allow_lesser = true
 
-[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_top = 151.0
-margin_right = 126.0
-margin_bottom = 165.0
-text = "Auto color"
+[node name="Choice Buttons" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+custom_constants/separation = 10
 
-[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer"]
-margin_left = 130.0
-margin_top = 146.0
-margin_right = 288.0
-margin_bottom = 170.0
+[node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
+margin_right = 270.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Visuals"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 106.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 5.0
+margin_right = 134.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Text Color "
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_right = 270.0
+margin_bottom = 24.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CheckBox2" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4"]
+margin_right = 24.0
+margin_bottom = 24.0
+pressed = true
+
+[node name="ButtonTextColor" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4"]
+margin_left = 28.0
+margin_right = 126.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+color = Color( 1, 1, 1, 1 )
+
+[node name="Label7" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 33.0
+margin_right = 134.0
+margin_bottom = 47.0
+text = "Background Color"
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_top = 28.0
+margin_right = 270.0
+margin_bottom = 52.0
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2"]
+margin_right = 24.0
+margin_bottom = 24.0
+
+[node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2"]
+margin_left = 28.0
+margin_right = 126.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 61.0
+margin_right = 134.0
+margin_bottom = 75.0
+text = "Background Texture"
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_top = 56.0
+margin_right = 270.0
+margin_bottom = 80.0
+
+[node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3"]
+margin_right = 24.0
+margin_bottom = 24.0
+pressed = true
+
+[node name="BackgroundTextureButton" type="Button" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3"]
+margin_left = 28.0
+margin_right = 126.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+text = "background-2"
+
+[node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Choice Buttons"]
+margin_left = 280.0
+margin_right = 284.0
+margin_bottom = 157.0
+
+[node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
+margin_left = 294.0
+margin_right = 575.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column2"]
+margin_right = 281.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Placement"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column2"]
+margin_top = 26.0
+margin_right = 281.0
+margin_bottom = 78.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="Label6" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer"]
+margin_top = 5.0
+margin_right = 119.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Box padding"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer"]
+margin_left = 129.0
+margin_right = 281.0
+margin_bottom = 24.0
+
+[node name="TextOffsetV" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer"]
+margin_right = 74.0
+margin_bottom = 24.0
+value = 5.0
+rounded = true
+allow_lesser = true
+prefix = "V"
+
+[node name="TextOffsetH" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer"]
+margin_left = 78.0
+margin_right = 152.0
+margin_bottom = 24.0
+value = 5.0
+rounded = true
+allow_lesser = true
+prefix = "H"
+
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer"]
+margin_top = 33.0
+margin_right = 119.0
+margin_bottom = 47.0
+text = "Vertical separation"
+
+[node name="VerticalSeparation" type="SpinBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer"]
+margin_left = 129.0
+margin_top = 28.0
+margin_right = 281.0
+margin_bottom = 52.0
+value = 5.0
+rounded = true
+allow_lesser = true
 
 [node name="Glossary" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
@@ -730,44 +934,51 @@ margin_left = 4.0
 margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
+custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Glossary"]
-margin_right = 40.0
-margin_bottom = 40.0
+margin_right = 270.0
+margin_bottom = 157.0
+rect_min_size = Vector2( 270, 0 )
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Visuals"
 
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Glossary/Column"]
-margin_left = 315.0
-margin_top = 429.0
-margin_right = 630.0
-margin_bottom = 483.0
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 80.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
 
 [node name="Label5" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
 margin_top = 3.0
-margin_right = 210.0
+margin_right = 165.0
 margin_bottom = 17.0
 size_flags_horizontal = 3
 text = "Font"
 
 [node name="FontButton" type="Button" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
-margin_left = 220.0
-margin_right = 315.0
+margin_left = 175.0
+margin_right = 270.0
 margin_bottom = 20.0
 size_flags_vertical = 4
 text = "GlossaryFont"
 
 [node name="Label3" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
 margin_top = 32.0
-margin_right = 210.0
+margin_right = 165.0
 margin_bottom = 46.0
 text = "Color"
 
 [node name="ColorPickerButton" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
-margin_left = 220.0
+margin_left = 175.0
 margin_top = 24.0
-margin_right = 315.0
+margin_right = 270.0
 margin_bottom = 54.0
 rect_min_size = Vector2( 50, 30 )
 color = Color( 0.215686, 0.654902, 0.67451, 1 )
@@ -831,16 +1042,16 @@ prefix = "Y"
 [node name="DelayPreviewTimer" type="Timer" parent="."]
 one_shot = true
 
-[connection signal="pressed" from="VBoxContainer/HBoxContainer3/PreviewButton" to="." method="_on_PreviewButton_pressed"]
 [connection signal="text_changed" from="VBoxContainer/HBoxContainer3/TextEdit" to="." method="_on_Preview_text_changed"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/FontButton" to="." method="_on_FontButton_pressed"]
-[connection signal="color_changed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/ColorPickerButton" to="." method="_on_ColorPickerButton_color_changed"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2/CheckBoxShadow" to="." method="_on_CheckBoxShadow_toggled"]
-[connection signal="color_changed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer2/ColorPickerButtonShadow" to="." method="_on_ColorPickerButtonShadow_color_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_ShadowOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer/ShadowOffsetY" to="." method="_on_ShadowOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Text/Column/GridContainer/TextSpeed" to="." method="_on_textSpeed_value_changed"]
-[connection signal="item_selected" from="VBoxContainer/TabContainer/Text/Column/GridContainer/HBoxContainer3/Alignment" to="." method="_on_Alignment_item_selected"]
+[connection signal="pressed" from="VBoxContainer/HBoxContainer3/PreviewButton" to="." method="_on_PreviewButton_pressed"]
+[connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/FontButton" to="." method="_on_FontButton_pressed"]
+[connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/ColorPickerButton" to="." method="_on_ColorPickerButton_color_changed"]
+[connection signal="item_selected" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer3/Alignment" to="." method="_on_Alignment_item_selected"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2/CheckBoxShadow" to="." method="_on_CheckBoxShadow_toggled"]
+[connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2/ColorPickerButtonShadow" to="." method="_on_ColorPickerButtonShadow_color_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_ShadowOffset_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer/ShadowOffsetY" to="." method="_on_ShadowOffset_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer/TextSpeed" to="." method="_on_textSpeed_value_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2/CheckBox" to="." method="_on_BackgroundColor_CheckBox_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2/ColorPickerButton" to="." method="_on_BackgroundColor_ColorPickerButton_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3/CheckBox" to="." method="_on_BackgroundTexture_CheckBox_toggled"]
@@ -849,32 +1060,32 @@ one_shot = true
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6/ColorPickerButton" to="." method="_on_ColorPicker_Background_texture_modulation_color_changed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/NextIndicatorButton" to="." method="_on_NextIndicatorButton_pressed"]
 [connection signal="item_selected" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/NextAnimation" to="." method="_on_NextAnimation_item_selected"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_TextMargin_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_TextMargin_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4/BoxSizeW" to="." method="_on_BoxSize_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer4/BoxSizeH" to="." method="_on_BoxSize_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer5/BottomGap" to="." method="_on_BottomGap_value_changed"]
-[connection signal="item_selected" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/BoxContainer/ActionOptionButton" to="." method="_on_ActionOptionButton_item_selected"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/BoxContainer/ActionOptionButton" to="." method="_on_ActionOptionButton_pressed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_TextMargin_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_TextMargin_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4/BoxSizeW" to="." method="_on_BoxSize_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer4/BoxSizeH" to="." method="_on_BoxSize_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Box/Column2/GridContainer/HBoxContainer5/BottomGap" to="." method="_on_BottomGap_value_changed"]
+[connection signal="item_selected" from="VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer/BoxContainer/ActionOptionButton" to="." method="_on_ActionOptionButton_item_selected"]
+[connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Box/Column3/GridContainer/BoxContainer/ActionOptionButton" to="." method="_on_ActionOptionButton_pressed"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/CharacterColor" to="." method="_on_name_auto_color_toggled"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/CheckBoxShadow" to="." method="_on_shadow_visible_toggled"]
+[connection signal="color_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/ColorPickerButtonShadow" to="." method="_on_name_shadow_color_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_name_ShadowOffset_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetY" to="." method="_on_name_ShadowOffset_value_changed"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2/CheckBox" to="." method="_on_name_background_visible_toggled"]
+[connection signal="color_changed" from="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer2/ColorPickerButton" to="." method="_on_name_background_color_changed"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3/CheckBox" to="." method="_on_name_image_visible_toggled"]
+[connection signal="pressed" from="VBoxContainer/TabContainer/Name Label/Column2/GridContainer/HBoxContainer3/BackgroundTextureButton" to="." method="_on_name_image_pressed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column3/GridContainer/HBoxContainer5/BottomGap" to="." method="_on_name_BottomGap_value_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4/CheckBox2" to="." method="_on_Custom_Button_Color_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer4/ButtonTextColor" to="." method="_on_ButtonTextColor_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2/CheckBox" to="." method="_on_button_background_visible_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer2/ColorPickerButton" to="." method="_on_button_background_color_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3/CheckBox" to="." method="_on_button_texture_toggled"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer3/BackgroundTextureButton" to="." method="_on_ButtonTextureButton_pressed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_ButtonOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_ButtonOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/VerticalSeparation" to="." method="_on_VerticalSeparation_value_changed"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2/CheckBox" to="." method="_on_name_background_visible_toggled"]
-[connection signal="color_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer2/ColorPickerButton" to="." method="_on_name_background_color_changed"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3/CheckBox" to="." method="_on_name_image_visible_toggled"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer3/BackgroundTextureButton" to="." method="_on_name_image_pressed"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/CheckBoxShadow" to="." method="_on_shadow_visible_toggled"]
-[connection signal="color_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer4/ColorPickerButtonShadow" to="." method="_on_name_shadow_color_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_name_ShadowOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer/ShadowOffsetY" to="." method="_on_name_ShadowOffset_value_changed"]
-[connection signal="value_changed" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/HBoxContainer5/BottomGap" to="." method="_on_name_BottomGap_value_changed"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Name Label/Column/GridContainer/CheckBox" to="." method="_on_name_auto_color_toggled"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_ButtonOffset_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_ButtonOffset_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation" to="." method="_on_VerticalSeparation_value_changed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/FontButton" to="." method="_on_GlossaryFontButton_pressed"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/ColorPickerButton" to="." method="_on_GlossaryColorPicker_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer2/CheckBoxShadow" to="." method="_on_CheckBoxShadow_toggled"]


### PR DESCRIPTION
- Creating multiple columns for all the tabs
- Creating a section title for each column
- general sorting and reordering of the settings/options
- Renaming the "Auto Color" option to "Use character Color"
- Renaming Text tab to Dialog Text
- Cleaning and reordering the beginnging of the ThemeEditor.gd script (The reference part)
- Fixing the refrences to all the elements in the ThemeEditor.gd script
- Making the tabs always go to the bottom
- moving the "text input" field and the "preview changes" button below the preview and switch them

Preview:
![2021-04-07-21-13-30](https://user-images.githubusercontent.com/42868150/113921324-25f4bb00-97e6-11eb-9aa2-976b00b2463a.gif)
