### PR TITLE
move start methods in dialog_node

### DIFF
--- a/addons/dialogic/Dialog.tscn
+++ b/addons/dialogic/Dialog.tscn
@@ -8,8 +8,6 @@
 [ext_resource path="res://addons/dialogic/Nodes/dialog_node.gd" type="Script" id=6]
 [ext_resource path="res://addons/dialogic/Nodes/BackgroundMusic.tscn" type="PackedScene" id=7]
 
-
-
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 1, 1, 1, 0 )
 expand_margin_left = 10.0
@@ -89,9 +87,9 @@ anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-margin_left = -250.0
+margin_left = -455.0
 margin_top = -207.0
-margin_right = 250.0
+margin_right = 455.0
 margin_bottom = -40.0
 __meta__ = {
 "_edit_use_anchors_": false
@@ -147,7 +145,7 @@ anchor_bottom = 1.0
 margin_left = -36.4279
 margin_top = -35.9016
 margin_right = 14.5721
-margin_bottom = 29.4015
+margin_bottom = 25.4599
 rect_scale = Vector2( 0.4, 0.4 )
 texture = ExtResource( 1 )
 stretch_mode = 4
@@ -204,6 +202,17 @@ __meta__ = {
 }
 
 [node name="Tween" type="Tween" parent="TextBubble"]
+
+[node name="CloseDialog" type="Control" parent="TextBubble"]
+margin_right = 40.0
+margin_bottom = 40.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Tween" type="Tween" parent="TextBubble/CloseDialog"]
+
+[node name="Timer" type="Timer" parent="TextBubble/CloseDialog"]
 
 [node name="Options" type="VBoxContainer" parent="."]
 anchor_left = 0.5
@@ -342,7 +351,6 @@ __meta__ = {
 [node name="Timer" type="Timer" parent="DefinitionInfo"]
 
 [node name="WaitSeconds" type="Timer" parent="."]
-
 [connection signal="meta_hover_ended" from="TextBubble/RichTextLabel" to="." method="_on_RichTextLabel_meta_hover_ended"]
 [connection signal="meta_hover_started" from="TextBubble/RichTextLabel" to="." method="_on_RichTextLabel_meta_hover_started"]
 [connection signal="timeout" from="DefinitionInfo/Timer" to="." method="_on_Definition_Timer_timeout"]

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -285,7 +285,7 @@ func _on_PreviewButton_pressed() -> void:
 	for i in $VBoxContainer/Panel.get_children():
 		i.free()
 	var dialogic_node = load("res://addons/dialogic/Dialog.tscn")
-	var preview_dialog = dialogic_node.instance()
+	var preview_dialog: DialogicNode = dialogic_node.instance()
 	preview_dialog.timeline = ''
 	preview_dialog.preview = true
 	preview_dialog.debug_mode = false
@@ -299,24 +299,24 @@ func _on_PreviewButton_pressed() -> void:
 		character_file = characters[0]['file']
 	
 	# Loading the theme here because I need it for the parse_alignment
-	preview_dialog.current_theme = preview_dialog.load_theme(current_theme)
+	preview_dialog.current_theme = preview_dialog._load_theme(current_theme)
 	
 	# Creating the one event timeline for the dialog
-	var text = preview_dialog.parse_definitions(n['text_preview'].text)
+	var text = preview_dialog._parse_definitions(n['text_preview'].text)
 	preview_dialog.dialog_script['events'] = [{
 		"character": character_file,
 		"portrait":'',
 		"text": text
 	}]
-	preview_dialog.parse_characters(preview_dialog.dialog_script)
+	preview_dialog._parse_characters(preview_dialog.dialog_script)
 	preview_dialog.settings = DialogicResources.get_settings_config()
 	
 	# Alignment
 	$VBoxContainer/Panel.add_child(preview_dialog)
 	
-	preview_dialog.load_dialog()
+	preview_dialog._init_dialog()
 	# Reloading the theme
-	preview_dialog.current_theme = preview_dialog.load_theme(current_theme)
+	preview_dialog.current_theme = preview_dialog._load_theme(current_theme)
 	
 	
 	# When not performing this step, the dialog name doesn't update the color for some reason

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -668,7 +668,7 @@ func _answer_question(i, event_id, question_id):
 	_dprint('[!] Going to ', event_id + 1, i, 'question_id:', question_id)
 	_dprint('')
 	waiting_for_answer = false
-	dialog_index = event_id + 1
+	dialog_index = event_id
 	questions[question_id]['answered'] = true
 	_dprint('    dialog_index = ', dialog_index)
 	_reset_options()

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -419,14 +419,10 @@ func load_event():
 	$DefinitionInfo.visible = definition_visible
 
 	# This will load the next entry in the dialog_script array.
-	if dialog_script.has('events'):
-		if dialog_index < dialog_script['events'].size():
-			var func_state = event_handler(dialog_script['events'][dialog_index])
-			if (func_state is GDScriptFunctionState):
-				yield(func_state, "completed")
-		else:
-			if not Engine.is_editor_hint():
-				queue_free()
+	if dialog_script.has('events') and dialog_index < dialog_script['events'].size():
+		var func_state = event_handler(dialog_script['events'][dialog_index])
+		if (func_state is GDScriptFunctionState):
+			yield(func_state, "completed")
 
 
 func event_handler(event: Dictionary):
@@ -954,4 +950,3 @@ func close_dialog_event():
 
 func _on_close_dialog_timeout():
 	on_timeline_end()
-	queue_free()

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -524,9 +524,9 @@ func _event_handler(event: Dictionary):
 			if event['set_theme'] != '':
 				current_theme = _load_theme(event['set_theme'])
 			_load_next_event(current_runtime_id)
-		{'_wait_seconds'}:
+		{'wait_seconds'}:
 			emit_signal("event_start", "wait", event)
-			_wait_seconds(event['_wait_seconds'])
+			_wait_seconds(event['wait_seconds'])
 			waiting = true
 		{'change_timeline'}:
 			dialog_script = _set_current_dialog(event['change_timeline'])

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -1,3 +1,4 @@
+tool
 extends Control
 class_name DialogicNode
 
@@ -96,6 +97,10 @@ func start_from_save(fallback: String, debug: bool=false):
 	if last.empty():
 		last = fallback
 	start(last, false, debug)
+
+
+func load_preview(theme: String):
+	pass
 
 
 ## *****************************************************************************

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -1,5 +1,5 @@
-tool
 extends Control
+class_name DialogicNode
 
 var last_mouse_mode = null
 var input_next: String = 'ui_accept'

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -46,6 +46,15 @@ var runtime_id
 ##								PUBLIC METHODS
 ## *****************************************************************************
 
+## Starts the dialog for the given timeline.
+##
+## This is exactly the same as using the editor:
+## you can drag and drop the scene located at /addons/dialogic/Dialog.tscn 
+## and set the current timeline via the inspector.
+##
+## @param given_timeline		The timeline to load. You can provide the timeline name or the filename.
+## @param reset					True to reset dialogic saved data such as definitions.
+## @param debug					Debug is disabled by default but can be enabled if needed.
 func start(given_timeline: String, reset: bool=true, debug: bool=false):
 	show()
 	reset_saves = reset
@@ -78,6 +87,10 @@ func start(given_timeline: String, reset: bool=true, debug: bool=false):
 		_init_dialog()
 
 
+## Same as the start method, but using the last timeline saved.
+## 
+## @param fallback				The timeline to load in case no save is found.
+## @param debug					Debug is disabled by default but can be enabled if needed.
 func start_from_save(fallback: String, debug: bool=false):
 	var last = DialogicSingleton.get_current_timeline()
 	if last.empty():

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -67,7 +67,7 @@ func _ready():
 
 
 func start(given_timeline: String, reset: bool=true, debug: bool=false):
-	print("starting: " + given_timeline)
+	show()
 	reset_saves = reset
 	debug_mode = debug
 	runtime_id = DialogicUtil.generate_random_id()
@@ -956,4 +956,5 @@ func stop_close_dialog():
 
 
 func _on_close_dialog_timeout(tween, close_dialog_timer):
+	hide()
 	on_timeline_end()

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -19,13 +19,30 @@ class_name Dialogic
 ## @param parent				The parent to add the dialogic node to.
 ## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
 ## @returns						The Dialog node or null if the parent was invalid.
-static func add_node(parent, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn") -> DialogicNode:
+static func add_as_child_of(parent: Node, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn") -> DialogicNode:
 	if parent is Control:
 		var dialog_node = get_instance(dialog_scene_path)
 		parent.add_child(dialog_node)
 		return dialog_node
 	else:
-		printerr("Dialogic node should have a Control parent")
+		printerr("[Dialogic] Node's parent should be a Control")
+		return null
+
+## Adds the dialogic node as a child of the given node, and below the given node
+## The parent node must be of type control
+## To start the timeline, use the start method from the returned node
+##
+## @param parent				The parent to add the dialogic node to.
+## @param node					The node to add dialogic below.
+## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+## @returns						The Dialog node or null if the parent was invalid.
+static func add_as_child_of_below_node(parent: Node, node: Node, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn") -> DialogicNode:
+	if parent is Control:
+		var dialog_node = get_instance(dialog_scene_path)
+		parent.add_child_below_node(node, dialog_node)
+		return dialog_node
+	else:
+		printerr("[Dialogic] Node's parent should be a Control")
 		return null
 
 
@@ -58,12 +75,12 @@ static func get_definitions() -> Dictionary:
 ## Definitions are automatically saved on timeline start/end
 ## 
 ## @returns						Error status, OK if all went well
-func save_definitions():
+static func save_definitions():
 	return DialogicSingleton.save_definitions()
 
 
 ## Resets data to default values. This is the same as calling start with reset_saves to true
-func reset_saves():
+static func reset_saves():
 	DialogicSingleton.init(true)
 
 

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -11,52 +11,13 @@ extends Node
 ## Trying to follow this documentation convention: https://github.com/godotengine/godot/pull/41095
 class_name Dialogic
 
+## Gets a DialogicNode instance to be added to the tree
+## This instance can then be added to the tree using add_child()
+## To start the timeline, use the start method from the returned node
+static func get_instance():
+	var dialog : = load("res://addons/dialogic/Dialog.tscn")
+	return dialog.instance()
 
-## Starts the dialog for the given timeline and returns a Dialog node.
-## You must then add it manually to the scene to display the dialog.
-##
-## Example:
-## var new_dialog = Dialogic.start('Your Timeline Name Here')
-## add_child(new_dialog)
-##
-## This is exactly the same as using the editor:
-## you can drag and drop the scene located at /addons/dialogic/Dialog.tscn 
-## and set the current timeline via the inspector.
-##
-## @param timeline				The timeline to load. You can provide the timeline name or the filename.
-## @param reset_saves			True to reset dialogic saved data such as definitions.
-## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
-## @param debug_mode			Debug is disabled by default but can be enabled if needed.
-## @returns						A Dialog node to be added into the scene tree.
-static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
-
-	var dialog:  = load(dialog_scene_path)
-	var d = dialog.instance()
-	d.reset_saves = reset_saves
-	d.debug_mode = debug_mode
-	if not timeline.empty():
-		for t in DialogicUtil.get_timeline_list():
-			if t['name'] == timeline or t['file'] == timeline:
-				d.timeline = t['file']
-				return d
-		d.dialog_script = {
-			"events":[{"character":"","portrait":"",
-			"text":"[Dialogic Error] Loading dialog [color=red]" + timeline + "[/color]. It seems like the timeline doesn't exists. Maybe the name is wrong?"}]
-		}
-	return d
-
-
-## Same as the start method above, but using the last timeline saved.
-## 
-## @param initial_timeline		The timeline to load in case no save is found.
-## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
-## @param debug_mode			Debug is disabled by default but can be enabled if needed.
-## @returns						A Dialog node to be added into the scene tree.
-static func start_from_save(initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
-	var current := get_current_timeline()
-	if current.empty():
-		current = initial_timeline
-	return start(current, false, dialog_scene_path, debug_mode)
 
 ## Gets default values for definitions.
 ## 

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -19,7 +19,7 @@ class_name Dialogic
 ## @param parent				The parent to add the dialogic node to.
 ## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
 ## @returns						The Dialog node or null if the parent was invalid.
-static func add_node(parent, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn"):
+static func add_node(parent, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn") -> DialogicNode:
 	if parent is Control:
 		var dialog_node = get_instance(dialog_scene_path)
 		parent.add_child(dialog_node)
@@ -35,7 +35,7 @@ static func add_node(parent, dialog_scene_path: String="res://addons/dialogic/Di
 ##
 ## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
 ## @returns						A Dialog node to be added into the scene tree.
-static func get_instance(dialog_scene_path: String="res://addons/dialogic/Dialog.tscn"):
+static func get_instance(dialog_scene_path: String="res://addons/dialogic/Dialog.tscn") -> DialogicNode:
 	var dialog : = load(dialog_scene_path)
 	return dialog.instance()
 
@@ -145,7 +145,7 @@ static func get_current_timeline() -> String:
 ## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
 ## @param debug_mode			Debug is disabled by default but can be enabled if needed.
 ## @returns						A Dialog node to be added into the scene tree.
-static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false) -> DialogicNode:
 
 	var dialog:  = load(dialog_scene_path)
 	var d = dialog.instance()
@@ -172,7 +172,7 @@ static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: S
 ## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
 ## @param debug_mode			Debug is disabled by default but can be enabled if needed.
 ## @returns						A Dialog node to be added into the scene tree.
-static func start_from_save(initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+static func start_from_save(initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false) -> DialogicNode:
 	var current := get_current_timeline()
 	if current.empty():
 		current = initial_timeline

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -11,11 +11,32 @@ extends Node
 ## Trying to follow this documentation convention: https://github.com/godotengine/godot/pull/41095
 class_name Dialogic
 
+
+## Adds the dialogic node as a child of the given node
+## The parent node must be of type control
+## To start the timeline, use the start method from the returned node
+##
+## @param parent				The parent to add the dialogic node to.
+## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+## @returns						The Dialog node or null if the parent was invalid.
+static func add_node(parent, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn"):
+	if parent is Control:
+		var dialog_node = get_instance(dialog_scene_path)
+		parent.add_child(dialog_node)
+		return dialog_node
+	else:
+		printerr("Dialogic node should have a Control parent")
+		return null
+
+
 ## Gets a DialogicNode instance to be added to the tree
 ## This instance can then be added to the tree using add_child()
 ## To start the timeline, use the start method from the returned node
-static func get_instance():
-	var dialog : = load("res://addons/dialogic/Dialog.tscn")
+##
+## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+## @returns						A Dialog node to be added into the scene tree.
+static func get_instance(dialog_scene_path: String="res://addons/dialogic/Dialog.tscn"):
+	var dialog : = load(dialog_scene_path)
 	return dialog.instance()
 
 
@@ -96,3 +117,63 @@ static func set_glossary(name: String, title: String, text: String, extra: Strin
 ## @returns						The current timeline filename, or an empty string if none was saved.
 static func get_current_timeline() -> String:
 	return DialogicSingleton.get_current_timeline()
+
+
+## ************************************************************
+## 					DEPRECATED FUNCTIONS
+##		These functions will be removed in future versions
+##					Use at your own risk
+## ************************************************************
+
+
+## /!\ DEPRECATED /!\
+## Use get_instance() instead
+##
+## Starts the dialog for the given timeline and returns a Dialog node.
+## You must then add it manually to the scene to display the dialog.
+##
+## Example:
+## var new_dialog = Dialogic.start('Your Timeline Name Here')
+## add_child(new_dialog)
+##
+## This is exactly the same as using the editor:
+## you can drag and drop the scene located at /addons/dialogic/Dialog.tscn 
+## and set the current timeline via the inspector.
+##
+## @param timeline				The timeline to load. You can provide the timeline name or the filename.
+## @param reset_saves			True to reset dialogic saved data such as definitions.
+## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+## @param debug_mode			Debug is disabled by default but can be enabled if needed.
+## @returns						A Dialog node to be added into the scene tree.
+static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+
+	var dialog:  = load(dialog_scene_path)
+	var d = dialog.instance()
+	d.reset_saves = reset_saves
+	d.debug_mode = debug_mode
+	if not timeline.empty():
+		for t in DialogicUtil.get_timeline_list():
+			if t['name'] == timeline or t['file'] == timeline:
+				d.timeline = t['file']
+				return d
+		d.dialog_script = {
+			"events":[{"character":"","portrait":"",
+			"text":"[Dialogic Error] Loading dialog [color=red]" + timeline + "[/color]. It seems like the timeline doesn't exists. Maybe the name is wrong?"}]
+		}
+	return d
+
+
+## /!\ DEPRECATED /!\
+## Use get_instance() instead
+##
+## Same as the start method above, but using the last timeline saved.
+## 
+## @param initial_timeline		The timeline to load in case no save is found.
+## @param dialog_scene_path		If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+## @param debug_mode			Debug is disabled by default but can be enabled if needed.
+## @returns						A Dialog node to be added into the scene tree.
+static func start_from_save(initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Dialog.tscn", debug_mode: bool=false):
+	var current := get_current_timeline()
+	if current.empty():
+		current = initial_timeline
+	return start(current, false, dialog_scene_path, debug_mode)


### PR DESCRIPTION
This PR moves the `start` and `start_from_save` methods from `DialogicClass` to `dialogic_node`.

This allows the DIalogicNode to be persistent: no need to delete and create a new node to play a new timeline.

I had to add a new var named `runtime_id` to check if the timeline changed between 2 events. This was necessary when calling start from a signal fired by Dialogic: the new timeline would get loaded, then the index incremented when reaching the end of the signal event, from the previous timeline, skipping the first event from the new timeline.

To make this work I had to refactor a bit the event loading system.

This may need more work, as the DIalogicNode was not designed to be reset.

Example usage:

With DialogNode added to the tree:
![Screenshot_20210409_191505](https://user-images.githubusercontent.com/80701113/114216986-e81fa000-9967-11eb-8187-4a6b4520349f.png)

The triggering timeline:

![Screenshot_20210409_191555](https://user-images.githubusercontent.com/80701113/114217096-07b6c880-9968-11eb-9227-6b7df46b7ba7.png)

After receiving the start_minigame signal, the dialog closes itself, the minigame starts, and on gameover, the next timeline starts. All this using the same Dialogic node.