### PR TITLE
Fix the portrait focus order

### DIFF
--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -88,10 +88,18 @@ func fade_out(node = self, time = 0.5):
 
 func focus():
 	tween_modulate(modulate, Color(1,1,1,1))
+	var _parent = get_parent()
+	if _parent:
+		# Make sure that this portrait is the last to be _draw -ed
+		_parent.move_child(self, _parent.get_child_count())
 
 
 func focusout():
 	tween_modulate(modulate, Color(0.5,0.5,0.5,1))
+	var _parent = get_parent()
+	if _parent:
+		# Render this portrait first
+		_parent.move_child(self, 0)
 
 
 func tween_modulate(from_value, to_value, time = 0.5):


### PR DESCRIPTION
TL;DR: this fix a no reported issue related to the order of the portraits

Apparently there's a bug that causes lost the focus order:
![image](https://user-images.githubusercontent.com/7025991/114289441-9a756700-9a3d-11eb-816f-895fe7b3042a.png)

This PR fixes it:
![image](https://user-images.githubusercontent.com/7025991/114289450-a5c89280-9a3d-11eb-8b15-e2ea8f700c51.png)
