### PR TITLE
allow clearing scene event

### DIFF
--- a/addons/dialogic/Editor/Pieces/Common/VisibleToggle.gd
+++ b/addons/dialogic/Editor/Pieces/Common/VisibleToggle.gd
@@ -17,11 +17,10 @@ func disabled():
 	is_disabled = true
 
 
-func _on_VisibleToggle_toggled(button_pressed):
-	if is_disabled:
-		return
+func set_visible(visible: bool):
+	pressed = visible
 	var current_rect_size = current_piece.get("rect_size")
-	if button_pressed:
+	if visible:
 		current_piece.get_node("PanelContainer/VBoxContainer/Header/Preview").hide()
 		
 		var index = 0
@@ -42,3 +41,9 @@ func _on_VisibleToggle_toggled(button_pressed):
 				current_piece.get_node("PanelContainer/VBoxContainer/Header/Preview").text = current_piece.preview
 			current_piece.set("rect_size", Vector2(current_rect_size.x,0))
 	release_focus()
+
+
+func _on_VisibleToggle_toggled(button_pressed):
+	if is_disabled:
+		return
+	set_visible(button_pressed)

--- a/addons/dialogic/Editor/Pieces/SceneEvent.gd
+++ b/addons/dialogic/Editor/Pieces/SceneEvent.gd
@@ -14,7 +14,37 @@ var event_data = {
 
 func _ready():
 	connect("gui_input", self, '_on_gui_input')
+
+
+func load_data(data):
+	event_data = data
+	print("loading")
+	print(data)
 	load_image(event_data['background'])
+
+
+func load_image(img_src: String):
+	event_data['background'] = img_src
+	if not img_src.empty() and not img_src.ends_with('.tscn'):
+		$PanelContainer/VBoxContainer/Header/Name.text = img_src
+		$PanelContainer/VBoxContainer/TextureRect.texture = load(img_src)
+		$PanelContainer/VBoxContainer/TextureRect.rect_min_size = Vector2(200,200)
+		$PanelContainer/VBoxContainer/Header/ClearButton.disabled = false
+		preview = "..."
+		toggler.show()
+		toggler.set_visible(true)
+	else:
+		$PanelContainer/VBoxContainer/Header/Name.text = 'No image (will clear previous scene event)'
+		$PanelContainer/VBoxContainer/TextureRect.rect_min_size = Vector2(0,0)
+		$PanelContainer/VBoxContainer/Header/ClearButton.disabled = true
+		preview = ""
+		toggler.hide()
+		toggler.set_visible(false)
+
+
+func _on_gui_input(event):
+	if event is InputEventMouseButton and event.is_pressed() and event.doubleclick and event.button_index == 1 and toggler.visible:
+		toggler.set_visible(not toggler.pressed)
 
 
 func _on_ImageButton_pressed():
@@ -26,26 +56,5 @@ func _on_file_selected(path, target):
 	target.load_image(path)
 
 
-func load_data(data):
-	event_data = data
-	load_image(event_data['background'])
-
-
-func load_image(img_src):
-	event_data['background'] = img_src
-	$PanelContainer/VBoxContainer/HBoxContainer/LineEdit.text = event_data['background']
-	if event_data['background'] != '' and not event_data['background'].ends_with('.tscn'):
-		$PanelContainer/VBoxContainer/TextureRect.texture = load(event_data['background'])
-		$PanelContainer/VBoxContainer/TextureRect.rect_min_size = Vector2(200,200)
-		preview = event_data['background']
-	else:
-		$PanelContainer/VBoxContainer/TextureRect.rect_min_size = Vector2(0,0)
-
-
-func _on_gui_input(event):
-	if event is InputEventMouseButton and event.is_pressed() and event.doubleclick:
-		if event.button_index == 1:
-			if toggler.pressed:
-				toggler.pressed = false
-			else:
-				toggler.pressed = true
+func _on_ClearButton_pressed():
+	load_image('')

--- a/addons/dialogic/Editor/Pieces/SceneEvent.tscn
+++ b/addons/dialogic/Editor/Pieces/SceneEvent.tscn
@@ -1,12 +1,11 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/Event Icons/Main Icons/scene event.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/PieceExtraSettings.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/dialogic/Images/Context Menus/Remove.svg" type="Texture" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/VisibleToggle.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/SceneEvent.gd" type="Script" id=5]
 [ext_resource path="res://addons/dialogic/Editor/Pieces/Common/Spacer.tscn" type="PackedScene" id=6]
-
-
 
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
@@ -26,6 +25,7 @@ corner_radius_bottom_left = 6
 
 [node name="SceneBlock" type="HBoxContainer"]
 anchor_right = 1.0
+margin_bottom = 44.0
 size_flags_horizontal = 3
 size_flags_vertical = 9
 script = ExtResource( 5 )
@@ -35,11 +35,11 @@ __meta__ = {
 
 [node name="Indent" type="Control" parent="."]
 visible = false
-margin_bottom = 74.0
+margin_bottom = 46.0
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 margin_right = 1024.0
-margin_bottom = 74.0
+margin_bottom = 44.0
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -49,86 +49,78 @@ custom_styles/panel = SubResource( 1 )
 margin_left = 16.0
 margin_top = 6.0
 margin_right = 1018.0
-margin_bottom = 68.0
+margin_bottom = 38.0
 size_flags_horizontal = 3
 
 [node name="Header" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
 margin_right = 1002.0
-margin_bottom = 30.0
+margin_bottom = 28.0
 
 [node name="TextureRect" type="TextureRect" parent="PanelContainer/VBoxContainer/Header"]
 margin_right = 22.0
-margin_bottom = 30.0
+margin_bottom = 28.0
 texture = ExtResource( 1 )
 stretch_mode = 6
 
 [node name="Title" type="Label" parent="PanelContainer/VBoxContainer/Header"]
 margin_left = 26.0
-margin_top = 8.0
-margin_right = 131.0
-margin_bottom = 22.0
-text = "  Scene settings "
+margin_top = 7.0
+margin_right = 139.0
+margin_bottom = 21.0
+text = "  Scene settings   "
+
+[node name="Name" type="Label" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 143.0
+margin_top = 7.0
+margin_right = 414.0
+margin_bottom = 21.0
+text = "No image (will clear previous scene event)"
+
+[node name="ImageButton" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 418.0
+margin_right = 442.0
+margin_bottom = 28.0
+text = "..."
+
+[node name="ClearButton" type="Button" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 446.0
+margin_right = 474.0
+margin_bottom = 28.0
+disabled = true
+icon = ExtResource( 3 )
 
 [node name="VisibleToggle" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
-margin_left = 135.0
-margin_right = 165.0
+visible = false
+margin_left = 478.0
+margin_right = 508.0
 
 [node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
 visible = false
-margin_left = 103.0
+margin_left = 512.0
 margin_top = 8.0
-margin_right = 131.0
+margin_right = 540.0
 margin_bottom = 22.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 text = "    ..."
 
 [node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 6 )]
-margin_left = 169.0
+margin_left = 478.0
 margin_right = 961.0
-margin_bottom = 30.0
+margin_bottom = 28.0
 
 [node name="OptionButton" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 2 )]
 margin_left = 965.0
 margin_right = 1002.0
+margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 
-[node name="HBoxContainer" type="HBoxContainer" parent="PanelContainer/VBoxContainer"]
-margin_top = 34.0
-margin_right = 1002.0
-margin_bottom = 58.0
-
-[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/HBoxContainer"]
-margin_top = 5.0
-margin_right = 131.0
-margin_bottom = 19.0
-text = "Change background: "
-
-[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/HBoxContainer"]
-margin_left = 135.0
-margin_right = 435.0
-margin_bottom = 24.0
-rect_min_size = Vector2( 300, 0 )
-caret_blink = true
-caret_blink_speed = 0.5
-
-[node name="ImageButton" type="Button" parent="PanelContainer/VBoxContainer/HBoxContainer"]
-margin_left = 439.0
-margin_right = 463.0
-margin_bottom = 24.0
-text = "..."
-
-[node name="Control" type="Control" parent="PanelContainer/VBoxContainer/HBoxContainer"]
-margin_left = 467.0
-margin_right = 1002.0
-margin_bottom = 24.0
-size_flags_horizontal = 3
-
 [node name="TextureRect" type="TextureRect" parent="PanelContainer/VBoxContainer"]
-margin_top = 62.0
+margin_top = 32.0
 margin_right = 1002.0
-margin_bottom = 62.0
+margin_bottom = 32.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 expand = true
 stretch_mode = 5
-[connection signal="pressed" from="PanelContainer/VBoxContainer/HBoxContainer/ImageButton" to="." method="_on_ImageButton_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ImageButton" to="." method="_on_ImageButton_pressed"]
+[connection signal="pressed" from="PanelContainer/VBoxContainer/Header/ClearButton" to="." method="_on_ClearButton_pressed"]


### PR DESCRIPTION
This PR allows the user to clear the selected scene from a scene event, like it can already do with audio events.

I moved the selectors to the header to follow what is already done in audio events. I also replace the LineEdit by a simple label as changing the path from the LineEdit had no effect.

Only Editor UI changed, so this is non breaking.

Closes #192 