### PR TITLE
Mirror portraits setting for characters and the Join event (updated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ v1.1 - WIP
   - You can now select a character to ask a question in the `Question Event` [[Tim Krief](https://github.com/timkrief)]
   - Added very basic syntax highlighting to the `Text Event` editor.
   - Fixed an indenting bug when removing events 
+  - The `Character Join` event no has a mirror option [[Jowan-Spooner](https://github.com/Jowan-Spooner)]
   - Shortcuts added! [[ellogwen](https://github.com/ellogwen)]
     - Selecting previous and next event in the timeline with `CTRL + UP` and `CTRL + DOWN`
     - Moving currently selected event up and down the timeline `ALT + UP` and `ALT + DOWN`
     - Remove the currently selected event node and selects the next/last event node `CTRL DELETE`
     - Create a new text event node below the currently selected and focus it's textbox to continue writing `CTRL T`
+- Character Editor
+  - There is an option `mirror portraits` below the portrait preview now, that will mirror all portraits when they appear in the game [[Jowan-Spooner](https://github.com/Jowan-Spooner)]
 - Theme Editor
   - Refreshed the UI to make room for more properties for each section
   - A reload of the preview dialog is performed when you change a property so you don't have to click the "preview changes" all the time

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -11,6 +11,7 @@ onready var nodes = {
 	'description': $HBoxContainer/Container/Description/TextEdit,
 	'file': $HBoxContainer/Container/FileName/LineEdit,
 	'color': $HBoxContainer/Container/Color/ColorPickerButton,
+	'mirror_portraits_checkbox' : $HBoxContainer/Container/MirrorOption/MirrorPortraitsCheckBox,
 	'default_speaker': $HBoxContainer/Container/Actions/DefaultSpeaker,
 	'display_name_checkbox': $HBoxContainer/Container/Name/CheckBox,
 	'display_name': $HBoxContainer/Container/DisplayName/LineEdit,
@@ -55,6 +56,7 @@ func clear_character_editor():
 	nodes['name'].text = ''
 	nodes['description'].text = ''
 	nodes['color'].color = Color('#ffffff')
+	nodes['mirror_portraits_checkbox'].pressed = false
 	nodes['default_speaker'].pressed = false
 	nodes['display_name_checkbox'].pressed = false
 	nodes['display_name'].text = ''
@@ -76,7 +78,8 @@ func create_character():
 		'color': '#ffffff',
 		'id': character_file,
 		'default_speaker': false,
-		'portraits': []
+		'portraits': [],
+		'mirror_portraits' :false
 	}
 	DialogicResources.set_character(character)
 	character['metadata'] = {'file': character_file}
@@ -101,6 +104,7 @@ func generate_character_data_to_save():
 		'id': nodes['file'].text,
 		'description': nodes['description'].text,
 		'color': '#' + nodes['color'].color.to_html(),
+		'mirror_portraits': nodes["mirror_portraits_checkbox"].pressed,
 		'default_speaker': default_speaker,
 		'portraits': portraits,
 		'display_name_bool': nodes['display_name_checkbox'].pressed,
@@ -150,7 +154,10 @@ func load_character(filename: String):
 	if data.has('offset_x'):
 		nodes['offset_x'].value = data['offset_x']
 		nodes['offset_y'].value = data['offset_y']
-
+	if data.has('mirror_portraits'):
+		nodes['mirror_portraits_checkbox'].pressed = data['mirror_portraits']
+	else:
+		nodes['mirror_portraits_checkbox'].pressed = false
 	# Portraits
 	var default_portrait = create_portrait_entry()
 	default_portrait.get_node('NameEdit').text = 'Default'

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -11,7 +11,7 @@ onready var nodes = {
 	'description': $HBoxContainer/Container/Description/TextEdit,
 	'file': $HBoxContainer/Container/FileName/LineEdit,
 	'color': $HBoxContainer/Container/Color/ColorPickerButton,
-	'mirror_portraits_checkbox' : $HBoxContainer/Container/MirrorOption/MirrorPortraitsCheckBox,
+	'mirror_portraits_checkbox' : $HBoxContainer/VBoxContainer/HBoxContainer/MirrorOption/MirrorPortraitsCheckBox,
 	'default_speaker': $HBoxContainer/Container/Actions/DefaultSpeaker,
 	'display_name_checkbox': $HBoxContainer/Container/Name/CheckBox,
 	'display_name': $HBoxContainer/Container/DisplayName/LineEdit,
@@ -154,10 +154,14 @@ func load_character(filename: String):
 	if data.has('offset_x'):
 		nodes['offset_x'].value = data['offset_x']
 		nodes['offset_y'].value = data['offset_y']
+	
 	if data.has('mirror_portraits'):
 		nodes['mirror_portraits_checkbox'].pressed = data['mirror_portraits']
+		nodes['portrait_preview'].flip_h = data['mirror_portraits']
 	else:
 		nodes['mirror_portraits_checkbox'].pressed = false
+		nodes['portrait_preview'].flip_h = false
+	
 	# Portraits
 	var default_portrait = create_portrait_entry()
 	default_portrait.get_node('NameEdit').text = 'Default'
@@ -190,3 +194,7 @@ func create_portrait_entry(p_name = '', path = '', grab_focus = false):
 		p.get_node("NameEdit").grab_focus()
 		p._on_ButtonSelect_pressed()
 	return p
+
+
+func _on_MirrorPortraitsCheckBox_toggled(button_pressed):
+	nodes['portrait_preview'].flip_h = button_pressed

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -8,7 +8,7 @@ content_margin_left = 5.0
 content_margin_right = 5.0
 content_margin_top = 5.0
 content_margin_bottom = 5.0
-bg_color = Color( 0.2, 0.23, 0.31, 1 )
+bg_color = Color( 0.03, 0.21, 0.26, 1 )
 
 [node name="CharacterEditor" type="ScrollContainer"]
 margin_left = 192.0
@@ -139,16 +139,6 @@ margin_bottom = 184.0
 margin_right = 143.0
 margin_bottom = 14.0
 text = "Portraits / Expressions"
-
-[node name="MirrorOption" type="HBoxContainer" parent="HBoxContainer/Container"]
-margin_top = 188.0
-margin_right = 523.0
-margin_bottom = 212.0
-
-[node name="MirrorPortraitsCheckBox" type="CheckBox" parent="HBoxContainer/Container/MirrorOption"]
-margin_right = 241.0
-margin_bottom = 24.0
-text = "Mirror portraits on right positions"
 
 [node name="Labels" type="HBoxContainer" parent="HBoxContainer/Container"]
 margin_top = 216.0
@@ -324,3 +314,15 @@ rect_min_size = Vector2( 100, 0 )
 allow_greater = true
 allow_lesser = true
 suffix = "Y"
+
+[node name="MirrorOption" type="HBoxContainer" parent="HBoxContainer/VBoxContainer/HBoxContainer"]
+margin_left = 398.0
+margin_right = 523.0
+margin_bottom = 24.0
+
+[node name="MirrorPortraitsCheckBox" type="CheckBox" parent="HBoxContainer/VBoxContainer/HBoxContainer/MirrorOption"]
+margin_right = 125.0
+margin_bottom = 24.0
+text = "Mirror portraits"
+
+[connection signal="toggled" from="HBoxContainer/VBoxContainer/HBoxContainer/MirrorOption/MirrorPortraitsCheckBox" to="." method="_on_MirrorPortraitsCheckBox_toggled"]

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -140,10 +140,20 @@ margin_right = 143.0
 margin_bottom = 14.0
 text = "Portraits / Expressions"
 
-[node name="Labels" type="HBoxContainer" parent="HBoxContainer/Container"]
+[node name="MirrorOption" type="HBoxContainer" parent="HBoxContainer/Container"]
 margin_top = 188.0
 margin_right = 523.0
-margin_bottom = 202.0
+margin_bottom = 212.0
+
+[node name="MirrorPortraitsCheckBox" type="CheckBox" parent="HBoxContainer/Container/MirrorOption"]
+margin_right = 241.0
+margin_bottom = 24.0
+text = "Mirror portraits on right positions"
+
+[node name="Labels" type="HBoxContainer" parent="HBoxContainer/Container"]
+margin_top = 216.0
+margin_right = 523.0
+margin_bottom = 230.0
 
 [node name="LineEdit" type="Label" parent="HBoxContainer/Container/Labels"]
 margin_right = 100.0

--- a/addons/dialogic/Editor/Events/CharacterJoinBlock.gd
+++ b/addons/dialogic/Editor/Events/CharacterJoinBlock.gd
@@ -3,7 +3,7 @@ extends Control
 
 var editor_reference
 onready var character_picker = $PanelContainer/VBoxContainer/Header/CharacterAndPortraitPicker
-
+onready var mirror_toggle = $PanelContainer/VBoxContainer/Header/MirrorButton
 var current_color = Color('#ffffff')
 var default_icon_color = Color("#65989898")
 
@@ -12,7 +12,8 @@ var event_data = {
 	'action': 'join',
 	'character': '',
 	'portrait': '',
-	'position': {"0":false,"1":false,"2":false,"3":false,"4":false}
+	'position': {"0":false,"1":false,"2":false,"3":false,"4":false},
+	'mirror':false
 }
 
 
@@ -21,6 +22,7 @@ func _ready():
 		p.connect('pressed', self, "position_button_pressed", [p.name])
 	character_picker.connect("character_changed", self, '_on_character_change')
 	character_picker.set_allow_portrait_dont_change(false)
+	mirror_toggle.icon = get_icon("MirrorX", "EditorIcons")
 
 
 func _on_character_change(character: Dictionary, portrait: String):
@@ -77,3 +79,11 @@ func load_data(data):
 		check_active_position(current_color)
 	else:
 		check_active_position()
+	
+	if data.has('mirror'):
+		mirror_toggle.pressed = data['mirror']
+	else:
+		mirror_toggle.pressed = false
+
+func _on_MirrorButton_toggled(button_pressed):
+	event_data['mirror'] = button_pressed

--- a/addons/dialogic/Editor/Events/CharacterJoinBlock.tscn
+++ b/addons/dialogic/Editor/Events/CharacterJoinBlock.tscn
@@ -121,8 +121,17 @@ margin_right = 186.0
 margin_bottom = 30.0
 icon = ExtResource( 5 )
 
-[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 1 )]
+[node name="MirrorButton" type="ToolButton" parent="PanelContainer/VBoxContainer/Header"]
 margin_left = 502.0
+margin_right = 514.0
+margin_bottom = 30.0
+hint_tooltip = "Mirrors the character"
+focus_mode = 0
+toggle_mode = true
+enabled_focus_mode = 0
+
+[node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 1 )]
+margin_left = 518.0
 margin_right = 1735.0
 margin_bottom = 30.0
 
@@ -130,3 +139,5 @@ margin_bottom = 30.0
 margin_left = 1739.0
 margin_right = 1776.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
+
+[connection signal="toggled" from="PanelContainer/VBoxContainer/Header/MirrorButton" to="." method="_on_MirrorButton_toggled"]

--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -47,9 +47,7 @@ func init(expression: String = '', position_offset = 'left') -> void:
 	if character_data["data"].has('mirror_portraits'):
 		if character_data["data"]['mirror_portraits']:
 			if direction in position_to_mirror:
-				$TextureRect.rect_pivot_offset.x = int($TextureRect.rect_size.x / 2)
-				$TextureRect.rect_scale.x = -1
-	
+				$TextureRect.flip_h = true
 
 func _ready():
 	if debug:
@@ -67,7 +65,7 @@ func set_portrait(expression: String) -> void:
 				$TextureRect.texture = load(p['path'])
 			else:
 				$TextureRect.texture = Texture.new()
-
+	
 
 # Tween stuff
 func fade_in(node = self, time = 0.5):

--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -4,7 +4,8 @@ var character_data = {
 	'name': 'Default',
 	'image': "res://addons/dialogic/Example Assets/portraits/df-3.png",
 	'color': Color(0.973511, 1, 0.152344),
-	'file': ''
+	'file': '',
+	'mirror_portraits': false
 }
 var positions = {
 	'left': Vector2(-400, 0),
@@ -13,11 +14,10 @@ var positions = {
 	'center_right': Vector2(200, 0),
 	'center_left': Vector2(-200, 0)}
 
-var position_to_mirror = ['center_right', 'right']
 var direction = 'left'
 var debug = false
 
-func init(expression: String = '', position_offset = 'left') -> void:
+func init(expression: String = '', position_offset = 'left', mirror = false) -> void:
 	rect_position += positions[position_offset]
 	direction = position_offset
 	modulate = Color(1,1,1,0)
@@ -44,10 +44,13 @@ func init(expression: String = '', position_offset = 'left') -> void:
 			$TextureRect.texture.get_height()
 		) * custom_scale
 	
+	# the mirror setting of the character
 	if character_data["data"].has('mirror_portraits'):
 		if character_data["data"]['mirror_portraits']:
-			if direction in position_to_mirror:
-				$TextureRect.flip_h = true
+			$TextureRect.flip_h = true
+	# the mirror setting of the join event
+	if mirror:
+		$TextureRect.flip_h = !$TextureRect.flip_h
 
 func _ready():
 	if debug:

--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -12,6 +12,8 @@ var positions = {
 	'center': Vector2(0, 0),
 	'center_right': Vector2(200, 0),
 	'center_left': Vector2(-200, 0)}
+
+var position_to_mirror = ['center_right', 'right']
 var direction = 'left'
 var debug = false
 
@@ -41,7 +43,13 @@ func init(expression: String = '', position_offset = 'left') -> void:
 			$TextureRect.texture.get_width() * 0.5,
 			$TextureRect.texture.get_height()
 		) * custom_scale
-
+	
+	if character_data["data"].has('mirror_portraits'):
+		if character_data["data"]['mirror_portraits']:
+			if direction in position_to_mirror:
+				$TextureRect.rect_pivot_offset.x = int($TextureRect.rect_size.x / 2)
+				$TextureRect.rect_scale.x = -1
+	
 
 func _ready():
 	if debug:

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -437,7 +437,7 @@ func event_handler(event: Dictionary):
 						if char_portrait == '':
 							char_portrait = 'Default'
 						p.character_data = character_data
-						p.init(char_portrait, get_character_position(event['position']))
+						p.init(char_portrait, get_character_position(event['position']), event.get('mirror', false))
 						$Portraits.add_child(p)
 						p.fade_in()
 				_load_next_event()


### PR DESCRIPTION
This is a simple implementation adding a setting for each character. If enabled the portraits will be mirrored when they are shown on the right or the center-right positions. 

There was a discussion about how to implement this, so if you don't like it, don't merge it.

It should fix #168 