### PR TITLE
Join events weren't recognised by the timeline FIX

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -372,7 +372,7 @@ func load_timeline(filename: String):
 				create_event("TextBlock", i)
 			{'background'}:
 				create_event("ChangeBackground", i)
-			{'character', 'action', 'position', 'portrait'}:
+			{'character', 'action', 'position', 'portrait',..}:
 				create_event("CharacterJoinBlock", i)
 			{'audio', 'file'}:
 				create_event("AudioBlock", i)


### PR DESCRIPTION
I added the mirror option to the dictionary but the timeline didn't expect it. I learned about this while working on the audio events. Sorry I introduced this.

This should fix #216.