### PR TITLE
Manual save data export/import

### DIFF
--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -77,7 +77,22 @@ static func get_definitions() -> Dictionary:
 ## 
 ## @returns						Error status, OK if all went well
 static func save_definitions():
-	return DialogicSingleton.save_definitions()
+	# Always try to save as much as possible.
+	var err1 = DialogicSingleton.save_definitions()
+	var err2 = DialogicSingleton.save_state()
+
+	# Try to combine the two error states in a way that makes sense.
+	return err1 if err1 != OK else err2
+
+
+## Sets whether to use Dialogic's built-in autosave functionality.
+static func set_autosave(save: bool) -> void:
+	DialogicSingleton.set_autosave(save);
+
+
+## Gets whether to use Dialogic's built-in autosave functionality.
+static func get_autosave() -> bool:
+	return DialogicSingleton.get_autosave();
 
 
 ## Resets data to default values. This is the same as calling start with reset_saves to true
@@ -135,3 +150,21 @@ static func set_glossary(name: String, title: String, text: String, extra: Strin
 ## @returns						The current timeline filename, or an empty string if none was saved.
 static func get_current_timeline() -> String:
 	return DialogicSingleton.get_current_timeline()
+
+
+## Export the current Dialogic state.
+## This can be used as part of your own saving mechanism if you have one. If you use this,
+## you should also disable autosaving.
+##
+## @return						A dictionary of data that can be later provided to import().
+static func export() -> Dictionary:
+	return DialogicSingleton.export()
+
+
+## Import a Dialogic state.
+## This can be used as part of your own saving mechanism if you have one. If you use this,
+## you should also disable autosaving.
+##
+## @param data				A dictionary of data as created by export().
+static func import(data: Dictionary) -> void:
+	DialogicSingleton.import(data)

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -65,13 +65,13 @@ static func get_config_files_paths() -> Dictionary:
 	}
 
 
-static func init_saves(overwrite: bool=true):
+static func init_saves():
 	var err = init_working_dir()
 	var paths := get_config_files_paths()
-	
+
 	if err == OK:
-		init_state_saves(overwrite)
-		init_definitions_saves(overwrite)
+		init_state_saves()
+		init_definitions_saves()
 	else:
 		print('[Dialogic] Error creating working directory: ' + str(err))
 
@@ -81,34 +81,30 @@ static func init_working_dir():
 	return directory.make_dir_recursive(get_working_directories()['WORKING_DIR'])
 
 
-static func init_state_saves(overwrite: bool=true):
+static func init_state_saves():
 	var file := File.new()
 	var paths := get_config_files_paths()
-	
-	if not file.file_exists(paths["SAVED_STATE_FILE"]) or overwrite:
-		var err = file.open(paths["SAVED_STATE_FILE"], File.WRITE)
-		if err == OK:
-			file.store_string('')
-			file.close()
-		else:
-			print('[Dialogic] Error opening saved state file: ' + str(err))
+	var err = file.open(paths["SAVED_STATE_FILE"], File.WRITE)
+	if err == OK:
+		file.store_string('')
+		file.close()
+	else:
+		print('[Dialogic] Error opening saved state file: ' + str(err))
 
 
-static func init_definitions_saves(overwrite: bool=true):
+static func init_definitions_saves():
 	var directory := Directory.new()
 	var source := File.new()
 	var sink := File.new()
 	var paths := get_config_files_paths()
-	var err
-	if not directory.file_exists(paths["SAVED_DEFINITIONS_FILE"]):
-		err = sink.open(paths["SAVED_DEFINITIONS_FILE"], File.WRITE)
-		print('[Dialogic] Saved definitions not present, creating file: ' + str(err))
-		if err == OK:
-			sink.store_string('')
-			sink.close()
-		else:
-			print('[Dialogic] Error opening saved definitions file: ' + str(err))
-	
+	var err = sink.open(paths["SAVED_DEFINITIONS_FILE"], File.WRITE)
+	print('[Dialogic] Saved definitions not present, creating file: ' + str(err))
+	if err == OK:
+		sink.store_string('')
+		sink.close()
+	else:
+		print('[Dialogic] Error opening saved definitions file: ' + str(err))
+
 	err = sink.open(paths["SAVED_DEFINITIONS_FILE"], File.READ_WRITE)
 	if err == OK:
 		if overwrite or sink.get_len() == 0:
@@ -323,6 +319,7 @@ static func get_saved_state() -> Dictionary:
 
 
 static func save_saved_state_config(data: Dictionary):
+	init_working_dir()
 	set_json(get_config_files_paths()['SAVED_STATE_FILE'], data)
 
 
@@ -373,4 +370,5 @@ static func get_saved_definitions() -> Dictionary:
 
 
 static func save_saved_definitions(data: Dictionary):
+	init_working_dir()
 	return set_json(get_config_files_paths()['SAVED_DEFINITIONS_FILE'], data)

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -107,14 +107,11 @@ static func init_definitions_saves():
 
 	err = sink.open(paths["SAVED_DEFINITIONS_FILE"], File.READ_WRITE)
 	if err == OK:
-		if overwrite or sink.get_len() == 0:
-			err = source.open(paths["DEFAULT_DEFINITIONS_FILE"], File.READ)
-			if err == OK:
-				sink.store_string(source.get_as_text())
-			else:
-				print('[Dialogic] Error opening default definitions file: ' + str(err))
+		err = source.open(paths["DEFAULT_DEFINITIONS_FILE"], File.READ)
+		if err == OK:
+			sink.store_string(source.get_as_text())
 		else:
-			print('[Dialogic] Did not overwrite previous saved definitions')
+			print('[Dialogic] Error opening default definitions file: ' + str(err))
 	else:
 		print('[Dialogic] Error opening saved definitions file: ' + str(err))
 	
@@ -365,8 +362,8 @@ static func delete_default_definition(id: String):
 # Can be edited at runtime, and will persist across runs
 
 
-static func get_saved_definitions() -> Dictionary:
-	return load_json(get_config_files_paths()['SAVED_DEFINITIONS_FILE'], {'variables': [], 'glossary': []})
+static func get_saved_definitions(default: Dictionary = {'variables': [], 'glossary': []}) -> Dictionary:
+	return load_json(get_config_files_paths()['SAVED_DEFINITIONS_FILE'], default)
 
 
 static func save_saved_definitions(data: Dictionary):

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -326,20 +326,6 @@ static func save_saved_state_config(data: Dictionary):
 	set_json(get_config_files_paths()['SAVED_STATE_FILE'], data)
 
 
-static func get_saved_state_general_key(key: String) -> String:
-	var data = get_saved_state()
-	if key in data['general'].keys():
-		return data['general'][key]
-	else:
-		return ''
-
-
-static func set_saved_state_general_key(key: String, value):
-	var data = get_saved_state()
-	data['general'][key] = str(value)
-	save_saved_state_config(data)
-
-
 # DEFAULT DEFINITIONS
 # Can only be edited in the editor
 

--- a/addons/dialogic/Other/DialogicSharp.cs
+++ b/addons/dialogic/Other/DialogicSharp.cs
@@ -35,6 +35,18 @@ public static class DialogicSharp
     }
   }
 
+  public static bool Autosave
+  {
+    get
+    {
+      return (bool)_dialogic.Call("get_autosave");
+    }
+    set
+    {
+      _dialogic.Call("set_autosave", value);
+    }
+  }
+
   public static Node Start(String timeline, bool resetSaves = true, bool debugMode = false)
   {
     return Start<Node>(timeline, DEFAULT_DIALOG_RESOURCE, resetSaves, debugMode);
@@ -73,5 +85,25 @@ public static class DialogicSharp
   public static void SetGlossary(String name, String title, String text, String extra)
   {
     _dialogic.Call("set_glossary", name, title, text, extra);
+  }
+
+  public static void ResetSaves()
+  {
+    _dialogic.Call("reset_saves");
+  }
+
+  public static Error SaveDefinitions()
+  {
+    return (Error)_dialogic.Call("save_definitions");
+  }
+
+  public static GC.Dictionary Export()
+  {
+    return (GC.Dictionary)_dialogic.Call("export");
+  }
+
+  public static void Import(GC.Dictionary data)
+  {
+    _dialogic.Call("import", data);
   }
 }

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -13,7 +13,7 @@ func _init() -> void:
 
 
 func init(reset: bool=false) -> void:
-	if reset:
+	if reset and autosave:
 		# Loads saved definitions into memory
 		DialogicResources.init_saves()
 	current_definitions = DialogicResources.get_saved_definitions()

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -2,6 +2,8 @@ extends Node
 
 var current_definitions := {}
 var default_definitions := {}
+var current_state := {}
+var autosave := false
 
 var current_timeline := ''
 
@@ -11,11 +13,13 @@ func _init() -> void:
 
 
 func init(reset: bool=false) -> void:
-	# Loads saved definitions into memory
-	DialogicResources.init_saves(reset)
+	if reset and not autosave:
+		# Loads saved definitions into memory
+		DialogicResources.init_saves(reset)
 	current_definitions = DialogicResources.get_saved_definitions()
 	default_definitions = DialogicResources.get_default_definitions()
-	current_timeline = DialogicResources.get_saved_state_general_key('timeline')
+	current_state = DialogicResources.get_saved_state()
+	current_timeline = get_saved_state_general_key('timeline')
 
 
 func get_definitions_list() -> Array:
@@ -35,7 +39,16 @@ func get_default_definitions_list() -> Array:
 
 
 func save_definitions():
-	return DialogicResources.save_saved_definitions(current_definitions)
+	if autosave:
+		return DialogicResources.save_saved_definitions(current_definitions)
+	else:
+		return OK
+
+func save_state():
+	if autosave:
+		return DialogicResources.save_saved_state_config(current_state)
+	else:
+		return OK
 
 
 func get_variable(name: String) -> String:
@@ -103,10 +116,41 @@ func set_glossary(name: String, title: String, text: String, extra: String) -> v
 
 func set_current_timeline(timeline: String):
 	current_timeline = timeline
-	DialogicResources.set_saved_state_general_key('timeline', timeline)
+	set_saved_state_general_key('timeline', timeline)
 
 
 func get_current_timeline() -> String:
 	return current_timeline
 
 
+func get_saved_state_general_key(key: String) -> String:
+	if key in current_state['general'].keys():
+		return current_state['general'][key]
+	else:
+		return ''
+
+
+func set_saved_state_general_key(key: String, value) -> void:
+	current_state['general'][key] = str(value)
+	save_state()
+
+
+func get_autosave() -> bool:
+	return autosave;
+
+
+func set_autosave(save: bool):
+	autosave = save;
+
+
+func export() -> Dictionary:
+	return {
+		'definitions': current_definitions,
+		'state': current_state,
+	}
+
+func import(data: Dictionary) -> void:
+	init(false);
+	current_definitions = data['definitions'];
+	current_state = data['state'];
+	current_timeline = get_saved_state_general_key('timeline')

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -3,7 +3,7 @@ extends Node
 var current_definitions := {}
 var default_definitions := {}
 var current_state := {}
-var autosave := false
+var autosave := true
 
 var current_timeline := ''
 
@@ -13,9 +13,9 @@ func _init() -> void:
 
 
 func init(reset: bool=false) -> void:
-	if reset and not autosave:
+	if reset:
 		# Loads saved definitions into memory
-		DialogicResources.init_saves(reset)
+		DialogicResources.init_saves()
 	current_definitions = DialogicResources.get_saved_definitions()
 	default_definitions = DialogicResources.get_default_definitions()
 	current_state = DialogicResources.get_saved_state()

--- a/addons/dialogic/Other/DialogicSingleton.gd
+++ b/addons/dialogic/Other/DialogicSingleton.gd
@@ -16,8 +16,8 @@ func init(reset: bool=false) -> void:
 	if reset and autosave:
 		# Loads saved definitions into memory
 		DialogicResources.init_saves()
-	current_definitions = DialogicResources.get_saved_definitions()
 	default_definitions = DialogicResources.get_default_definitions()
+	current_definitions = DialogicResources.get_saved_definitions(default_definitions)
 	current_state = DialogicResources.get_saved_state()
 	current_timeline = get_saved_state_general_key('timeline')
 


### PR DESCRIPTION
Fixes #224.

This is my proposal for manual save management. This allows developers to manually handle save data management if they need something more complicated that the autosave provides. This also allows for multiple save states using whatever save mechanism the developer is using already.

Example usage:

```gdscript
# Disable the normal autosave mechanism.
Dialogic.set_autosave(false)
# To save your game, call this and serialise the results however you like.
var dialogic_data = Dialogic.export()
# To load a game, call this with the unserialised value from #export() above.
Dialogic.import(dialogic_data);
```

## Changes to existing behaviour

Dialogic should continue to work the same way unless `set_autosave(false)` is called with one exception:

1. Dialogic will no long pre-emptively create files and folders in `user://dialogic`, instead waiting to create them just in time as it saves state for the first time.
