### PR TITLE
allow hiding glossary in theme settings

### DIFF
--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -82,6 +82,7 @@ onready var n : Dictionary = {
 	# Glossary
 	'glossary_font': $VBoxContainer/TabContainer/Glossary/Column/GridContainer/FontButton,
 	'glossary_color': $VBoxContainer/TabContainer/Glossary/Column/GridContainer/ColorPickerButton,
+	'glossary_enabled': $VBoxContainer/TabContainer/Glossary/Column/GridContainer/ShowGlossaryCheckBox,
 	
 	# Text preview
 	'text_preview': $VBoxContainer/HBoxContainer3/TextEdit,
@@ -155,6 +156,7 @@ func load_theme(filename):
 	# Definitions
 	n['glossary_color'].color = Color(theme.get_value('definitions', 'color', "#ffffffff"))
 	n['glossary_font'].text = DialogicResources.get_filename_from_path(theme.get_value('definitions', 'font', "res://addons/dialogic/Example Assets/Fonts/GlossaryFont.tres"))
+	n['glossary_enabled'].pressed = theme.get_value('definitions', 'show_glossary', true)
 	
 	# Text
 	n['theme_text_speed'].value = theme.get_value('text','speed', 2)
@@ -495,6 +497,14 @@ func _on_Glossary_Font_selected(path, target) -> void:
 	_on_PreviewButton_pressed() # Refreshing the preview
 
 
+func _on_ShowGlossaryCheckBox_toggled(button_pressed):
+	if loading:
+		return
+	DialogicResources.set_theme_value(current_theme, 'definitions','show_glossary', button_pressed)
+	_on_PreviewButton_pressed() # Refreshing the preview
+
+
+
 func _on_visibility_changed() -> void:
 	if visible:
 		# Refreshing the dialog 
@@ -683,3 +693,4 @@ func _on_ButtonSize_value_changed(value):
 		return
 	DialogicResources.set_theme_value(current_theme, 'buttons','fixed_size', Vector2(n['button_fixed_x'].value,n['button_fixed_y'].value))
 	_on_PreviewButton_pressed() # Refreshing the preview
+

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -8,7 +8,7 @@ content_margin_left = 4.0
 content_margin_right = 4.0
 content_margin_top = 4.0
 content_margin_bottom = 4.0
-bg_color = Color( 0.252, 0.2718, 0.3246, 1 )
+bg_color = Color( 0.2652, 0.2784, 0.3114, 1 )
 
 [node name="ThemeEditor" type="ScrollContainer"]
 anchor_right = 1.0
@@ -29,13 +29,13 @@ custom_constants/separation = 15
 
 [node name="Panel" type="Panel" parent="VBoxContainer"]
 margin_right = 1018.0
-margin_bottom = 460.0
-rect_min_size = Vector2( 0, 460 )
+margin_bottom = 297.0
+rect_min_size = Vector2( 0, 297 )
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
-margin_top = 475.0
+margin_top = 312.0
 margin_right = 1018.0
-margin_bottom = 535.0
+margin_bottom = 372.0
 custom_constants/separation = 10
 
 [node name="TextEdit" type="TextEdit" parent="VBoxContainer/HBoxContainer3"]
@@ -55,7 +55,7 @@ text = "  Preview changes  "
 icon = ExtResource( 1 )
 
 [node name="TabContainer" type="TabContainer" parent="VBoxContainer"]
-margin_top = 550.0
+margin_top = 387.0
 margin_right = 1018.0
 margin_bottom = 911.0
 size_flags_horizontal = 3
@@ -74,7 +74,7 @@ custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text"]
 margin_right = 270.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
@@ -200,12 +200,12 @@ prefix = "Y"
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Text"]
 margin_left = 280.0
 margin_right = 284.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 
 [node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text"]
 margin_left = 294.0
 margin_right = 564.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
@@ -824,6 +824,7 @@ allow_greater = true
 allow_lesser = true
 
 [node name="Choice Buttons" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -834,7 +835,7 @@ custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
 margin_right = 270.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
@@ -965,12 +966,12 @@ margin_bottom = 136.0
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Choice Buttons"]
 margin_left = 280.0
 margin_right = 284.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 
 [node name="Column2" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
 margin_left = 294.0
 margin_right = 603.0
-margin_bottom = 325.0
+margin_bottom = 488.0
 rect_min_size = Vector2( 270, 0 )
 size_flags_vertical = 3
 __meta__ = {
@@ -1068,7 +1069,6 @@ allow_greater = true
 allow_lesser = true
 
 [node name="Glossary" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -1079,7 +1079,7 @@ custom_constants/separation = 10
 
 [node name="Column" type="VBoxContainer" parent="VBoxContainer/TabContainer/Glossary"]
 margin_right = 270.0
-margin_bottom = 157.0
+margin_bottom = 488.0
 rect_min_size = Vector2( 270, 0 )
 
 [node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column"]
@@ -1091,7 +1091,7 @@ text = "Visuals"
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Glossary/Column"]
 margin_top = 26.0
 margin_right = 270.0
-margin_bottom = 80.0
+margin_bottom = 108.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
@@ -1124,17 +1124,36 @@ margin_bottom = 54.0
 rect_min_size = Vector2( 50, 30 )
 color = Color( 0.215686, 0.654902, 0.67451, 1 )
 
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
+margin_top = 63.0
+margin_right = 165.0
+margin_bottom = 77.0
+text = "Show"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="ShowGlossaryCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
+margin_left = 175.0
+margin_top = 58.0
+margin_right = 270.0
+margin_bottom = 82.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
 visible = false
-margin_top = 66.0
-margin_right = 141.0
-margin_bottom = 80.0
+margin_top = 58.0
+margin_right = 165.0
+margin_bottom = 72.0
 text = "Shadow"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
 visible = false
+margin_left = 175.0
 margin_top = 58.0
-margin_right = 213.0
+margin_right = 270.0
 margin_bottom = 88.0
 
 [node name="CheckBoxShadow" type="CheckBox" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer2"]
@@ -1143,7 +1162,7 @@ margin_bottom = 30.0
 
 [node name="ColorPickerButtonShadow" type="ColorPickerButton" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer2"]
 margin_left = 28.0
-margin_right = 213.0
+margin_right = 95.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 50, 30 )
 size_flags_horizontal = 3
@@ -1159,7 +1178,7 @@ text = "S, Offset"
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TabContainer/Glossary/Column/GridContainer"]
 visible = false
 margin_top = 58.0
-margin_right = 213.0
+margin_right = 165.0
 margin_bottom = 82.0
 custom_constants/separation = 10
 
@@ -1182,7 +1201,6 @@ prefix = "Y"
 
 [node name="DelayPreviewTimer" type="Timer" parent="."]
 one_shot = true
-
 [connection signal="text_changed" from="VBoxContainer/HBoxContainer3/TextEdit" to="." method="_on_Preview_text_changed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer3/PreviewButton" to="." method="_on_PreviewButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/FontButton" to="." method="_on_FontButton_pressed"]
@@ -1240,6 +1258,7 @@ one_shot = true
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer2/ButtonSizeY" to="." method="_on_ButtonSize_value_changed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/FontButton" to="." method="_on_GlossaryFontButton_pressed"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/ColorPickerButton" to="." method="_on_GlossaryColorPicker_color_changed"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/ShowGlossaryCheckBox" to="." method="_on_ShowGlossaryCheckBox_toggled"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer2/CheckBoxShadow" to="." method="_on_CheckBoxShadow_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer2/ColorPickerButtonShadow" to="." method="_on_ColorPickerButtonShadow_color_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_ShadowOffset_value_changed"]

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -250,11 +250,17 @@ func parse_branches(dialog_script: Dictionary) -> Dictionary:
 	return dialog_script
 
 
+func _should_show_glossary():
+	if current_theme != null:
+		return current_theme.get_value('definitions', 'show_glossary', true)
+	return true
+
+
 func parse_definitions(text: String, variables: bool = true, glossary: bool = true):
 	var final_text: String = text
 	if variables:
 		final_text = _insert_variable_definitions(text)
-	if glossary:
+	if glossary and _should_show_glossary():
 		final_text = _insert_glossary_definitions(final_text)
 	return final_text
 


### PR DESCRIPTION
This PR adds the possibility to disable glossary using a theme. This is pretty simple: a checkbox under the glossary tab. The text will not be highlighted and the infobox will not show.

Setting enabled:

![Screenshot_20210418_071837](https://user-images.githubusercontent.com/80701113/115135143-4dcdf500-a016-11eb-9c15-4fac0545db4f.png)

Setting disabled:

![Screenshot_20210418_071904](https://user-images.githubusercontent.com/80701113/115135151-5cb4a780-a016-11eb-867f-0e678f077819.png)

Closes #220 
