### PR TITLE
show real event in drag and drop

### DIFF
--- a/addons/dialogic/Editor/Events/Templates/EventTemplate.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventTemplate.gd
@@ -26,6 +26,10 @@ var header_node
 var body_node
 var indent_size = 25
 
+# Setting this to true will ignore the event while saving
+# Useful for making placeholder events in drag and drop
+var ignore_save = false
+
 ## *****************************************************************************
 ##								PUBLIC METHODS
 ## *****************************************************************************

--- a/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
@@ -1,11 +1,13 @@
 tool
 extends ScrollContainer
 
-var _drag_drop_indicator = null
 # store last attempts since godot sometimes misses drop events
 var _is_drag_receiving = false
 var _last_event_button_drop_attempt = '' 
 var _mouse_exited = false
+
+# todo, getting timeline like this is prone to fail someday
+onready var timeline_editor = get_parent()
 
 func _ready():
 	connect("mouse_entered", self, '_on_mouse_entered')
@@ -14,53 +16,43 @@ func _ready():
 
 
 func can_drop_data(position, data):
-	if (data != null and data is Dictionary and data.has("source")):
-		if (data["source"] == "EventButton"):
-			# position drop indicator
-			_set_indicator_position(position)
+	if data != null and data is Dictionary and data.has("source"):
+		if data["source"] == "EventButton":
+			if _last_event_button_drop_attempt.empty():
+				timeline_editor.create_drag_and_drop_event(data["event_name"])
 			_is_drag_receiving = true
 			_last_event_button_drop_attempt = data["event_name"]
 			return true
-	
-	_remove_drop_indicator()
 	return false
-	
+
 
 func cancel_drop():
 	_is_drag_receiving = false
 	_last_event_button_drop_attempt = ''
-	_remove_drop_indicator()
-	pass
+	timeline_editor.cancel_drop_event()
 
 	
 func drop_data(position, data):
-	# todo, getting timeline like this is prone to fail someday
-	var timeline_editor = get_parent()
-	
 	# add event
 	if (data["source"] == "EventButton"):
-		var piece = timeline_editor.create_event(data["event_name"])
-		if (piece != null and _drag_drop_indicator != null):
-			var parent = piece.get_parent()
-			if (parent != null):
-				parent.remove_child(piece)
-				parent.add_child_below_node(_drag_drop_indicator, piece)
-				timeline_editor.indent_events()
-				# @todo _select_item seems to be a "private" function
-				# maybe expose it as "public" or add a public helper function
-				# to TimelineEditor.gd
-				timeline_editor._select_item(piece)
-				
+		timeline_editor.drop_event()
 	_is_drag_receiving = false
 	_last_event_button_drop_attempt = ''
-	_remove_drop_indicator()
-	
-	
+
+
 func _on_mouse_exited():
+	if _is_drag_receiving and not _mouse_exited:
+		var preview_label = Label.new()
+		preview_label.text = "Cancel"
+		set_drag_preview(preview_label)	
 	_mouse_exited = true
 	
   
 func _on_mouse_entered():
+	if _is_drag_receiving and _mouse_exited:
+		var preview_label = Label.new()
+		preview_label.text = "Insert Event"
+		set_drag_preview(preview_label)	
 	_mouse_exited = false	
 	
   
@@ -68,8 +60,8 @@ func _input(event):
 	if (event is InputEventMouseButton and is_visible_in_tree() and event.button_index == BUTTON_LEFT):
 		if (_mouse_exited and _is_drag_receiving):
 			cancel_drop()
-			
-      
+
+
 func _on_gui_input(event):
 	# godot sometimes misses drop events
 	if (event is InputEventMouseButton and event.button_index == BUTTON_LEFT):
@@ -77,63 +69,3 @@ func _on_gui_input(event):
 			if (_last_event_button_drop_attempt != ''):
 				drop_data(Vector2.ZERO, { "source": "EventButton", "event_name": _last_event_button_drop_attempt} )
 			_is_drag_receiving = false
-			_remove_drop_indicator()
-	pass
-	
-	
-func _create_drop_indicator():
-	_remove_drop_indicator()
-	
-	var timeline = get_child(0)
-	if (timeline == null):
-		return
-	
-	var indicator = ColorRect.new()
-	indicator.name = "DropIndicator"
-	indicator.rect_size.y = 100
-	indicator.rect_min_size.y = 100
-	indicator.color = Color(0.35, 0.37, 0.44) # default editor light blue
-	indicator.mouse_filter = MOUSE_FILTER_IGNORE
-	
-	# add indent node like the other scene nodes have
-	var indent = Control.new()
-	indent.rect_min_size.x = 25
-	indent.visible = false
-	indent.name = "Indent"
-	indicator.add_child(indent)
-	
-	var label = Label.new()
-	label.text = "Drop here"
-	indicator.add_child(label)
-	
-	timeline.add_child(indicator)
-	
-	_drag_drop_indicator = indicator
-	
-	
-func _remove_drop_indicator():	
-	if (_drag_drop_indicator != null):
-		_drag_drop_indicator.get_parent().remove_child(_drag_drop_indicator)
-		_drag_drop_indicator.queue_free()
-		
-	_drag_drop_indicator = null
-	
-	
-func _set_indicator_position(position):
-	var timeline = get_child(0)
-	if (timeline == null):
-		return
-		
-	if (_drag_drop_indicator == null):
-		_create_drop_indicator()
-		
-	var highest_index = 0
-	var index = 0
-	for child in timeline.get_children():
-		if child.get_local_mouse_position().y > 0 and index > highest_index:
-			highest_index = index
-		index += 1
-		
-	if (_drag_drop_indicator.is_inside_tree()):
-		timeline.move_child(_drag_drop_indicator, max(0, highest_index))
-	pass

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -305,6 +305,34 @@ func _on_ButtonCondition_pressed() -> void:
 		create_event("EndBranch", {'no-data': true}, true)
 
 
+# Creates a ghost event for drag and drop
+func create_drag_and_drop_event(scene: String):
+	var index = get_index_under_cursor()
+	var piece = create_event(scene)
+	timeline.move_child(piece, index)
+	moving_piece = piece
+	piece_was_dragged = true
+	set_event_ignore_save(piece, true)
+	_select_item(piece)
+	return piece
+
+
+func drop_event():
+	if moving_piece != null:
+		set_event_ignore_save(moving_piece, false)
+		moving_piece = null
+		piece_was_dragged = false
+		indent_events()
+
+
+func cancel_drop_event():
+	if moving_piece != null:
+		moving_piece = null
+		piece_was_dragged = false
+		delete_event()
+		_clear_selection()
+
+
 # Adding an event to the timeline
 func create_event(scene: String, data: Dictionary = {'no-data': true} , indent: bool = false):
 	var piece = load("res://addons/dialogic/Editor/Events/" + scene + ".tscn").instance()
@@ -482,6 +510,16 @@ func get_block_height(block):
 		return null
 
 
+func get_index_under_cursor():
+	var current_position = get_global_mouse_position()
+	var top_pos = 0
+	for i in range(timeline.get_child_count()):
+		var c = timeline.get_child(i)
+		if c.rect_global_position.y < current_position.y:
+			top_pos = i
+	return top_pos
+
+
 # ordering blocks in timeline
 func move_block(block, direction):
 	var block_index = block.get_index()
@@ -524,12 +562,28 @@ func generate_save_data():
 		'events': []
 	}
 	for event in timeline.get_children():
-		# check that event has event_data (e.g. drag drop indicators)
-		if (not "event_data" in event):
-			continue
-		if event.is_queued_for_deletion() == false: # Checking that the event is not waiting to be removed
+		# Checking that the event is not waiting to be removed
+		# or that it is not a drag and drop placeholder
+		if not get_event_ignore_save(event) and event.is_queued_for_deletion() == false:
 			info_to_save['events'].append(event.event_data)
 	return info_to_save
+
+
+func set_event_ignore_save(event: Node, ignore: bool):
+	if _has_template(event):
+		event.ignore_save = ignore
+	else:
+		if ignore:
+			event.event_data["_ignore_save"] = true
+		else:
+			event.event_data.erase("_ignore_save")
+
+
+func get_event_ignore_save(event: Node) -> bool:
+	if _has_template(event):
+		return event.ignore_save
+	else:
+		return event.event_data.has("_ignore_save") and event.event_data["_ignore_save"]
 
 
 func save_timeline() -> void:


### PR DESCRIPTION
This PR improves drag and drop by reusing event dragging behavior.

Instead of creating a placeholder where the event will be created, the actual event piece is added to the timeline. This event will be ignored when saving unless it is actually dropped (mouse key released). The  event is selected and thus can use the already defined dragging behavior, fixing a lot of issues with moving drag-and-drop events that were already fixed for regular event dragging inside the timeline (see 95d7296ea17b346272a13753b62d92122020301b).

https://user-images.githubusercontent.com/80701113/115136885-0863f480-a023-11eb-8f8b-6a77250426f9.mp4




