### PR TITLE
fix event template size

### DIFF
--- a/addons/dialogic/Editor/Events/Templates/EventTemplate.tscn
+++ b/addons/dialogic/Editor/Events/Templates/EventTemplate.tscn
@@ -6,6 +6,10 @@
 [ext_resource path="res://addons/dialogic/Images/Plugin/plugin-editor-icon-dark-theme.svg" type="Texture" id=6]
 
 [sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 0.0
+content_margin_right = 0.0
+content_margin_top = 0.0
+content_margin_bottom = 0.0
 bg_color = Color( 0.262745, 0.262745, 0.262745, 1 )
 border_width_left = 2
 border_width_top = 2
@@ -18,8 +22,8 @@ corner_radius_bottom_left = 6
 
 [node name="EventTemplate" type="HBoxContainer"]
 anchor_right = 1.0
-margin_bottom = 44.0
-rect_min_size = Vector2( 0, 44 )
+margin_bottom = 42.0
+rect_min_size = Vector2( 0, 42 )
 size_flags_horizontal = 3
 size_flags_vertical = 9
 __meta__ = {
@@ -32,7 +36,7 @@ margin_bottom = 64.0
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
 margin_right = 1024.0
-margin_bottom = 46.0
+margin_bottom = 42.0
 mouse_filter = 1
 mouse_default_cursor_shape = 6
 size_flags_horizontal = 3
@@ -40,10 +44,8 @@ size_flags_vertical = 3
 custom_styles/panel = SubResource( 1 )
 
 [node name="MarginContainer" type="MarginContainer" parent="PanelContainer"]
-margin_left = 2.0
-margin_top = 2.0
-margin_right = 1022.0
-margin_bottom = 44.0
+margin_right = 1024.0
+margin_bottom = 42.0
 mouse_filter = 1
 custom_constants/margin_right = 6
 custom_constants/margin_top = 6
@@ -53,13 +55,13 @@ custom_constants/margin_bottom = 6
 [node name="VBoxContainer" type="VBoxContainer" parent="PanelContainer/MarginContainer"]
 margin_left = 6.0
 margin_top = 6.0
-margin_right = 1014.0
+margin_right = 1018.0
 margin_bottom = 36.0
 rect_min_size = Vector2( 0, 30 )
 size_flags_horizontal = 3
 
 [node name="Header" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
-margin_right = 1008.0
+margin_right = 1012.0
 margin_bottom = 30.0
 rect_min_size = Vector2( 0, 30 )
 size_flags_horizontal = 3
@@ -126,18 +128,18 @@ margin_right = 230.0
 
 [node name="Spacer" parent="PanelContainer/MarginContainer/VBoxContainer/Header" instance=ExtResource( 4 )]
 margin_left = 178.0
-margin_right = 962.0
+margin_right = 966.0
 margin_bottom = 30.0
 
 [node name="VSeparator3" type="VSeparator" parent="PanelContainer/MarginContainer/VBoxContainer/Header"]
-margin_left = 966.0
-margin_right = 970.0
+margin_left = 970.0
+margin_right = 974.0
 margin_bottom = 30.0
 mouse_filter = 1
 
 [node name="OptionsControl" parent="PanelContainer/MarginContainer/VBoxContainer/Header" instance=ExtResource( 5 )]
-margin_left = 974.0
-margin_right = 1008.0
+margin_left = 978.0
+margin_right = 1012.0
 margin_bottom = 30.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", false, "Remove", null, 0, false, false, 3, 0, null, "", false ]
 

--- a/addons/dialogic/Editor/Events/styles/ChangeBackground.tres
+++ b/addons/dialogic/Editor/Events/styles/ChangeBackground.tres
@@ -1,6 +1,10 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
+content_margin_left = 0.0
+content_margin_right = 0.0
+content_margin_top = 0.0
+content_margin_bottom = 0.0
 bg_color = Color( 0.219608, 0.34902, 0.701961, 0.443137 )
 border_width_left = 2
 border_width_top = 2

--- a/addons/dialogic/Editor/Events/styles/WaitSeconds.tres
+++ b/addons/dialogic/Editor/Events/styles/WaitSeconds.tres
@@ -1,6 +1,10 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
+content_margin_left = 0.0
+content_margin_right = 0.0
+content_margin_top = 0.0
+content_margin_bottom = 0.0
 bg_color = Color( 0.435294, 0.301961, 0.603922, 0.192157 )
 border_width_left = 2
 border_width_top = 2

--- a/addons/dialogic/Editor/Events/styles/selected_styleboxflat_template.tres
+++ b/addons/dialogic/Editor/Events/styles/selected_styleboxflat_template.tres
@@ -1,6 +1,10 @@
 [gd_resource type="StyleBoxFlat" format=2]
 
 [resource]
+content_margin_left = 0.0
+content_margin_right = 0.0
+content_margin_top = 0.0
+content_margin_bottom = 0.0
 bg_color = Color( 0.0980392, 0.329412, 0.509804, 1 )
 border_width_left = 2
 border_width_top = 2


### PR DESCRIPTION
This PR makes template items 42 units tall instead of 44, to match non-template events