### PR TITLE
Adding Nicknames (New Feature) and fixing auto-color names in text events

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -15,6 +15,8 @@ onready var nodes = {
 	'default_speaker': $HBoxContainer/Container/Actions/DefaultSpeaker,
 	'display_name_checkbox': $HBoxContainer/Container/Name/CheckBox,
 	'display_name': $HBoxContainer/Container/DisplayName/LineEdit,
+	'nickname_checkbox': $HBoxContainer/Container/Name/CheckBox2,
+	'nickname': $HBoxContainer/Container/DisplayNickname/LineEdit,
 	'new_portrait_button': $HBoxContainer/Container/ScrollContainer/VBoxContainer/HBoxContainer/Button,
 	'portrait_preview': $HBoxContainer/VBoxContainer/Control/TextureRect,
 	'scale': $HBoxContainer/VBoxContainer/HBoxContainer/Scale,
@@ -26,6 +28,7 @@ onready var nodes = {
 func _ready():
 	nodes['new_portrait_button'].connect('pressed', self, '_on_New_Portrait_Button_pressed')
 	nodes['display_name_checkbox'].connect('toggled', self, '_on_display_name_toggled')
+	nodes['nickname_checkbox'].connect('toggled', self, '_on_nickname_toggled')
 	nodes['name'].connect('text_changed', self, '_on_name_changed')
 	nodes['color'].connect('color_changed', self, '_on_color_changed')
 	var style = get('custom_styles/bg')
@@ -37,6 +40,10 @@ func is_selected(file: String):
 
 func _on_display_name_toggled(button_pressed):
 	$HBoxContainer/Container/DisplayName.visible = button_pressed
+
+
+func _on_nickname_toggled(button_pressed):
+	$HBoxContainer/Container/DisplayNickname.visible = button_pressed
 
 
 func _on_name_changed(value):
@@ -59,7 +66,9 @@ func clear_character_editor():
 	nodes['mirror_portraits_checkbox'].pressed = false
 	nodes['default_speaker'].pressed = false
 	nodes['display_name_checkbox'].pressed = false
+	nodes['nickname_checkbox'].pressed = false
 	nodes['display_name'].text = ''
+	nodes['nickname'].text = ''
 	nodes['portraits'] = []
 	nodes['scale'].value = 100
 	nodes['offset_x'].value = 0
@@ -109,6 +118,8 @@ func generate_character_data_to_save():
 		'portraits': portraits,
 		'display_name_bool': nodes['display_name_checkbox'].pressed,
 		'display_name': nodes['display_name'].text,
+		'nickname_bool': nodes['nickname_checkbox'].pressed,
+		'nickname': nodes['nickname'].text,
 		'scale': nodes['scale'].value,
 		'offset_x': nodes['offset_x'].value,
 		'offset_y': nodes['offset_y'].value,
@@ -150,6 +161,11 @@ func load_character(filename: String):
 		nodes['display_name'].text = data['display_name']
 	if data.has('scale'):
 		nodes['scale'].value = float(data['scale'])
+	
+	if data.has('nickname_bool'):
+		nodes['nickname_checkbox'].pressed = data['nickname_bool']
+	if data.has('nickname'):
+		nodes['nickname'].text = data['nickname']
 	
 	if data.has('offset_x'):
 		nodes['offset_x'].value = data['offset_x']

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -8,7 +8,7 @@ content_margin_left = 5.0
 content_margin_right = 5.0
 content_margin_top = 5.0
 content_margin_bottom = 5.0
-bg_color = Color( 0.03, 0.21, 0.26, 1 )
+bg_color = Color( 0.160784, 0.160784, 0.160784, 1 )
 
 [node name="CharacterEditor" type="ScrollContainer"]
 margin_left = 192.0
@@ -23,21 +23,21 @@ __meta__ = {
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 margin_left = 5.0
 margin_top = 5.0
-margin_right = 1056.0
-margin_bottom = 656.0
+margin_right = 1132.0
+margin_bottom = 644.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Container" type="VBoxContainer" parent="HBoxContainer"]
-margin_right = 523.0
-margin_bottom = 651.0
+margin_right = 600.0
+margin_bottom = 639.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 9
 
 [node name="Name" type="HBoxContainer" parent="HBoxContainer/Container"]
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 24.0
 
 [node name="Label" type="Label" parent="HBoxContainer/Container/Name"]
@@ -58,6 +58,15 @@ margin_left = 278.0
 margin_right = 451.0
 margin_bottom = 24.0
 text = "Different display name"
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CheckBox2" type="CheckBox" parent="HBoxContainer/Container/Name"]
+margin_left = 455.0
+margin_right = 600.0
+margin_bottom = 24.0
+text = "Enable Nicknames"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -85,9 +94,32 @@ margin_right = 274.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 140, 0 )
 
+[node name="DisplayNickname" type="HBoxContainer" parent="HBoxContainer/Container"]
+visible = false
+margin_top = 28.0
+margin_right = 491.0
+margin_bottom = 52.0
+__meta__ = {
+"_editor_description_": "Display name is the name that will
+show up on the dialogs in game."
+}
+
+[node name="Label" type="Label" parent="HBoxContainer/Container/DisplayNickname"]
+margin_top = 5.0
+margin_right = 130.0
+margin_bottom = 19.0
+rect_min_size = Vector2( 130, 0 )
+text = "Nicknames: "
+
+[node name="LineEdit" type="LineEdit" parent="HBoxContainer/Container/DisplayNickname"]
+margin_left = 134.0
+margin_right = 274.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 140, 0 )
+
 [node name="Color" type="HBoxContainer" parent="HBoxContainer/Container"]
 margin_top = 28.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 48.0
 
 [node name="Label" type="Label" parent="HBoxContainer/Container/Color"]
@@ -107,7 +139,7 @@ edit_alpha = false
 
 [node name="Description" type="HBoxContainer" parent="HBoxContainer/Container"]
 margin_top = 52.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 152.0
 
 [node name="Label" type="Label" parent="HBoxContainer/Container/Description"]
@@ -119,20 +151,20 @@ text = "Description: "
 
 [node name="TextEdit" type="TextEdit" parent="HBoxContainer/Container/Description"]
 margin_left = 134.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 100.0
 rect_min_size = Vector2( 100, 100 )
 size_flags_horizontal = 3
 
 [node name="Separator" type="Control" parent="HBoxContainer/Container"]
 margin_top = 156.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 166.0
 rect_min_size = Vector2( 0, 10 )
 
 [node name="Portraits" type="HBoxContainer" parent="HBoxContainer/Container"]
 margin_top = 170.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 184.0
 
 [node name="Label" type="Label" parent="HBoxContainer/Container/Portraits"]
@@ -141,9 +173,9 @@ margin_bottom = 14.0
 text = "Portraits / Expressions"
 
 [node name="Labels" type="HBoxContainer" parent="HBoxContainer/Container"]
-margin_top = 216.0
-margin_right = 523.0
-margin_bottom = 230.0
+margin_top = 188.0
+margin_right = 600.0
+margin_bottom = 202.0
 
 [node name="LineEdit" type="Label" parent="HBoxContainer/Container/Labels"]
 margin_right = 100.0
@@ -160,28 +192,28 @@ text = "Path"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="HBoxContainer/Container"]
 margin_top = 206.0
-margin_right = 523.0
-margin_bottom = 623.0
+margin_right = 600.0
+margin_bottom = 611.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer/Container/ScrollContainer"]
-margin_right = 523.0
-margin_bottom = 417.0
+margin_right = 600.0
+margin_bottom = 405.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="PortraitList" type="VBoxContainer" parent="HBoxContainer/Container/ScrollContainer/VBoxContainer"]
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="PortraitEntry" parent="HBoxContainer/Container/ScrollContainer/VBoxContainer/PortraitList" instance=ExtResource( 1 )]
-margin_right = 523.0
+margin_right = 600.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/Container/ScrollContainer/VBoxContainer"]
 margin_top = 28.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 48.0
 
 [node name="Button" type="Button" parent="HBoxContainer/Container/ScrollContainer/VBoxContainer/HBoxContainer"]
@@ -212,9 +244,9 @@ size_flags_horizontal = 3
 editable = false
 
 [node name="Actions" type="HBoxContainer" parent="HBoxContainer/Container"]
-margin_top = 627.0
-margin_right = 523.0
-margin_bottom = 651.0
+margin_top = 615.0
+margin_right = 600.0
+margin_bottom = 639.0
 
 [node name="DefaultSpeaker" type="CheckBox" parent="HBoxContainer/Container/Actions"]
 margin_right = 128.0
@@ -228,20 +260,20 @@ text = "Default Speaker"
 
 [node name="Control" type="Control" parent="HBoxContainer/Container/Actions"]
 margin_left = 132.0
-margin_right = 523.0
+margin_right = 600.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="HBoxContainer"]
-margin_left = 527.0
-margin_right = 1051.0
-margin_bottom = 651.0
+margin_left = 604.0
+margin_right = 1127.0
+margin_bottom = 639.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Control" type="Panel" parent="HBoxContainer/VBoxContainer"]
-margin_right = 524.0
-margin_bottom = 623.0
+margin_right = 523.0
+margin_bottom = 611.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -271,9 +303,9 @@ __meta__ = {
 }
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/VBoxContainer"]
-margin_top = 627.0
-margin_right = 524.0
-margin_bottom = 651.0
+margin_top = 615.0
+margin_right = 523.0
+margin_bottom = 639.0
 
 [node name="Label" type="Label" parent="HBoxContainer/VBoxContainer/HBoxContainer"]
 margin_top = 5.0
@@ -324,5 +356,4 @@ margin_bottom = 24.0
 margin_right = 125.0
 margin_bottom = 24.0
 text = "Mirror portraits"
-
 [connection signal="toggled" from="HBoxContainer/VBoxContainer/HBoxContainer/MirrorOption/MirrorPortraitsCheckBox" to="." method="_on_MirrorPortraitsCheckBox_toggled"]

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -140,10 +140,19 @@ func parse_characters(dialog_script):
 		for t in dialog_script['events']:
 			if t.has('text'):
 				for n in names:
+					var name_end_check = [' ', ',', '.', '?', '!', "'"]
 					if n.has('name'):
-						dialog_script['events'][index]['text'] = t['text'].replace(n['name'],
-							'[color=#' + n['color'].to_html() + ']' + n['name'] + '[/color]'
-						)
+						for c in name_end_check:
+							dialog_script['events'][index]['text'] = t['text'].replace(n['name'] + c,
+								'[color=#' + n['color'].to_html() + ']' + n['name'] + '[/color]' + c
+							)
+						if n.has('nickname') and n['nickname'] != '':
+							var nicknames_array = n['nickname'].split(",", true, 0)
+							for c in name_end_check:
+								for nn in nicknames_array:
+									dialog_script['events'][index]['text'] = t['text'].replace(nn + c,
+										'[color=#' + n['color'].to_html() + ']' + nn + '[/color]' + c
+									)
 			index += 1
 	return dialog_script
 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -12,6 +12,7 @@ static func get_character_list() -> Array:
 			var default_speaker      = false
 			var portraits: Array     = []
 			var display_name: String = ''
+			var nickname: String = ''
 			
 			if data.has('color'):
 				color = Color(data['color'])
@@ -25,6 +26,10 @@ static func get_character_list() -> Array:
 				if data['display_name_bool']:
 					if data.has('display_name'):
 						display_name = data['display_name']
+			if data.has('nickname'):
+				if data['nickname_bool']:
+					if data.has('nickname'):
+						nickname = data['nickname']
 						
 			characters.append({
 				'name': c_name,
@@ -33,6 +38,7 @@ static func get_character_list() -> Array:
 				'default_speaker' : default_speaker,
 				'portraits': portraits,
 				'display_name': display_name,
+				'nickname': nickname,
 				'data': data # This should be the only thing passed... not sure what I was thinking
 			})
 


### PR DESCRIPTION
Hello, Emilio and everyone else! My name is Zak. I have been wanting to add **_Nicknames_** to the project since I tried it out. I call my friends nicknames and it is common in literature and video games as well, so I felt that naturally it should be included. I finally decided to do it myself and I hope everyone else can find some use for them as well as a feature! What this entails is this: **any Nicknames that you give to the character and enable in the editor will also follow auto-color rules**. If you don't have auto-color enabled it does nothing. This is also per character so each one doesn't need to have Nicknames (similar to display names). What is different is that these are not on the name tag and you will not need to go in and manually color nicknames in text events using BBCode. This could be expanded upon in the future with Nicknames having more functionality (although I don't know what, maybe branch it off into a different feature) but that is all at the moment. Here are some GIFs showing the changes to the editor and the functionality:
1) General conversation showing their nicknames and names at the same time
![Nickname Showcase1](https://user-images.githubusercontent.com/82480325/115498654-f7da9680-a23b-11eb-834a-d41893f16824.gif)
2) Showing changes to the Character Editor
![Nickname Showcase2](https://user-images.githubusercontent.com/82480325/115498655-f8732d00-a23b-11eb-9770-d7f09c4f6fa7.gif)
3) Showing off adding more Nicknames (you just put a comma in-between on the _**Nicknames:**_ line edit)
![Nickname Showcase3](https://user-images.githubusercontent.com/82480325/115498657-f8732d00-a23b-11eb-8876-da07f24ec6c6.gif)
4) Showing off that disabling it for one person only affects the Nicknames for that person. Everyone else continues to work.
![Nickname Showcase4](https://user-images.githubusercontent.com/82480325/115498660-f90bc380-a23b-11eb-9564-461fa0742afc.gif)

Additionally, here is a screenshot where I show the previous issue with the names (this needed a fix regardless of this feature) and another with it fixed for comparison. As you can see the name should not be highlighted when part of another word:
![Nickname Screenshot 5](https://user-images.githubusercontent.com/82480325/115498831-44be6d00-a23c-11eb-8bb1-d56f1ea4fbae.PNG)
![Nickname Screenshot 6](https://user-images.githubusercontent.com/82480325/115498875-50119880-a23c-11eb-95b5-f48689a21448.PNG)

Anyway, I thought this was neat and it seems to work well. I will be using this for my own games in the future (maybe not all of them but that is what makes it flexible) so I figured it would be something some people may want to use but obviously no one is required to use and doesn't impede on any existing functionality to do so (as far as I am aware). I hope you think it is worth adding as well. I love the project so far! To make it easier for you to go through, the files that were changed were: CharacterEditor.tscn (checkbox and line edit additions), CharacterEditor.gd, DialogicUtil.gd, and dialog_node.gd all had changes to accomplish this, though most were admittedly minor and nothing was really removed, just added to. 

_An additional note:_ 
I have not tried it on a small screen like 13" so I don't know if the additional checkbox will make it seem to cramped there since I only have a 17" and 27" and seems to fit right in for me on both just fine. Some testing may be needed and is easy to just change a checkbox position to underneath the display name checkbox or something if needed (any contributor can do this if they want).

Have a Great day!
-Zak