### PR TITLE
add support for custom choice buttons

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -8,6 +8,7 @@ onready var nodes = {
 	'auto_color_names': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer3/AutoColorNames,
 	'propagate_input': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer4/PropagateInput,
 	'dim_characters': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer5/DimCharacters,
+	'advanced_themes': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer6/AdvancedThemes,
 }
 
 
@@ -20,6 +21,7 @@ func _ready():
 	nodes['auto_color_names'].connect('toggled', self, '_on_auto_color_names_toggled')
 	nodes['propagate_input'].connect('toggled', self, '_on_propagate_input_toggled')
 	nodes['dim_characters'].connect('toggled', self, '_on_dim_characters_toggled')
+	nodes['advanced_themes'].connect('toggled', self, '_on_advanced_themes_toggled')
 
 
 func update_data():
@@ -39,6 +41,8 @@ func dialog_options(settings):
 		nodes['propagate_input'].pressed = settings.get_value('dialog', 'propagate_input')
 	if settings.has_section_key('dialog', 'dim_characters'):
 		nodes['dim_characters'].pressed = settings.get_value('dialog', 'dim_characters')
+	if settings.has_section_key('dialog', 'advanced_themes'):
+		nodes['advanced_themes'].pressed = settings.get_value('dialog', 'advanced_themes')
 
 
 func refresh_themes(settings):
@@ -87,6 +91,11 @@ func _on_propagate_input_toggled(value):
 
 func _on_dim_characters_toggled(value):
 	set_value('dialog', 'dim_characters', value)
+
+
+func _on_advanced_themes_toggled(value):
+	set_value('dialog', 'advanced_themes', value)
+
 
 # Reading and saving data to the settings file
 func set_value(section, key, value):

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -18,11 +18,11 @@ size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1024.0
-margin_bottom = 240.0
+margin_bottom = 268.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_right = 304.0
-margin_bottom = 240.0
+margin_bottom = 268.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
@@ -59,20 +59,18 @@ margin_left = 50.0
 margin_right = 190.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 140, 0 )
-text = "Basic"
-items = [ "Alternative", null, false, 0, {
-"file": "theme-1617143167.cfg"
-}, "Basic", null, false, 1, {
-"file": "theme-1616778229.cfg"
-}, "New Theme", null, false, 2, {
-"file": "theme-1617143282.cfg"
+text = "normal"
+items = [ "no_gloss", null, false, 0, {
+"file": "theme-1618722854.cfg"
+}, "normal", null, false, 1, {
+"file": "theme-1616687382.cfg"
 } ]
 selected = 1
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 70.0
 margin_right = 304.0
-margin_bottom = 240.0
+margin_bottom = 268.0
 
 [node name="Panel2" type="Panel" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_right = 304.0
@@ -175,3 +173,20 @@ margin_left = 280.0
 margin_right = 304.0
 margin_bottom = 24.0
 pressed = true
+
+[node name="HBoxContainer6" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+margin_top = 174.0
+margin_right = 304.0
+margin_bottom = 198.0
+hint_tooltip = "These options can lead to unexpected behaviors. Make sure to read the documentation before using these."
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer6"]
+margin_top = 5.0
+margin_right = 160.0
+margin_bottom = 19.0
+text = "Advanced theme options"
+
+[node name="AdvancedThemes" type="CheckBox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer6"]
+margin_left = 164.0
+margin_right = 188.0
+margin_bottom = 24.0

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -71,6 +71,9 @@ onready var n : Dictionary = {
 	'button_modulation': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/CheckBox",
 	'button_modulation_color': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/ColorPickerButton",
 	'button_use_native': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/CheckBox",
+	'button_use_custom': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsCheckBox",
+	'button_custom_path': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsButton",
+	
 	'button_offset_x': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH",
 	'button_offset_y': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV",
 	'button_separation': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation",
@@ -142,6 +145,8 @@ func load_theme(filename):
 	n['button_image'].text = DialogicResources.get_filename_from_path(theme.get_value('buttons', 'image', 'res://addons/dialogic/Example Assets/backgrounds/background-2.png'))
 	n['button_image_visible'].pressed = theme.get_value('buttons', 'use_image', true)
 	n['button_use_native'].pressed = theme.get_value('buttons', 'use_native', false)
+	n['button_use_custom'].pressed = theme.get_value('buttons', 'use_custom', false)
+	n['button_custom_path'].text = DialogicResources.get_filename_from_path(theme.get_value('buttons', 'custom_path', ""))
 	n['button_offset_x'].value = theme.get_value('buttons', 'padding', Vector2(5,5)).x
 	n['button_offset_y'].value = theme.get_value('buttons', 'padding', Vector2(5,5)).y
 	n['button_separation'].value = theme.get_value('buttons', 'gap', 5)
@@ -151,7 +156,7 @@ func load_theme(filename):
 	n['button_fixed_x'].value = theme.get_value('buttons', 'fixed_size', Vector2(130,40)).x
 	n['button_fixed_y'].value = theme.get_value('buttons', 'fixed_size', Vector2(130,40)).y
 	
-	toggle_button_customization_fields(not theme.get_value('buttons', 'use_native', false))
+	toggle_button_customization_fields(theme.get_value('buttons', 'use_native', false), theme.get_value('buttons', 'use_custom', false))
 	
 	# Definitions
 	n['glossary_color'].color = Color(theme.get_value('definitions', 'color', "#ffffffff"))
@@ -461,20 +466,42 @@ func _on_native_button_toggled(button_pressed) -> void:
 	if loading:
 		return
 	DialogicResources.set_theme_value(current_theme, 'buttons', 'use_native', button_pressed)
-	toggle_button_customization_fields(not button_pressed)
+	toggle_button_customization_fields(button_pressed, false)
 
-func toggle_button_customization_fields(enabled) -> void:
-	var disabled = not enabled
-	n['button_text_color_enabled'].disabled = disabled
-	n['button_text_color'].disabled = disabled
-	n['button_background'].disabled = disabled
-	n['button_background_visible'].disabled = disabled
-	n['button_image'].disabled = disabled
-	n['button_image_visible'].disabled = disabled
-	n['button_modulation'].disabled = disabled
-	n['button_modulation_color'].disabled = disabled
-	n['button_offset_x'].editable = enabled
-	n['button_offset_y'].editable = enabled
+
+func toggle_button_customization_fields(native_enabled: bool, custom_enabled: bool) -> void:
+	var customization_disabled = native_enabled or custom_enabled
+	n['button_text_color_enabled'].disabled = customization_disabled
+	n['button_text_color'].disabled = customization_disabled
+	n['button_background'].disabled = customization_disabled
+	n['button_background_visible'].disabled = customization_disabled
+	n['button_image'].disabled = customization_disabled
+	n['button_image_visible'].disabled = customization_disabled
+	n['button_modulation'].disabled = customization_disabled
+	n['button_modulation_color'].disabled = customization_disabled
+	n['button_use_native'].disabled = custom_enabled
+	n['button_use_custom'].disabled = native_enabled
+	n['button_custom_path'].disabled = native_enabled
+	n['button_offset_x'].editable = not customization_disabled
+	n['button_offset_y'].editable = not customization_disabled
+
+
+func _on_CustomButtonsCheckBox_toggled(button_pressed):
+	if loading:
+		return
+	DialogicResources.set_theme_value(current_theme, 'buttons', 'use_custom', button_pressed)
+	toggle_button_customization_fields(false, button_pressed)
+
+
+func _on_CustomButtonsButton_pressed():
+	editor_reference.godot_dialog("*.tscn")
+	editor_reference.godot_dialog_connect(self, "_on_custom_button_selected")
+
+func _on_custom_button_selected(path, target) -> void:
+	if loading:
+		return
+	DialogicResources.set_theme_value(current_theme, 'buttons', 'custom_path', path)
+	n['button_custom_path'].text = DialogicResources.get_filename_from_path(path)
 
 
 func _on_GlossaryColorPicker_color_changed(color) -> void:

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -6,6 +6,8 @@ onready var master_tree = get_node('../MasterTreeContainer/MasterTree')
 onready var settings_editor = get_node('../SettingsEditor')
 var current_theme : String = ''
 
+var use_advanced_themes := false
+
 # When loading the variables to the input fields in the 
 # load_theme function, every element thinks the value was updated
 # so it has to perform a "saving" of that property. 
@@ -17,6 +19,14 @@ var loading : bool = true
 # complain because "that is not how you are supposed to work". If there was only
 # a way to set an id and then access that node via id...
 # Here you have paths in all its glory. Praise the paths (っ´ω`c)♡
+
+onready var advanced_containers := {
+	'buttons' : {
+		'container': $"VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer",
+		'disabled_text': $"VBoxContainer/TabContainer/Choice Buttons/Column3/Label"
+	}
+}
+
 onready var n : Dictionary = {
 	# Dialog Text
 	'theme_text_shadow': $"VBoxContainer/TabContainer/Dialog Text/Column/GridContainer/HBoxContainer2/CheckBoxShadow",
@@ -71,9 +81,8 @@ onready var n : Dictionary = {
 	'button_modulation': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/CheckBox",
 	'button_modulation_color': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/ColorPickerButton",
 	'button_use_native': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/CheckBox",
-	'button_use_custom': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsCheckBox",
-	'button_custom_path': $"VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsButton",
-	
+	'button_use_custom': $"VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5/CustomButtonsCheckBox",
+	'button_custom_path': $"VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5/CustomButtonsButton",
 	'button_offset_x': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH",
 	'button_offset_y': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV",
 	'button_separation': $"VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation",
@@ -109,10 +118,24 @@ func _ready() -> void:
 	_on_visibility_changed()
 
 
+func setup_advanced_containers():
+	use_advanced_themes = DialogicResources.get_settings_config().get_value('dialog', 'advanced_themes', false)
+	
+	for key in advanced_containers:
+		var c = advanced_containers[key]
+		if use_advanced_themes:
+			c["container"].show()
+			c["disabled_text"].hide()
+		else:
+			c["container"].hide()
+			c["disabled_text"].show()
+
+
 func load_theme(filename):
 	loading = true
 	current_theme = filename
 	var theme = DialogicResources.get_theme_config(filename)
+	setup_advanced_containers()
 	# Settings
 	n['theme_action_key'].text = theme.get_value('settings', 'action_key', 'ui_accept')
 	

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -824,7 +824,6 @@ allow_greater = true
 allow_lesser = true
 
 [node name="Choice Buttons" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -851,7 +850,7 @@ text = "Visuals"
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column"]
 margin_top = 26.0
 margin_right = 270.0
-margin_bottom = 162.0
+margin_bottom = 206.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
@@ -951,17 +950,80 @@ margin_right = 126.0
 margin_bottom = 24.0
 size_flags_horizontal = 3
 
-[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 117.0
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 112.0
 margin_right = 134.0
-margin_bottom = 131.0
+margin_bottom = 116.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HSeparator2" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_top = 112.0
+margin_right = 270.0
+margin_bottom = 116.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 125.0
+margin_right = 134.0
+margin_bottom = 139.0
 text = "Use Native Buttons"
 
 [node name="CheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
 margin_left = 144.0
-margin_top = 112.0
+margin_top = 120.0
 margin_right = 270.0
-margin_bottom = 136.0
+margin_bottom = 144.0
+
+[node name="HSeparator3" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 148.0
+margin_right = 134.0
+margin_bottom = 152.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HSeparator4" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_top = 148.0
+margin_right = 270.0
+margin_bottom = 152.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CustomButtonsLabel" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_top = 161.0
+margin_right = 134.0
+margin_bottom = 175.0
+hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
+mouse_filter = 1
+text = "Use Custom Buttons"
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
+margin_left = 144.0
+margin_top = 156.0
+margin_right = 270.0
+margin_bottom = 180.0
+
+[node name="CustomButtonsCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5"]
+margin_right = 24.0
+margin_bottom = 24.0
+
+[node name="CustomButtonsButton" type="Button" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5"]
+margin_left = 28.0
+margin_right = 126.0
+margin_bottom = 24.0
+hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
+size_flags_horizontal = 3
+text = "custom"
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Choice Buttons"]
 margin_left = 280.0
@@ -1069,6 +1131,7 @@ allow_greater = true
 allow_lesser = true
 
 [node name="Glossary" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_left = 4.0
@@ -1250,6 +1313,8 @@ one_shot = true
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/CheckBox" to="." method="_on_ChoiceButtons_texture_modulate_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/ColorPickerButton" to="." method="_on_ColorPicker_ChoiceButtons_modulation_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/CheckBox" to="." method="_on_native_button_toggled"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsCheckBox" to="." method="_on_CustomButtonsCheckBox_toggled"]
+[connection signal="pressed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsButton" to="." method="_on_CustomButtonsButton_pressed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_ButtonOffset_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_ButtonOffset_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation" to="." method="_on_VerticalSeparation_value_changed"]

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -850,7 +850,7 @@ text = "Visuals"
 [node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column"]
 margin_top = 26.0
 margin_right = 270.0
-margin_bottom = 206.0
+margin_bottom = 170.0
 size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
@@ -979,52 +979,6 @@ margin_top = 120.0
 margin_right = 270.0
 margin_bottom = 144.0
 
-[node name="HSeparator3" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 148.0
-margin_right = 134.0
-margin_bottom = 152.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="HSeparator4" type="HSeparator" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 144.0
-margin_top = 148.0
-margin_right = 270.0
-margin_bottom = 152.0
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="CustomButtonsLabel" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_top = 161.0
-margin_right = 134.0
-margin_bottom = 175.0
-hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
-mouse_filter = 1
-text = "Use Custom Buttons"
-__meta__ = {
-"_editor_description_": ""
-}
-
-[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer"]
-margin_left = 144.0
-margin_top = 156.0
-margin_right = 270.0
-margin_bottom = 180.0
-
-[node name="CustomButtonsCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5"]
-margin_right = 24.0
-margin_bottom = 24.0
-
-[node name="CustomButtonsButton" type="Button" parent="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5"]
-margin_left = 28.0
-margin_right = 126.0
-margin_bottom = 24.0
-hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
-size_flags_horizontal = 3
-text = "custom"
-
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Choice Buttons"]
 margin_left = 280.0
 margin_right = 284.0
@@ -1129,6 +1083,69 @@ margin_bottom = 24.0
 rounded = true
 allow_greater = true
 allow_lesser = true
+
+[node name="VSeparator2" type="VSeparator" parent="VBoxContainer/TabContainer/Choice Buttons"]
+margin_left = 613.0
+margin_right = 617.0
+margin_bottom = 488.0
+
+[node name="Column3" type="VBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons"]
+margin_left = 627.0
+margin_right = 897.0
+margin_bottom = 488.0
+rect_min_size = Vector2( 270, 0 )
+size_flags_vertical = 3
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="SectionTitle" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column3"]
+margin_right = 270.0
+margin_bottom = 22.0
+custom_styles/normal = SubResource( 1 )
+text = "Advanced"
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column3"]
+margin_top = 26.0
+margin_right = 270.0
+margin_bottom = 40.0
+text = "Go to settings to enable those options"
+
+[node name="GridContainer" type="GridContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column3"]
+margin_top = 44.0
+margin_right = 270.0
+margin_bottom = 68.0
+size_flags_horizontal = 3
+custom_constants/hseparation = 10
+columns = 2
+
+[node name="CustomButtonsLabel" type="Label" parent="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer"]
+margin_top = 5.0
+margin_right = 132.0
+margin_bottom = 19.0
+hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
+mouse_filter = 1
+text = "Use Custom Buttons"
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer"]
+margin_left = 142.0
+margin_right = 230.0
+margin_bottom = 24.0
+
+[node name="CustomButtonsCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5"]
+margin_right = 24.0
+margin_bottom = 24.0
+
+[node name="CustomButtonsButton" type="Button" parent="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5"]
+margin_left = 28.0
+margin_right = 88.0
+margin_bottom = 24.0
+hint_tooltip = "The selected scene must have the 'pressed' signal and the 'text' property'"
+size_flags_horizontal = 3
+text = "custom"
 
 [node name="Glossary" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
@@ -1313,14 +1330,14 @@ one_shot = true
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/CheckBox" to="." method="_on_ChoiceButtons_texture_modulate_toggled"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer6/ColorPickerButton" to="." method="_on_ColorPicker_ChoiceButtons_modulation_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/CheckBox" to="." method="_on_native_button_toggled"]
-[connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsCheckBox" to="." method="_on_CustomButtonsCheckBox_toggled"]
-[connection signal="pressed" from="VBoxContainer/TabContainer/Choice Buttons/Column/GridContainer/HBoxContainer5/CustomButtonsButton" to="." method="_on_CustomButtonsButton_pressed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetV" to="." method="_on_ButtonOffset_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer/TextOffsetH" to="." method="_on_ButtonOffset_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/VerticalSeparation" to="." method="_on_VerticalSeparation_value_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer2/FixedSize" to="." method="_on_FixedSize_toggled"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer2/ButtonSizeX" to="." method="_on_ButtonSize_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer/HBoxContainer2/ButtonSizeY" to="." method="_on_ButtonSize_value_changed"]
+[connection signal="toggled" from="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5/CustomButtonsCheckBox" to="." method="_on_CustomButtonsCheckBox_toggled"]
+[connection signal="pressed" from="VBoxContainer/TabContainer/Choice Buttons/Column3/GridContainer/HBoxContainer5/CustomButtonsButton" to="." method="_on_CustomButtonsButton_pressed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/FontButton" to="." method="_on_GlossaryFontButton_pressed"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/ColorPickerButton" to="." method="_on_GlossaryColorPicker_color_changed"]
 [connection signal="toggled" from="VBoxContainer/TabContainer/Glossary/Column/GridContainer/ShowGlossaryCheckBox" to="." method="_on_ShowGlossaryCheckBox_toggled"]


### PR DESCRIPTION
This PR lets the user use custom choice buttons. The custom scenes can be selected from the theme editor.

The selected scene must implement the `pressed` signal and have the `text` property available, like any component extending `Button`.

No checks are performed, the user is only told in the button/label tooltip in the theme editor. Selecting a scene which does not meet the requirements could crash the game.

Like with native buttons, activating custom buttons in the theme editor disables other controls.
![Screenshot_20210421_113115](https://user-images.githubusercontent.com/80701113/115531458-1751dd80-a295-11eb-98aa-16aa2bc8d1ba.png)
![Screenshot_20210421_113136](https://user-images.githubusercontent.com/80701113/115531503-23d63600-a295-11eb-9238-b36ba6eb53b7.png)
![Screenshot_20210421_113215](https://user-images.githubusercontent.com/80701113/115531583-3badba00-a295-11eb-9cbd-f7e143f8a899.png)




Closes #247