### PR TITLE
improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,19 @@
 project-icon.png
 project.godot
 test-scenes
-/dialogic
 /.import
 /default_env.tres
 /icon.png
 *.import
 /.vscode
-/addons/godot-plugin-refresher
-/addons/explore-editor-theme
 /previous
 export_presets.cfg
 /builds
+
+# Only add dialogic plugin 
+/addons/*
+!/addons/dialogic
+# Ignore dialogic resources
+/dialogic
+# Place test project files here
+/test-project


### PR DESCRIPTION
This PR updates the gitignore to ignore all plugins but dialogic, and also ignores a folder named `test-project` which can be used to store all files related to testing the plugin while working on it.