### PR TITLE
Add explaining label to the Emit Signal event

### DIFF
--- a/addons/dialogic/Editor/Events/EmitSignal.tscn
+++ b/addons/dialogic/Editor/Events/EmitSignal.tscn
@@ -5,9 +5,6 @@
 [ext_resource path="res://addons/dialogic/Editor/Events/Common/Spacer.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Events/Common/PieceExtraSettings.tscn" type="PackedScene" id=4]
 
-
-
-
 [sub_resource type="StyleBoxFlat" id=1]
 content_margin_left = 16.0
 content_margin_right = 6.0
@@ -82,9 +79,19 @@ margin_right = 124.0
 margin_bottom = 21.0
 text = "  Emit Signal     "
 
-[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Header"]
+[node name="Label" type="Label" parent="PanelContainer/VBoxContainer/Header"]
 margin_left = 128.0
-margin_right = 176.0
+margin_top = 7.0
+margin_right = 472.0
+margin_bottom = 21.0
+text = "Emit the dialogic_signal with the following argument:  "
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LineEdit" type="LineEdit" parent="PanelContainer/VBoxContainer/Header"]
+margin_left = 476.0
+margin_right = 524.0
 margin_bottom = 28.0
 custom_styles/read_only = SubResource( 2 )
 custom_styles/focus = SubResource( 2 )
@@ -101,14 +108,14 @@ caret_blink = true
 caret_blink_speed = 0.5
 
 [node name="Preview" type="Label" parent="PanelContainer/VBoxContainer/Header"]
-margin_left = 180.0
+margin_left = 528.0
 margin_top = 7.0
-margin_right = 180.0
+margin_right = 528.0
 margin_bottom = 21.0
 custom_colors/font_color = Color( 1, 1, 1, 0.513726 )
 
 [node name="Spacer" parent="PanelContainer/VBoxContainer/Header" instance=ExtResource( 3 )]
-margin_left = 184.0
+margin_left = 532.0
 margin_right = 941.0
 margin_bottom = 28.0
 
@@ -117,4 +124,5 @@ margin_left = 945.0
 margin_right = 982.0
 margin_bottom = 28.0
 items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
+
 [connection signal="text_changed" from="PanelContainer/VBoxContainer/Header/LineEdit" to="." method="_on_LineEdit_text_changed"]


### PR DESCRIPTION
There was just to much confusion.

This is how it looks now:
![grafik](https://user-images.githubusercontent.com/42868150/116082982-5bc9e880-a69c-11eb-92d5-deadad183f24.png)
