### PR TITLE
pretty print resources json with sorted keys

### DIFF
--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -219,7 +219,7 @@ static func set_json(path: String, data: Dictionary):
 	var file = File.new()
 	var err = file.open(path, File.WRITE)
 	if err == OK:
-		file.store_line(to_json(data))
+		file.store_line(JSON.print(data, '\t', true))
 		file.close()
 	return err
 


### PR DESCRIPTION
This PR makes timelines and definitions easier to read and to handle with git. It also sorts object keys to prevent unnecessary changes when simply opening the timeline without modifying it in the editor.

The drawback is the file size, which increases because of the added characters. This PR does not provide any minifying script to run before packing the game.


Closes #269