### PR TITLE
Update dialog_node.gd to warn the user when Dialogic node is not child of canvas layer

### DIFF
--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -76,7 +76,7 @@ func _ready():
 	else:
 		# Copied
 		if not(get_parent() is CanvasLayer):
-			push_warning("[Dialogic] You didn't add this node to a CanvasLayer. If this was intentional, you can ignore this warning."))
+			push_warning("[Dialogic] You didn't add this node to a CanvasLayer. If this was intentional, you can ignore this warning.")
 		
 		_init_dialog()
 

--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -74,6 +74,10 @@ func _ready():
 		if preview:
 			_init_dialog()
 	else:
+		# Copied
+		if not(get_parent() is CanvasLayer):
+			push_warning("[Dialogic] You didn't add this node to a CanvasLayer. If this was intentional, you can ignore this warning."))
+		
 		_init_dialog()
 
 


### PR DESCRIPTION
This way you can warn the user that he did not add his node to a canvas layer and that it probably won't show up in the game as expects. 

It is not an automatic way to solve the problem, but a way to tell you what the problem is.