### PR TITLE
Modify loading function to permit direct loading from GDscript

### DIFF
--- a/addons/dialogic/Nodes/dialog_node.gd
+++ b/addons/dialogic/Nodes/dialog_node.gd
@@ -48,7 +48,7 @@ func _ready():
 	
 	# Checking if the dialog should read the code from a external file
 	if not timeline.empty():
-		dialog_script = set_current_dialog(timeline)
+		set_current_dialog(timeline)
 	elif dialog_script.keys().size() == 0:
 		dialog_script = {
 			"events":[
@@ -56,6 +56,9 @@ func _ready():
 				"character":"","portrait":"",
 				"text":"[Dialogic Error] No timeline specified."}]
 		}
+	# Load the dialog directly from GDscript
+	else:
+		load_dialog()
 	
 	# Connecting resize signal
 	get_viewport().connect("size_changed", self, "resize_main")
@@ -139,7 +142,10 @@ func resize_main():
 
 func set_current_dialog(dialog_path: String):
 	current_timeline = dialog_path
-	var dialog_script = DialogicResources.get_timeline_json(dialog_path)
+	dialog_script = DialogicResources.get_timeline_json(dialog_path)
+	load_dialog()
+	
+func load_dialog():
 	# All this parse events should be happening in the same loop ideally
 	# But until performance is not an issue I will probably stay lazy
 	# And keep adding different functions for each parsing operation.
@@ -151,8 +157,6 @@ func set_current_dialog(dialog_path: String):
 	
 	dialog_script = parse_text_lines(dialog_script)
 	dialog_script = parse_branches(dialog_script)
-	return dialog_script
-
 
 func parse_characters(dialog_script):
 	var names = DialogicUtil.get_character_list()


### PR DESCRIPTION
When loading the timeline directly with GDscript as descriped in the FAQ :

```
func _ready():
	var gdscript_dialog = Dialogic.start('')
	gdscript_dialog.dialog_script = {
		"events":[
			{ 'event_id':'dialogic_001', "character": "", "portrait":"", "text": "This dialog was created using GDScript!"}
		]
	}
	add_child(gdscript_dialog)
```
the loading of the timeline is not complete because most of the loading is done in the set_current_dialog function, and that function is only called if the "timeline" attribute is set.

I tried in this PR to create a separate loading method that is called by set_current_dialog and by itself if the timeline is created by GDscript (with empty timeline attribute).