### PR TITLE
Custom Canvas Layer in settings

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -16,10 +16,12 @@ onready var nodes = {
 	'save_definitions_on_end': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3/HBoxContainer4/SaveDefinitionsOnEnd,
 	'delay_after_options': $VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer/LineEdit,
 	'default_action_key': $VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer2/DefaultActionKey,
+	'canvas_layer' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3/CanvasLayer,
 }
 
 var THEME_KEYS := [
 	'advanced_themes',
+	'canvas_layer',
 	]
 
 var INPUT_KEYS := [
@@ -51,6 +53,7 @@ func _ready():
 	nodes['delay_after_options'].connect('text_changed', self, '_on_delay_options_text_changed')
 	# TODO move to theme section later
 	nodes['advanced_themes'].connect('toggled', self, '_on_item_toggled', ['dialog', 'advanced_themes'])
+	nodes['canvas_layer'].connect('text_changed', self, '_on_canvas_layer_text_changed')
 
 	nodes['default_action_key'].connect('pressed', self, '_on_default_action_key_presssed')
 	nodes['default_action_key'].connect('item_selected', self, '_on_default_action_key_item_selected')
@@ -137,6 +140,10 @@ func _on_default_action_key_item_selected(index) -> void:
 	if index == 0:
 		print('here')
 	set_value('input', 'default_action_key', nodes['default_action_key'].text)
+
+
+func _on_canvas_layer_text_changed(text) -> void:
+	set_value('theme', 'canvas_layer', text)
 
 
 # Reading and saving data to the settings file

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -12,23 +12,23 @@ __meta__ = {
 }
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
-margin_right = 1024.0
-margin_bottom = 600.0
+margin_right = 1920.0
+margin_bottom = 1080.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
-margin_right = 1024.0
-margin_bottom = 452.0
+margin_right = 1920.0
+margin_bottom = 480.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_right = 356.0
-margin_bottom = 452.0
+margin_bottom = 480.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_right = 356.0
-margin_bottom = 74.0
+margin_bottom = 102.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer" instance=ExtResource( 2 )]
 margin_right = 356.0
@@ -47,22 +47,14 @@ text = "Default"
 
 [node name="ThemeOptionButton" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer"]
 margin_left = 50.0
-margin_right = 228.0
+margin_right = 190.0
 margin_bottom = 20.0
 rect_min_size = Vector2( 140, 0 )
-text = "theme-1622916617.cfg"
-items = [ "another", null, false, 0, {
-"file": "theme-1622727938.cfg"
-}, "test", null, false, 1, {
-"file": "theme-1625139864.cfg"
-}, "theme-1622916617.cfg", null, false, 2, {
-"file": "theme-1622916617.cfg"
-}, "theme-1622916814.cfg", null, false, 3, {
-"file": "theme-1622916814.cfg"
-}, "theme-1625138420.cfg", null, false, 4, {
-"file": "theme-1625138420.cfg"
+text = "main_theme"
+items = [ "main_theme", null, false, 0, {
+"file": "theme-1626129237.cfg"
 } ]
-selected = 2
+selected = 0
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer"]
 margin_top = 50.0
@@ -80,11 +72,29 @@ text = "Advanced theme options"
 margin_left = 164.0
 margin_right = 188.0
 margin_bottom = 24.0
+pressed = true
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer"]
+margin_top = 78.0
+margin_right = 356.0
+margin_bottom = 102.0
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3"]
+margin_top = 5.0
+margin_right = 87.0
+margin_bottom = 19.0
+text = "Canvas layer :"
+
+[node name="CanvasLayer" type="LineEdit" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3"]
+margin_left = 91.0
+margin_right = 149.0
+margin_bottom = 24.0
+text = "1"
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 90.0
+margin_top = 118.0
 margin_right = 356.0
-margin_bottom = 302.0
+margin_bottom = 330.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 2 )]
 margin_right = 356.0
@@ -146,6 +156,7 @@ text = "Auto color character names in messages"
 margin_left = 264.0
 margin_right = 288.0
 margin_bottom = 24.0
+pressed = true
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 114.0
@@ -178,6 +189,7 @@ text = "Dim characters when they are not speaking"
 margin_left = 280.0
 margin_right = 304.0
 margin_bottom = 24.0
+pressed = true
 
 [node name="Label2" type="Label" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 170.0
@@ -201,12 +213,11 @@ margin_left = 332.0
 margin_right = 356.0
 margin_bottom = 24.0
 hint_tooltip = "If enabled, inputs for text events will be treated as keys for tr()"
-pressed = true
 
 [node name="VBoxContainer3" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_top = 318.0
+margin_top = 346.0
 margin_right = 356.0
-margin_bottom = 452.0
+margin_bottom = 480.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3" instance=ExtResource( 2 )]
 margin_right = 356.0
@@ -288,7 +299,7 @@ pressed = true
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
 margin_left = 360.0
 margin_right = 664.0
-margin_bottom = 452.0
+margin_bottom = 480.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
 margin_right = 304.0

--- a/addons/dialogic/Nodes/canvas_dialog_node.gd
+++ b/addons/dialogic/Nodes/canvas_dialog_node.gd
@@ -38,6 +38,10 @@ func set_dialog_script(value):
 
 
 func _ready() -> void:
+	# change the canvas layer
+	var config = DialogicResources.get_settings_config()	
+	layer = int(config.get_value("theme", "canvas_layer", 1))
+	
 	var _err:int
 	if dialog_node:
 		_err = dialog_node.connect("event_start", self, "_on_event_start")


### PR DESCRIPTION
This is a fix to [Issue]https://github.com/coppolaemilio/dialogic/issues/362)
In the settings editor, you can now choose the layer index which the dialogic's canvas layer will use.
This should prevent dialogues from being rendered behind UI with higher layers.