### PR TITLE
This tells git to ignore certain nonessential files from export allowing for faster installing from AssetLib

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+.git/           export-ignore
+.github/        export-ignore
+docs/           export-ignore
+.gitattributes  export-ignore
+.gitignore      export-ignore
+LICENSE         export-ignore
+README.md       export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,4 @@
 .git/           export-ignore
 .github/        export-ignore
-docs/           export-ignore
 .gitattributes  export-ignore
 .gitignore      export-ignore
-LICENSE         export-ignore
-README.md       export-ignore


### PR DESCRIPTION
Not sure if this is actually welcome, but this gives a faster and easier install flow where user doesn't need to select what to keep.

Note: this works by removing ignored files from zip downloaded from github. This also affects releases archives, so you might want to keep something like README or LICENSE. But other than that folders like .github and files like .git* are really have no reason to be exported.

Awesome project :)