### PR TITLE
Use last part of path to find specific timeline in 'Dialogic.start()'

### DIFF
--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -61,18 +61,11 @@ static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: S
 				current_data = timelines['folders'][p]
 			elif current_depth == parts.size() - 1:
 				# The final destination
-				# Filter this folder's timeline from all timelines
-				var timelinesInFolder: Array= []
 				for t in DialogicUtil.get_timeline_list():
 					for f in current_data['files']:
-						if t['file'] == f:
-							timelinesInFolder.append(t)
-				
-				# Find timeline that matches final part
-				for t in timelinesInFolder:
-					if t['name'] == p:
-						dialog_node.timeline = t['file']
-						return returned_dialog_node
+						if t['file'] == f && t['name'] == p:
+							dialog_node.timeline = t['file']
+							return returned_dialog_node
 			else:
 				# Still going deeper
 				current_data = current_data['folders'][p]

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -61,11 +61,18 @@ static func start(timeline: String, reset_saves: bool=true, dialog_scene_path: S
 				current_data = timelines['folders'][p]
 			elif current_depth == parts.size() - 1:
 				# The final destination
+				# Filter this folder's timeline from all timelines
+				var timelinesInFolder: Array= []
 				for t in DialogicUtil.get_timeline_list():
 					for f in current_data['files']:
 						if t['file'] == f:
-							dialog_node.timeline = t['file']
-							return returned_dialog_node
+							timelinesInFolder.append(t)
+				
+				# Find timeline that matches final part
+				for t in timelinesInFolder:
+					if t['name'] == p:
+						dialog_node.timeline = t['file']
+						return returned_dialog_node
 			else:
 				# Still going deeper
 				current_data = current_data['folders'][p]


### PR DESCRIPTION
Changes the 'find timeline' part of `Dialogic.start()` to filter timelines from `DialogicUtil.get_timeline_list()` by `current_data['files']`, leaving only the relevant ones. Then find the the timeline where name equals end of the path (at this point `p`).

Fixes #451