### PR TITLE
Fixed "Don't change" setting.

### DIFF
--- a/addons/dialogic/Nodes/Portrait.gd
+++ b/addons/dialogic/Nodes/Portrait.gd
@@ -25,6 +25,9 @@ func _ready():
 
 
 func set_portrait(expression: String) -> void:
+	if expression == "(Don't change)":
+		return
+
 	if expression == '':
 		expression = 'Default'
 	


### PR DESCRIPTION
Currently the "Don't change" setting isn't handled in the `set_portrait` method and will reset the portrait to the default one.