### PR TITLE
Add CI with static checks

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -1,0 +1,15 @@
+name: Static Checks
+on: [push, pull_request]
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdformat --diff .
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip3 install gdtoolkit
+      - run: gdlint .


### PR DESCRIPTION
This PR adds an action that will run both `gdformat` and `gdlint` (from [godot-gdscript-toolkit](https://github.com/Scony/godot-gdscript-toolkit)) on the whole repository.

It reports what changes are needed, but doesn't modify any file.