### PR TITLE
fix code insertion in documentation of Emit Signal Event

### DIFF
--- a/addons/dialogic/Documentation/Content/Events/040.md
+++ b/addons/dialogic/Documentation/Content/Events/040.md
@@ -5,7 +5,8 @@ The `Emit Signal` event will emit the signal `dialogic_signal` of the **current 
 The event does NOT create a new signal!
 
 If you instance your dialog via script, use a code similar to this:
-`func start_dialog():
+```gdscript
+func start_dialog():
 	var dialog = Dialogic.start("my_timeline")
 	dialog.connect("dialogic_signal", self, "dialog_listener")
 	add_node(dialog)
@@ -15,7 +16,7 @@ func dialog_listener(string):
 		"quest_point_two":
 			# do something
 			pass
-`
+```
 
 If you instanced the scene using the editor you can connect the signal like you would always do in Godot from the `NODE TAB > Signals`.
 


### PR DESCRIPTION
Hi there :)
make highlighting and indentation work. 