### PR TITLE
Fixing bug that prevented portrait update

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -1105,9 +1105,10 @@ func handle_voice(event):
 func grab_portrait_focus(character_data, event: Dictionary = {}) -> bool:
 	var exists = false
 	var visually_focus = settings.get_value('dialog', 'dim_characters', true)
-
+	
 	for portrait in $Portraits.get_children():
-		if portrait.character_data == character_data:
+		# check if it's the same character
+		if portrait.character_data.get("file", "something") == character_data.get("file", "none"):
 			exists = true
 			
 			if visually_focus:


### PR DESCRIPTION
When looking if a character already entered (to update the portrait on text and question events), it checked the character data against the one of the portrait. That didn't work. So now it checks the characters file, which should actually always be the same.