### PR TITLE
Changing the DocsMarkdownParser to understand ``` code as well

### DIFF
--- a/addons/dialogic/Documentation/Nodes/DocsMarkdownParser.gd
+++ b/addons/dialogic/Documentation/Nodes/DocsMarkdownParser.gd
@@ -98,11 +98,15 @@ func parse(content : String,  file_path:String = '', docs_path:String = ''):
 			parsed_text = parsed_text.replace("~~"+res.get_string("strikedtext")+"~~","[s]"+res.get_string("strikedtext")+"[/s]")
 	
 	## Find all occurences of code snippets
-	regex.compile("\\`(?<coded>(?:[^\\`]|\\n)*)\\`")
+	regex.compile("(([^`]`)|(```))(?<coded>[^`]+)(?(2)(`)|(```))")
 	result = regex.search_all(content)
 	if result:
 		for res in result:
-			parsed_text = parsed_text.replace("`"+res.get_string("coded")+"`","[color=#"+accent_color.lightened(0.6).to_html()+"][code]"+res.get_string("coded")+"[/code][/color]")
+			if res.get_string().begins_with("```"):
+				parsed_text = parsed_text.replace("```"+res.get_string("coded")+"```","[indent][color=#"+accent_color.lightened(0.6).to_html()+"][code]"+res.get_string("coded")+"[/code][/color][/indent]")
+			else:
+				parsed_text = parsed_text.replace("`"+res.get_string("coded")+"`","[color=#"+accent_color.lightened(0.6).to_html()+"][code]"+res.get_string("coded")+"[/code][/color]")
+				
 	
 	
 	## Find all occurences of list items


### PR DESCRIPTION
Previously it only recognized `code`, now it can also do:
```
longer code snippets.
```
They will be slightly indented, we'll see if that's good.