### PR TITLE
Documentation improvements.

### DIFF
--- a/addons/dialogic/Documentation/Content/FAQ/CSharp.md
+++ b/addons/dialogic/Documentation/Content/FAQ/CSharp.md
@@ -1,9 +1,10 @@
 # Can I use C# with Dialogic?
+
 It is experimental! So if you want to try it out and you find issues, let us know. Usage:
 
 `public override void _Ready()
 	{
-		var dialog = DialogicSharp.Start("Greeting", false);
+		var dialog = DialogicSharp.Start("Greeting");
 		AddChild(dialog);
 	}
 `

--- a/addons/dialogic/Documentation/Content/FAQ/Portraits.md
+++ b/addons/dialogic/Documentation/Content/FAQ/Portraits.md
@@ -1,5 +1,6 @@
-# Portraits not showing in game?
+# Show portraits?
 
+**Portraits not showing in game?**
 Before the characters show up on screen, you need to make them join your current scene using the [Character Join](../Events/001.md). 
 
 If you used the join event and you still don't see them, you should try modifying the offset and scale values in your character's portrait.

--- a/addons/dialogic/Documentation/Content/FAQ/can-i-use-dialogic-in-my-project.md
+++ b/addons/dialogic/Documentation/Content/FAQ/can-i-use-dialogic-in-my-project.md
@@ -1,3 +1,4 @@
-# Can I use Dialogic in one of my projects?
+# What license?
 
+**Can I use Dialogic in one of my projects?**
 Yes, you can use Dialogic to make any kind of game (even commercial ones). The project is developed under the [MIT License](https://github.com/coppolaemilio/dialogic/blob/master/LICENSE). Please remember to credit!

--- a/addons/dialogic/Documentation/Content/FAQ/create-timeline-using-gdscript.md
+++ b/addons/dialogic/Documentation/Content/FAQ/create-timeline-using-gdscript.md
@@ -1,11 +1,12 @@
-# Can I create a timeline using GDScript?
+# Creating timeline in code?
 
+**Can I create a timeline using GDScript?**
 Yes! it is a bit harder since you will have to create each event yourself, and to do that they have to be **valid**. You can check already created timelines with a text editor and see how an event should look like. A better tutorial and improvements will come soon.
 
 
 A simple example:
 
-```gdscript
+```
 
 func _ready():
 

--- a/addons/dialogic/Documentation/Content/FAQ/how-to-make-dialog-show-up-in-game.md
+++ b/addons/dialogic/Documentation/Content/FAQ/how-to-make-dialog-show-up-in-game.md
@@ -1,5 +1,6 @@
-# How can I make a dialog show up in game?
+# Enable/start dialog?
 
+**How can I make a dialog show up in game?**
 There are two ways of doing this; using gdscript or the scene editor.
 
 Using the `Dialogic` class you can add dialogs from code easily:

--- a/addons/dialogic/Documentation/Content/FAQ/plugin-shipped-godot.md
+++ b/addons/dialogic/Documentation/Content/FAQ/plugin-shipped-godot.md
@@ -1,3 +1,4 @@
-# The plugin is cool! Why is it not shipped with Godot?
+# Why a plugin?
 
+**The plugin is cool! Why is it not shipped with Godot?**
 I see a lot of people saying that the plugin should come with Godot, but I believe this should stay as a plugin since most of the people making games won't be using it. I'm flattered by your comments but this will remain a plugin :)

--- a/addons/dialogic/Documentation/Content/FAQ/resolution-small-dialog-big.md
+++ b/addons/dialogic/Documentation/Content/FAQ/resolution-small-dialog-big.md
@@ -1,3 +1,4 @@
-# My resolution is too small and the dialog is too big. Help!
+# Text box to big?
 
+**My resolution is too small and the dialog is too big. Help!**
 If you are setting the resolution of your game to a very small value, you will have to create a theme in Dialogic and pick a smaller font and make the box size of the Dialog Box smaller as well.

--- a/addons/dialogic/Documentation/Content/FAQ/why-not-graph-nodes.md
+++ b/addons/dialogic/Documentation/Content/FAQ/why-not-graph-nodes.md
@@ -1,5 +1,6 @@
-# Why are you not using graph nodes?
+# Why not graph nodes?
 
+**Why are you not using graph nodes?**
 Because of how the graph nodes are, the screen gets full of UI elements and it gets harder to follow.
 
 If you want to use graph based editors you can try [Levraut's LE Dialogue Editor](https://levrault.itch.io/le-dialogue-editor) or [EXP Godot Dialog System](https://github.com/EXPWorlds/Godot-Dialog-System).

--- a/addons/dialogic/Documentation/Content/Reference/001.md
+++ b/addons/dialogic/Documentation/Content/Reference/001.md
@@ -1,48 +1,136 @@
 # Dialog Class
 
+The dialogic class provides pretty much all the methods you need to interact with dialogic via code.
+You can access them simply by using the class name `Dialogic.method_i_want_to_call()`.
 
+## Starting dialog
 
-### Methods:
-#### start()
-`start(timeline: String, default_timeline: String, dialog_scene_path: String="res://addons/dialogic/Nodes/DialogNode.tscn", use_canvas_instead=true)`
+### start()
+`start(timeline, default_timeline, dialog_scene_path, use_canvas_instead)`
+
 Starts the dialog for the given timeline and returns a Dialog node.
 You must then add it manually to the scene to display the dialog.
 
 Example:
+```
 var new_dialog = Dialogic.start('Your Timeline Name Here')
 add_child(new_dialog)
+```
 
-This is exactly the same as using the editor:
-you can drag and drop the scene located at /addons/dialogic/Dialog.tscn 
-and set the current timeline via the inspector.
+`@param timeline`
+The timeline to load. You can provide the timeline name or the filename. Leave this empty to start from save.
+It's encouraged to specify the timeline name with the folders in front (e.g. 'Part 1/Chapter 1').
 
-@param timeline			The timeline to load. You can provide the timeline name or the filename.
-@param default_timeline		If timeline == '' and no valid data was found, this will be loaded.
-@param dialog_scene_path	If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
-@param use_canvas_instead	Create the Dialog inside a canvas layer to make it show up regardless of the camera 2D/3D situation.
-@returns			A Dialog node to be added into the scene tree.
+`@param default_timeline`
+If timeline == '' (so it's loading from the save slot) and no valid data was found, this will be loaded.
+
+`@param dialog_scene_path`
+If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
+
+`@param use_canvas_instead`
+True by default. Creates the Dialog inside a canvas layer to make it show up regardless of the camera 2D/3D situation.
+
+**@returns**
+A Dialog node to be added into the scene tree (see example above).
 
 
-#### start_from_save()
-`start_from_save(timeline: String, initial_timeline: String, dialog_scene_path: String="res://addons/dialogic/Nodes/DialogNode.tscn")`
-Same as the start method above, but using the last timeline saved.
+## Save and loading
+The Dialogic class provides the following methods for dealing with saving and loading. Learn more about how to use them in the Saving and Loading tutorial.
 
-@param timeline              	The current timeline to load
-@param initial_timeline		The timeline to load in case no save is found.
-@param dialog_scene_path	If you made a custom Dialog scene or moved it from its default path, you can specify its new path here.
-@returns			A Dialog node to be added into the scene tree.
+### load()
+`load(slot_name)`
 
-## Previously on the Dialogic Singleton (RIP - rest in pain)
+`@param slot_name`
+Specifies the slot name to be loaded. If empty, it will load the default save.
 
-#### set_current_timeline()
-#### get_current_timeline()
+### save()
+`save(slot_name)`
 
-#### get_definitions()
-#### set_definitions()
-#### set_variable()
-#### get_variable()
-#### set_glossary_from_id()
-#### set_variable_from_id()
+`@param slot_name`
+Specifies the slot name to be saved to. If empty, it will save to the default slot.
 
-#### save_defintions()
+### get_slot_names()
+`get_slot_names()`
 
+**@returns**
+An array with all the available slot names.
+
+### erase_slot()
+`erase_slot(slot_name)`
+
+`@param slot_name`
+Specifies the slot name to be deleted.
+
+### has_current_dialog_node()
+`has_current_dialog_node()`
+
+**@returns**
+True if there is a Dialog Node active, otherwise false.
+
+### reset_saves()
+`reset_saves(slot_name)`
+
+`@param slot_name`
+Specifies the slot to be reset. Uses the default slot if left empty.
+
+### get_current_slot()
+`get_current_slot()`
+
+**@returns**
+The name of the last loaded slot or "/" if import() was used.
+
+### export()
+`export()`
+Is used to get all necessary info, so you can save it however you want.
+
+**@returns**
+A dictionary with all important information about the dialogic game state.
+There are three sub-dictionaries with the keys 'definitions', 'state' and 'dialog_state'.
+- *'definitions'* contains all the definitions, values as well as glossary entries (only their current value, not the defaults
+- *'state'* contains the so called "game_state": custom information that can be accessed with the `Dialogic.get_saved_state_general_key()` and `Dialogic.set_saved_state_general_key()` methods.
+- *'dialog_state'* that contains all information needed to load the dialog back in (if any dialog was playing when export() is called. Example information is the current timeline, event index, characters on screen with their portraits, background, music, etc...
+
+### import()
+`import(data)`
+Is used to load data that was exported back in.
+
+`@param data`
+A dictionary that should be the same as the one you get from `export()`.
+
+
+
+## Variables
+You can change the value definitions through your code!
+### set_variable()
+`set_variable(name, value)`
+
+Sets the value of the value definition named `@param name` to `@param value`.
+
+### get_variable()
+`get_variable(name, default)`
+
+Returns the current (not default) value of the value definition named `@param name` or `@param default` if no value definition like that was named.
+
+
+## Game State
+The game state is custom information that you can access with the following functions and that will be saved and loaded alongside the other dialogic data.
+
+### get_saved_state_general_key()
+`get_saved_state_general_key(key, default)`
+
+**@returns**
+The value of the given `@param key` or `@param default` if nothing is found.
+ 
+### set_saved_state_general_key()
+`set_saved_state_general_key(key, value)`
+
+Changes the value of the given `@param key` to the value of `@param value`.
+
+
+## Other stuff
+
+### get_action_button()
+Mostly used for internal purposes. 
+
+**@returns**
+The input action selected on the dialogic setting page.

--- a/addons/dialogic/Documentation/Nodes/DocsTreeHelper.gd
+++ b/addons/dialogic/Documentation/Nodes/DocsTreeHelper.gd
@@ -184,7 +184,7 @@ func get_title(path, default_name):
 	f.open(path, File.READ)
 	var arr = f.get_as_text().split('\n', false, 1)
 	if not arr.empty():
-		return arr[0].replace('#', '').strip_edges()
+		return arr[0].trim_prefix('#').strip_edges()
 	else:
 		return default_name
 ## ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -109,7 +109,6 @@ static func load(slot_name: String = ''):
 ## 
 ## @param slot_name		The name of the save slot. To load this save you have to specify the same
 ##						If the slot folder doesn't exist it will be created. 
-##						Leaving this empty will use the last loaded save slot.
 static func save(slot_name: String = '', is_autosave = false) -> void:
 	# check if to save (if this is a autosave)
 	if is_autosave and not get_autosave():


### PR DESCRIPTION
Fixes #521.

Rewrite of the DialogicClass reference to contain all the important methods (and no outdated ones.

Makes the titles of the FAQ pages shorter.

