### PR TITLE
Automatic Pauses for Specific Symbols

### DIFF
--- a/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd
+++ b/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd
@@ -1,0 +1,14 @@
+tool
+extends HBoxContainer
+
+signal data_changed
+
+func _ready():
+	$DeleteButton.icon = get_icon("Remove", "EditorIcons")
+
+func set_data(data):
+	$Symbol.text = data[0]
+	$Duration.value = float(data[1])
+
+func change(value):
+	emit_signal("data_changed")

--- a/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd
+++ b/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd
@@ -12,3 +12,8 @@ func set_data(data):
 
 func change(value):
 	emit_signal("data_changed")
+
+
+func _on_DeleteButton_pressed():
+	queue_free()
+	emit_signal("data_changed")

--- a/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.tscn
@@ -1,6 +1,21 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd" type="Script" id=1]
+
+[sub_resource type="Image" id=3]
+data = {
+"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+"format": "LumAlpha8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id=2]
+flags = 4
+flags = 4
+image = SubResource( 3 )
+size = Vector2( 16, 16 )
 
 [node name="AutoPauseContainer" type="HBoxContainer"]
 margin_right = 252.0
@@ -30,9 +45,11 @@ suffix = "s"
 
 [node name="DeleteButton" type="Button" parent="."]
 margin_left = 242.0
-margin_right = 254.0
+margin_right = 270.0
 margin_bottom = 24.0
+icon = SubResource( 2 )
 flat = true
 
 [connection signal="text_changed" from="Symbol" to="." method="change"]
 [connection signal="value_changed" from="Duration" to="." method="change"]
+[connection signal="pressed" from="DeleteButton" to="." method="_on_DeleteButton_pressed"]

--- a/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.gd" type="Script" id=1]
+
+[node name="AutoPauseContainer" type="HBoxContainer"]
+margin_right = 252.0
+margin_bottom = 24.0
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Symbol" type="LineEdit" parent="."]
+margin_right = 160.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 160, 0 )
+
+[node name="Duration" type="SpinBox" parent="."]
+margin_left = 164.0
+margin_right = 238.0
+margin_bottom = 24.0
+rect_min_size = Vector2( 60, 0 )
+size_flags_horizontal = 3
+min_value = 0.001
+max_value = 5.0
+step = 0.001
+value = 0.01
+align = 2
+suffix = "s"
+
+[node name="DeleteButton" type="Button" parent="."]
+margin_left = 242.0
+margin_right = 254.0
+margin_bottom = 24.0
+flat = true
+
+[connection signal="text_changed" from="Symbol" to="." method="change"]
+[connection signal="value_changed" from="Duration" to="." method="change"]

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -189,6 +189,7 @@ func _ready() -> void:
 	n['theme_text_speed'].connect('value_changed', self, '_on_generic_value_change', ['text','speed'])
 	
 	n['theme_auto_pause_add'].icon = get_icon("Add", "EditorIcons")
+	n['theme_auto_pause_add'].connect('pressed', self, 'on_AddAutopause_pressed')
 	
 	# Dialog Box tab
 	n['theme_background_color_visible'].connect('toggled', self, '_on_generic_checkbox', ['background', 'use_color'])
@@ -672,6 +673,11 @@ func _on_ShadowOffset_value_changed(_value) -> void:
 		return
 	DialogicResources.set_theme_value(current_theme, 'text','shadow_offset', Vector2(n['theme_shadow_offset_x'].value,n['theme_shadow_offset_y'].value))
 	_on_PreviewButton_pressed() # Refreshing the preview
+
+func on_AddAutopause_pressed():
+	var autopausenode = load("res://addons/dialogic/Editor/ThemeEditor/AutoPauseContainer.tscn").instance()
+	n['theme_auto_pause_section'].add_child(autopausenode)
+	autopausenode.connect('data_changed', self, '_on_Autopause_data_changed')
 
 func _on_Autopause_data_changed():
 	if loading:

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/Plugin/plugin-editor-icon-light-theme.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd" type="Script" id=2]
@@ -9,7 +9,7 @@
 [ext_resource path="res://addons/dialogic/Editor/ThemeEditor/AudioPicker.tscn" type="PackedScene" id=7]
 [ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=8]
 
-[sub_resource type="Image" id=9]
+[sub_resource type="Image" id=11]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -18,25 +18,10 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id=8]
+[sub_resource type="ImageTexture" id=10]
 flags = 4
 flags = 4
-image = SubResource( 9 )
-size = Vector2( 16, 16 )
-
-[sub_resource type="Image" id=10]
-data = {
-"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
-"format": "LumAlpha8",
-"height": 16,
-"mipmaps": false,
-"width": 16
-}
-
-[sub_resource type="ImageTexture" id=6]
-flags = 4
-flags = 4
-image = SubResource( 10 )
+image = SubResource( 11 )
 size = Vector2( 16, 16 )
 
 [node name="ThemeEditor" type="ScrollContainer"]
@@ -158,7 +143,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -188,7 +173,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel3" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -218,7 +203,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Text"]
 margin_left = 280.0
@@ -350,37 +335,19 @@ size_flags_horizontal = 3
 custom_constants/hseparation = 10
 columns = 2
 
-[node name="TLabel" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer" instance=ExtResource( 8 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_top = 5.0
-margin_right = 148.0
-margin_bottom = 19.0
-text = "Speed (bigger = slower)"
-text_key = "Speed (bigger = slower)"
-
-[node name="TextSpeed" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer"]
-margin_left = 158.0
-margin_right = 232.0
-margin_bottom = 24.0
-max_value = 10.0
-step = 0.01
-value = 2.0
-
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 31.0
+margin_top = 3.0
 margin_right = 148.0
-margin_bottom = 45.0
+margin_bottom = 17.0
 text = "Alignment"
 text_key = "Alignment"
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer"]
 margin_left = 158.0
-margin_top = 28.0
 margin_right = 232.0
-margin_bottom = 48.0
+margin_bottom = 20.0
 
 [node name="Alignment" type="OptionButton" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer/HBoxContainer3"]
 margin_right = 74.0
@@ -393,17 +360,75 @@ selected = 0
 [node name="TLabel3" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_top = 57.0
+margin_top = 29.0
 margin_right = 148.0
-margin_bottom = 71.0
+margin_bottom = 43.0
 text = "Single Portrait Mode"
 text_key = "Single Portrait Mode"
 
 [node name="SinglePortraitModeCheckBox" type="CheckBox" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer"]
 margin_left = 158.0
+margin_top = 24.0
+margin_right = 232.0
+margin_bottom = 48.0
+
+[node name="TLabel" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer" instance=ExtResource( 8 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 57.0
+margin_right = 148.0
+margin_bottom = 71.0
+text = "Speed (bigger = slower)"
+text_key = "Speed (bigger = slower)"
+
+[node name="TextSpeed" type="SpinBox" parent="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer"]
+margin_left = 158.0
 margin_top = 52.0
 margin_right = 232.0
 margin_bottom = 76.0
+max_value = 10.0
+step = 0.01
+value = 2.0
+
+[node name="Autopauses" parent="VBoxContainer/TabContainer/Dialog Text/Column3" instance=ExtResource( 3 )]
+margin_top = 106.0
+margin_bottom = 128.0
+text = "Autopauses"
+text_key = "Autopauses"
+
+[node name="AutoPauses" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column3"]
+margin_top = 132.0
+margin_right = 270.0
+margin_bottom = 152.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Labels" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses"]
+margin_right = 270.0
+margin_bottom = 20.0
+
+[node name="Label" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
+margin_top = 3.0
+margin_right = 160.0
+margin_bottom = 17.0
+rect_min_size = Vector2( 160, 0 )
+text = "Symbol"
+
+[node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
+margin_left = 164.0
+margin_top = 3.0
+margin_right = 254.0
+margin_bottom = 17.0
+rect_min_size = Vector2( 60, 0 )
+size_flags_horizontal = 3
+text = "Duration"
+
+[node name="NewButton" type="Button" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
+margin_left = 258.0
+margin_right = 270.0
+margin_bottom = 20.0
+flat = true
 
 [node name="Dialog Box" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
@@ -591,8 +616,8 @@ margin_top = 56.0
 margin_right = 266.0
 margin_bottom = 78.0
 text = "Top Left"
-icon = SubResource( 6 )
-items = [ "Top Left", SubResource( 8 ), false, 0, null, "Top Center", SubResource( 8 ), false, 1, null, "Top Right", SubResource( 8 ), false, 2, null, "", null, false, -1, null, "Center Left", SubResource( 8 ), false, 3, null, "Center", SubResource( 8 ), false, 4, null, "Center Right", SubResource( 8 ), false, 5, null, "", null, false, -1, null, "Bottom Left", SubResource( 8 ), false, 6, null, "Bottom Center", SubResource( 8 ), false, 7, null, "Bottom Right", SubResource( 8 ), false, 8, null ]
+icon = SubResource( 10 )
+items = [ "Top Left", SubResource( 10 ), false, 0, null, "Top Center", SubResource( 10 ), false, 1, null, "Top Right", SubResource( 10 ), false, 2, null, "", null, false, 3, null, "Center Left", SubResource( 10 ), false, 3, null, "Center", SubResource( 10 ), false, 4, null, "Center Right", SubResource( 10 ), false, 5, null, "", null, false, 7, null, "Bottom Left", SubResource( 10 ), false, 6, null, "Bottom Center", SubResource( 10 ), false, 7, null, "Bottom Right", SubResource( 10 ), false, 8, null ]
 selected = 0
 __meta__ = {
 "_edit_use_anchors_": false
@@ -890,7 +915,7 @@ margin_left = 130.0
 margin_right = 158.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1390,8 +1415,8 @@ margin_right = 309.0
 margin_bottom = 130.0
 size_flags_horizontal = 3
 text = "Top Left"
-icon = SubResource( 6 )
-items = [ "Top Left", SubResource( 8 ), false, 0, null, "Top Center", SubResource( 8 ), false, 1, null, "Top Right", SubResource( 8 ), false, 2, null, "", null, false, -1, null, "Center Left", SubResource( 8 ), false, 3, null, "Center", SubResource( 8 ), false, 4, null, "Center Right", SubResource( 8 ), false, 5, null, "", null, false, -1, null, "Bottom Left", SubResource( 8 ), false, 6, null, "Bottom Center", SubResource( 8 ), false, 7, null, "Bottom Right", SubResource( 8 ), false, 8, null ]
+icon = SubResource( 10 )
+items = [ "Top Left", SubResource( 10 ), false, 0, null, "Top Center", SubResource( 10 ), false, 1, null, "Top Right", SubResource( 10 ), false, 2, null, "", null, false, 3, null, "Center Left", SubResource( 10 ), false, 3, null, "Center", SubResource( 10 ), false, 4, null, "Center Right", SubResource( 10 ), false, 5, null, "", null, false, 7, null, "Bottom Left", SubResource( 10 ), false, 6, null, "Bottom Center", SubResource( 10 ), false, 7, null, "Bottom Right", SubResource( 10 ), false, 8, null ]
 selected = 0
 
 [node name="TLabel6" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer" instance=ExtResource( 8 )]
@@ -1492,7 +1517,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Glossary"]
 margin_left = 280.0
@@ -1544,7 +1569,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1591,7 +1616,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel4" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1638,7 +1663,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 8 )
+icon = SubResource( 10 )
 
 [node name="TLabel6" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://addons/dialogic/Images/Plugin/plugin-editor-icon-light-theme.svg" type="Texture" id=1]
 [ext_resource path="res://addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd" type="Script" id=2]
@@ -18,10 +18,25 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id=10]
+[sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
 image = SubResource( 11 )
+size = Vector2( 16, 16 )
+
+[sub_resource type="Image" id=12]
+data = {
+"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+"format": "LumAlpha8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id=10]
+flags = 4
+flags = 4
+image = SubResource( 12 )
 size = Vector2( 16, 16 )
 
 [node name="ThemeEditor" type="ScrollContainer"]
@@ -143,7 +158,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -173,7 +188,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel3" parent="VBoxContainer/TabContainer/Dialog Text/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -203,7 +218,7 @@ margin_left = 122.0
 margin_right = 150.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Dialog Text"]
 margin_left = 280.0
@@ -399,35 +414,36 @@ text_key = "Autopauses"
 [node name="AutoPauses" type="VBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column3"]
 margin_top = 132.0
 margin_right = 270.0
-margin_bottom = 152.0
+margin_bottom = 154.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Labels" type="HBoxContainer" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses"]
 margin_right = 270.0
-margin_bottom = 20.0
+margin_bottom = 22.0
 
 [node name="Label" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
-margin_top = 3.0
+margin_top = 4.0
 margin_right = 160.0
-margin_bottom = 17.0
+margin_bottom = 18.0
 rect_min_size = Vector2( 160, 0 )
 text = "Symbol"
 
 [node name="Label2" type="Label" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
 margin_left = 164.0
-margin_top = 3.0
-margin_right = 254.0
-margin_bottom = 17.0
+margin_top = 4.0
+margin_right = 238.0
+margin_bottom = 18.0
 rect_min_size = Vector2( 60, 0 )
 size_flags_horizontal = 3
 text = "Duration"
 
 [node name="NewButton" type="Button" parent="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses/Labels"]
-margin_left = 258.0
+margin_left = 242.0
 margin_right = 270.0
-margin_bottom = 20.0
+margin_bottom = 22.0
+icon = SubResource( 2 )
 flat = true
 
 [node name="Dialog Box" type="HBoxContainer" parent="VBoxContainer/TabContainer"]
@@ -617,7 +633,7 @@ margin_right = 266.0
 margin_bottom = 78.0
 text = "Top Left"
 icon = SubResource( 10 )
-items = [ "Top Left", SubResource( 10 ), false, 0, null, "Top Center", SubResource( 10 ), false, 1, null, "Top Right", SubResource( 10 ), false, 2, null, "", null, false, 3, null, "Center Left", SubResource( 10 ), false, 3, null, "Center", SubResource( 10 ), false, 4, null, "Center Right", SubResource( 10 ), false, 5, null, "", null, false, 7, null, "Bottom Left", SubResource( 10 ), false, 6, null, "Bottom Center", SubResource( 10 ), false, 7, null, "Bottom Right", SubResource( 10 ), false, 8, null ]
+items = [ "Top Left", SubResource( 2 ), false, 0, null, "Top Center", SubResource( 2 ), false, 1, null, "Top Right", SubResource( 2 ), false, 2, null, "", null, false, -1, null, "Center Left", SubResource( 2 ), false, 3, null, "Center", SubResource( 2 ), false, 4, null, "Center Right", SubResource( 2 ), false, 5, null, "", null, false, -1, null, "Bottom Left", SubResource( 2 ), false, 6, null, "Bottom Center", SubResource( 2 ), false, 7, null, "Bottom Right", SubResource( 2 ), false, 8, null ]
 selected = 0
 __meta__ = {
 "_edit_use_anchors_": false
@@ -915,7 +931,7 @@ margin_left = 130.0
 margin_right = 158.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Name Label/Column/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1416,7 +1432,7 @@ margin_bottom = 130.0
 size_flags_horizontal = 3
 text = "Top Left"
 icon = SubResource( 10 )
-items = [ "Top Left", SubResource( 10 ), false, 0, null, "Top Center", SubResource( 10 ), false, 1, null, "Top Right", SubResource( 10 ), false, 2, null, "", null, false, 3, null, "Center Left", SubResource( 10 ), false, 3, null, "Center", SubResource( 10 ), false, 4, null, "Center Right", SubResource( 10 ), false, 5, null, "", null, false, 7, null, "Bottom Left", SubResource( 10 ), false, 6, null, "Bottom Center", SubResource( 10 ), false, 7, null, "Bottom Right", SubResource( 10 ), false, 8, null ]
+items = [ "Top Left", SubResource( 2 ), false, 0, null, "Top Center", SubResource( 2 ), false, 1, null, "Top Right", SubResource( 2 ), false, 2, null, "", null, false, -1, null, "Center Left", SubResource( 2 ), false, 3, null, "Center", SubResource( 2 ), false, 4, null, "Center Right", SubResource( 2 ), false, 5, null, "", null, false, -1, null, "Bottom Left", SubResource( 2 ), false, 6, null, "Bottom Center", SubResource( 2 ), false, 7, null, "Bottom Right", SubResource( 2 ), false, 8, null ]
 selected = 0
 
 [node name="TLabel6" parent="VBoxContainer/TabContainer/Choice Buttons/Column2/GridContainer" instance=ExtResource( 8 )]
@@ -1517,7 +1533,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="VSeparator" type="VSeparator" parent="VBoxContainer/TabContainer/Glossary"]
 margin_left = 280.0
@@ -1569,7 +1585,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel2" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1616,7 +1632,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel4" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1663,7 +1679,7 @@ margin_left = 90.0
 margin_right = 118.0
 margin_bottom = 22.0
 size_flags_vertical = 4
-icon = SubResource( 10 )
+icon = SubResource( 2 )
 
 [node name="TLabel6" parent="VBoxContainer/TabContainer/Glossary/Column3/GridContainer" instance=ExtResource( 8 )]
 anchor_right = 0.0
@@ -1862,6 +1878,7 @@ one_shot = true
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer/HBoxContainer/ShadowOffsetX" to="." method="_on_ShadowOffset_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/TabContainer/Dialog Text/Column2/GridContainer/HBoxContainer/ShadowOffsetY" to="." method="_on_ShadowOffset_value_changed"]
 [connection signal="item_selected" from="VBoxContainer/TabContainer/Dialog Text/Column3/GridContainer/HBoxContainer3/Alignment" to="." method="_on_Alignment_item_selected"]
+[connection signal="resized" from="VBoxContainer/TabContainer/Dialog Text/Column3/AutoPauses" to="." method="_on_Autopause_data_changed"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer2/ColorPickerButton" to="." method="_on_BackgroundColor_ColorPickerButton_color_changed"]
 [connection signal="pressed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer3/BackgroundTextureButton" to="." method="_on_BackgroundTextureButton_pressed"]
 [connection signal="color_changed" from="VBoxContainer/TabContainer/Dialog Box/Column/GridContainer/HBoxContainer6/ColorPickerButton" to="." method="_on_ColorPicker_Background_texture_modulation_color_changed"]

--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -52,11 +52,12 @@ func update_text(text:String):
 		text_bbcodefree = text_bbcodefree.replace(result.get_string(), "")
 	
 	#### INSERTING AUTO-PAUSES
-	print(autopauses)
 	for i in autopauses:
 		if i[0]:
-			text_bbcodefree = text_bbcodefree.replace(i[0], i[0]+'[pause='+str(i[1])+']')
-	print(text_bbcodefree)
+			for character in i[0]:
+				text_bbcodefree = text_bbcodefree.replace(character, character+'[pause='+str(i[1])+']')
+	
+	
 	#regex moved from func scope to class scope
 	#regex compilation moved to _ready
 	#  - KvaGram
@@ -86,12 +87,11 @@ func update_text(text:String):
 			pass
 		else:
 			#Store an assigned varible command as an array by 0 index in text, 1 command-name, 2 argument
-			commands.append([result.get_start()-1, result.get_string(2), result.get_string(3)])
+			commands.append([result.get_start(), result.get_string(2), result.get_string(3)])
 		text_bbcodefree = text_bbcodefree.substr(0, result.get_start()) + text_bbcodefree.substr(result.get_end())
 		text = text.replace(result.get_string(), "")
 		
 		result = regex.search(text_bbcodefree)
-	
 
 	# Updating the text and starting the animation from 0
 	text_label.bbcode_text = text

--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -3,6 +3,7 @@ extends Control
 
 var text_speed := 0.02 # Higher = lower speed
 var theme_text_speed = text_speed
+var autopauses
 
 #experimental database of current commands
 var commands = []
@@ -42,6 +43,14 @@ func update_name(name: String, color: Color = Color.white, autocolor: bool=false
 
 
 func update_text(text:String):
+	#### INSERTING AUTO-PAUSES
+	print(autopauses)
+	for i in autopauses:
+		if i[0]:
+			for character in i[0]:
+				print(character)
+				text = text.replace(character, character+'[pause='+str(i[1])+']')
+	print(text)
 	#regex moved from func scope to class scope
 	#regex compilation moved to _ready
 	#  - KvaGram
@@ -143,6 +152,8 @@ func load_theme(theme: ConfigFile):
 	# Text speed
 	text_speed = theme.get_value('text','speed', 2) * 0.01
 	theme_text_speed = text_speed
+	
+	autopauses = theme.get_value('text', 'autopauses', [])
 
 	# Margin
 	var text_margin = theme.get_value('text', 'margin', Vector2(20, 10))

--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -55,10 +55,8 @@ func update_text(text:String):
 	print(autopauses)
 	for i in autopauses:
 		if i[0]:
-			for character in i[0]:
-				print(character)
-				text = text.replace(character, character+'[pause='+str(i[1])+']')
-	print(text)
+			text_bbcodefree = text_bbcodefree.replace(i[0], i[0]+'[pause='+str(i[1])+']')
+	print(text_bbcodefree)
 	#regex moved from func scope to class scope
 	#regex compilation moved to _ready
 	#  - KvaGram

--- a/addons/dialogic/Nodes/TextBubble.tscn
+++ b/addons/dialogic/Nodes/TextBubble.tscn
@@ -44,9 +44,9 @@ tracks/0/keys = {
 }
 
 [sub_resource type="StyleBoxFlat" id=6]
-content_margin_left = 20.0
-content_margin_right = 20.0
-content_margin_bottom = -200.0
+content_margin_left = 10.0
+content_margin_right = 10.0
+content_margin_bottom = 0.0
 bg_color = Color( 1, 1, 1, 0 )
 expand_margin_left = 10.0
 


### PR DESCRIPTION
The theme menu has now a section called Autopauses, where you can add a unlimited number of special strings (e.g. ".", ",","?","!"). 
Not well explained in the editor yet, but it actually only cares for single characters, so you can add all of these in one field if you want all of them to have the same pause duration.

A known problem right now is, that adding the "." string breakes all other commands that include a dot (like [pause=0.5] or [play=mysound.wav])