### PR TITLE
closes #657 build error for DialogSharp.cs

### DIFF
--- a/addons/dialogic/Other/DialogicSharp.cs
+++ b/addons/dialogic/Other/DialogicSharp.cs
@@ -13,7 +13,7 @@ public static class DialogicSharp
     return Start<Node>(timeline, default_timeline, DEFAULT_DIALOG_RESOURCE, useCanvasInstead);
   }
 
-  public static T Start<T>(String timeline = "", String default_timeline = "", String dialogScenePath, bool useCanvasInstead = true) where T : class
+  public static T Start<T>(String timeline = "", String default_timeline = "", String dialogScenePath = "", bool useCanvasInstead = true) where T : class
   {
     return (T)_dialogic.Call("start", timeline, default_timeline, dialogScenePath, useCanvasInstead);
   }


### PR DESCRIPTION
When building a Godot Mono 3.4 project using the library a build error
occurs:

`\addons\dialogic\Other\DialogicSharp.cs(16,102): Optional parameters
must appear after all required parameters`

Made set a default parameter for `dialogScenePath` so that ordering
rules for C# are respected and the library builds when used in a
project.

See C# documentation for more details:

https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/named-and-optional-arguments