### PR TITLE
added better Events navigation in docs.

### DIFF
--- a/addons/dialogic/Documentation/Content/Events/000.md
+++ b/addons/dialogic/Documentation/Content/Events/000.md
@@ -40,3 +40,7 @@ After the event containing the *speed* tag is passed, it will go back to whateve
 
 ## Voice Line Support
 You can find a tutorial on how to use the voice line feature in the tutorials folder!
+
+---------------------------------------
+#### Previous: N/A
+#### Next: [Character Join](./001)

--- a/addons/dialogic/Documentation/Content/Events/001.md
+++ b/addons/dialogic/Documentation/Content/Events/001.md
@@ -16,3 +16,7 @@ The current 5 positions are the only ones available at the moment, but more cust
 TODO: Mirror icon image and same portrait both regular and mirrored
 
 By clicking on this icon, you can mirror the current character's portrait.
+
+---------------------------------------
+#### Previous: [Text Event](./000)
+#### Next: [Character Leave](./002)

--- a/addons/dialogic/Documentation/Content/Events/002.md
+++ b/addons/dialogic/Documentation/Content/Events/002.md
@@ -4,3 +4,7 @@
 This events causes character portraits that previously joined with the [Character Join Event](./001.md) to leave the screen.
 
 You can choose to make all joined characters leave or choose one. If that character isn't on screen, the event will be ignored.
+
+---------------------------------------
+#### Previous: [Character Join](./001)
+#### Next: [Question Event](./010)

--- a/addons/dialogic/Documentation/Content/Events/010.md
+++ b/addons/dialogic/Documentation/Content/Events/010.md
@@ -12,3 +12,7 @@ To add choices to your question you can add [Choice Events](./011.md).
 
 ## Ending a question
 After all your choices, there also needs to be an [End Event](./013.md).
+
+---------------------------------------
+#### Previous: [Character Leave](./002)
+#### Next: [Choice Event](./011)

--- a/addons/dialogic/Documentation/Content/Events/011.md
+++ b/addons/dialogic/Documentation/Content/Events/011.md
@@ -9,3 +9,7 @@ Choice Events only work if they are placed inside a "question" ([Question Event]
 ## Adding a condition
 By checking the `Has condition` check box and setting that condition, the player will only see that choice if the result is true.
 The condition is made up of three parts: The `Value Definition` that will be compared, the `type of comparison` and the `value` that it will be compared to.
+
+---------------------------------------
+#### Previous: [Question Event](./010)
+#### Next: [Condition Event](./012)

--- a/addons/dialogic/Documentation/Content/Events/012.md
+++ b/addons/dialogic/Documentation/Content/Events/012.md
@@ -20,3 +20,7 @@ Every condition needs to have an [End Event](./013.md). After that event, all fo
 When creating a Condition Event a End Event will be added too.
 
 *Note: You can of course have conditions inside conditions. Just make sure to have the same amount of End Events*
+
+---------------------------------------
+#### Previous: [Choice Event](./011)
+#### Next: [End Event](./013)

--- a/addons/dialogic/Documentation/Content/Events/013.md
+++ b/addons/dialogic/Documentation/Content/Events/013.md
@@ -1,3 +1,7 @@
 # End Event
 
 This event adds itself when you add its parent event. Its only function is to mark the end of a [question](./010.md) or [condition](./012.md).
+
+---------------------------------------
+#### Previous: [Condition Event](./012)
+#### Next: [Set Value](./014)

--- a/addons/dialogic/Documentation/Content/Events/014.md
+++ b/addons/dialogic/Documentation/Content/Events/014.md
@@ -9,3 +9,7 @@ You can select the `value definition` to be changed, then the `type of change`. 
 
 By toggling the little cube icon, you can use a random number instead of the fixed input field.
 ![image](./Images/Event_Set_Value_random.PNG)
+
+---------------------------------------
+#### Previous: [End Event](./013)
+#### Next: [Audio Events](./030)

--- a/addons/dialogic/Documentation/Content/Events/030.md
+++ b/addons/dialogic/Documentation/Content/Events/030.md
@@ -19,3 +19,7 @@ To solve this:
 2. Go to the import tab (it's next to the scene tree tab by default)
 3. Uncheck the loop checkbox.
 4. Hit re-import.
+
+---------------------------------------
+#### Previous: [Set Value](./014)
+#### Next: [Emit Signal](./040)

--- a/addons/dialogic/Documentation/Content/Events/040.md
+++ b/addons/dialogic/Documentation/Content/Events/040.md
@@ -21,3 +21,7 @@ func dialog_listener(string):
 If you instanced the scene using the editor, you can connect the signal like normal in Godot from the `NODE TAB > Signals`.
 
 *If you don't know about signals you should definitely learn about them. For example [here](https://docs.godotengine.org/en/stable/getting_started/step_by_step/signals.html).*
+
+---------------------------------------
+#### Previous: [Audio Events](./030)
+#### Next: [Change Scene](./041)

--- a/addons/dialogic/Documentation/Content/Events/041.md
+++ b/addons/dialogic/Documentation/Content/Events/041.md
@@ -3,3 +3,7 @@
 The `Change Scene` event will stop the current scene and load the selected one. This means the dialogue will be stopped too. 
 
 Be careful when using this while you your tree is set to paused! Consider adding an [Emit Signal event](./040.md) before and resume the tree with `get_tree().paused = false`.
+
+---------------------------------------
+#### Previous: [Emit Signal](./040)
+#### Next: [Call Node](./042)

--- a/addons/dialogic/Documentation/Content/Events/042.md
+++ b/addons/dialogic/Documentation/Content/Events/042.md
@@ -29,3 +29,7 @@ But we want to call a function in the Temple scene with our Call Node Event. Fro
 
 #### Using the name of an autoload
 If you use an autoload instead, it's wonderfully easy. You can just use the name of the autoload!
+
+---------------------------------------
+#### Previous: [Change Scene](./041)
+#### Next: N/A


### PR DESCRIPTION
Whilst reading the Help docs in Godot it was annoying to have to click back to help every time I wanted to go to a new event. 
example mp4 

https://user-images.githubusercontent.com/53924507/145822684-ef7a3c5e-f951-4c15-9dd7-77864a88cdaa.mp4


All I did was add links to the previous and next events in the list.


See my mp4 for it in action.

https://user-images.githubusercontent.com/53924507/145822362-54f96945-94a8-4ccb-b766-c24d5eb97308.mp4




