### PR TITLE
Add translation preview

### DIFF
--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -91,6 +91,10 @@ func _ready():
 		$ToolBar/Version.text = 'Dialogic v' + version_string
 		
 	$MainPanel/MasterTreeContainer/FilterMasterTreeEdit.right_icon = get_icon("Search", "EditorIcons")
+	
+	# Serialize the translations file if translation preview is enabled
+	if DialogicResources.get_settings_config().get_value('dialog', 'translations_preview'):
+		DialogicResources.serialize_translations()
 
 
 func on_master_tree_editor_selected(editor: String):

--- a/addons/dialogic/Editor/Events/Parts/Logic/ChoicePicker.tscn
+++ b/addons/dialogic/Editor/Events/Parts/Logic/ChoicePicker.tscn
@@ -36,7 +36,14 @@ margin_right = 76.0
 margin_bottom = 27.0
 rect_min_size = Vector2( 10, 0 )
 
-[node name="ConditionPicker" parent="." instance=ExtResource( 1 )]
+[node name="Preview" type="LineEdit" parent="HBox"]
 margin_left = 80.0
-margin_right = 202.0
-margin_bottom = 27.0
+margin_right = 138.0
+margin_bottom = 30.0
+editable = false
+expand_to_text_length = true
+
+[node name="ConditionPicker" parent="." instance=ExtResource( 1 )]
+margin_left = 142.0
+margin_right = 564.0
+margin_bottom = 30.0

--- a/addons/dialogic/Editor/Events/Parts/Logic/EventPart_ChoicePicker.gd
+++ b/addons/dialogic/Editor/Events/Parts/Logic/EventPart_ChoicePicker.gd
@@ -5,6 +5,7 @@ extends "res://addons/dialogic/Editor/Events/Parts/EventPart.gd"
 
 ## node references
 onready var input_field = $HBox/ChoiceText
+onready var preview_field = $HBox/Preview
 onready var condition_picker = $ConditionPicker
 
 # used to connect the signals
@@ -26,17 +27,32 @@ func load_data(data:Dictionary):
 	# Loading the data on the selectors
 	condition_picker.load_data(event_data)
 	
+	# Show the preview field if the option is enabled
+	var config = DialogicResources.get_settings_config()
+	preview_field.visible = config.get_value('dialog', 'translations_preview')
+	update_preview(input_field.text)
+	
 
 # has to return the wanted preview, only useful for body parts
 func get_preview():
 	return ''
 
 
+func update_preview(text: String):
+	preview_field.text = DialogicResources.translate(text)
+
+
 func _on_ChoiceText_text_changed(text):
 	event_data['choice'] = text
 	
+	# Update the preview field if the option is enabled
+	var config = DialogicResources.get_settings_config()
+	if config.get_value('dialog', 'translations_preview'):
+		update_preview(text)
+	
 	# informs the parent about the changes!
 	data_changed()
+	
 
 func _on_ConditionPicker_data_changed(data):
 	event_data = data

--- a/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextAndVoicePicker.gd
+++ b/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextAndVoicePicker.gd
@@ -41,7 +41,7 @@ func _on_text_editor_data_changed(data) -> void:
 
 
 func update_voices_lines():
-	var text = text_editor.get_child(1).text
+	var text = text_editor.get_child(1).get_child(0).text
 	voice_editor._on_text_changed(text)
 
 

--- a/addons/dialogic/Editor/Events/Parts/Text/TextEditor.tscn
+++ b/addons/dialogic/Editor/Events/Parts/Text/TextEditor.tscn
@@ -43,10 +43,14 @@ margin_right = 46.0
 margin_bottom = 40.0
 rect_min_size = Vector2( 46, 0 )
 
-[node name="TextEdit" type="TextEdit" parent="."]
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_left = 50.0
 margin_right = 67.0
-margin_bottom = 40.0
+margin_bottom = 80.0
+
+[node name="TextEdit" type="TextEdit" parent="VBoxContainer"]
+margin_right = 17.0
+margin_bottom = 38.0
 size_flags_vertical = 3
 custom_colors/member_variable_color = Color( 0, 0, 0, 1 )
 custom_colors/function_color = Color( 0, 0, 0, 1 )
@@ -59,4 +63,20 @@ syntax_highlighting = true
 smooth_scrolling = true
 wrap_enabled = true
 
-[connection signal="focus_exited" from="TextEdit" to="." method="_on_TextEdit_focus_exited"]
+[node name="Preview" type="TextEdit" parent="VBoxContainer"]
+margin_top = 42.0
+margin_right = 17.0
+margin_bottom = 80.0
+size_flags_vertical = 3
+custom_styles/focus = SubResource( 3 )
+custom_styles/normal = SubResource( 2 )
+custom_colors/member_variable_color = Color( 0, 0, 0, 1 )
+custom_colors/function_color = Color( 0, 0, 0, 1 )
+custom_colors/symbol_color = Color( 0, 0, 0, 1 )
+custom_colors/font_color = Color( 1, 1, 1, 1 )
+custom_colors/number_color = Color( 0, 0, 0, 1 )
+readonly = true
+smooth_scrolling = true
+wrap_enabled = true
+
+[connection signal="focus_exited" from="VBoxContainer/TextEdit" to="." method="_on_TextEdit_focus_exited"]

--- a/addons/dialogic/Editor/GlossaryEntryEditor/GlossaryEntryEditor.gd
+++ b/addons/dialogic/Editor/GlossaryEntryEditor/GlossaryEntryEditor.gd
@@ -11,6 +11,10 @@ onready var nodes = {
 	'extra_title': $VBoxContainer/HBoxContainer/ExtraInfo/Title,
 	'extra_text': $VBoxContainer/HBoxContainer/ExtraInfo/Text,
 	'extra_extra': $VBoxContainer/HBoxContainer/ExtraInfo/Extra,
+	'preview_editor': $VBoxContainer/HBoxContainer/ExtraInfoPreview,
+	'preview_title': $VBoxContainer/HBoxContainer/ExtraInfoPreview/Title,
+	'preview_text': $VBoxContainer/HBoxContainer/ExtraInfoPreview/Text,
+	'preview_extra': $VBoxContainer/HBoxContainer/ExtraInfoPreview/Extra
 }
 
 func _ready():
@@ -32,6 +36,17 @@ func load_definition(id):
 	nodes['extra_title'].text = current_definition['title']
 	nodes['extra_text'].text = current_definition['text']
 	nodes['extra_extra'].text = current_definition['extra']
+	
+	# Show the preview fields if the option is enabled
+	var config = DialogicResources.get_settings_config()
+	var is_preview_enabled = config.get_value('dialog', 'translations_preview')
+	nodes['preview_editor'].visible = is_preview_enabled
+	
+	# Update the preview fields if the option is enabled
+	if config.get_value('dialog', 'translations_preview'):
+		update_preview('preview_title', nodes['extra_title'].text)
+		update_preview('preview_text', nodes['extra_text'].text)
+		update_preview('preview_extra', nodes['extra_extra'].text)
 	
 
 func reset_editor():
@@ -69,3 +84,25 @@ func create_glossary_entry() -> String:
 func save_definition():
 	if current_definition != null and current_definition['id'] != '':
 		DialogicResources.set_default_definition_glossary(current_definition['id'], nodes['name'].text, nodes['extra_title'].text, nodes['extra_text'].text, nodes['extra_extra'].text)
+
+
+func _on_Title_text_changed(new_text: String) -> void:
+	# Update the preview field if the option is enabled
+	update_preview('preview_title', new_text)
+
+func _on_Text_text_changed() -> void:
+	# Update the preview field if the option is enabled
+	var new_text = nodes['extra_text'].text
+	update_preview('preview_text', new_text)
+
+
+func _on_Extra_text_changed(new_text: String) -> void:
+	# Update the preview field if the option is enabled
+	update_preview('preview_extra', new_text)
+
+
+func update_preview(node: String, text: String):
+	var config = DialogicResources.get_settings_config()
+	if config.get_value('dialog', 'translations_preview'):
+		nodes[node].text = DialogicResources.translate(text)
+	

--- a/addons/dialogic/Editor/GlossaryEntryEditor/GlossaryEntryEditor.tscn
+++ b/addons/dialogic/Editor/GlossaryEntryEditor/GlossaryEntryEditor.tscn
@@ -74,3 +74,49 @@ margin_top = 206.0
 margin_right = 300.0
 margin_bottom = 230.0
 placeholder_text = "Extra"
+
+[node name="ExtraInfoPreview" type="VBoxContainer" parent="VBoxContainer/HBoxContainer"]
+margin_left = 632.0
+margin_right = 932.0
+margin_bottom = 230.0
+rect_min_size = Vector2( 300, 0 )
+
+[node name="RichTextLabel2" type="Label" parent="VBoxContainer/HBoxContainer/ExtraInfoPreview"]
+margin_right = 300.0
+margin_bottom = 31.0
+text = "Preview:
+"
+autowrap = true
+
+[node name="Control" type="Control" parent="VBoxContainer/HBoxContainer/ExtraInfoPreview"]
+margin_top = 35.0
+margin_right = 300.0
+margin_bottom = 70.0
+rect_min_size = Vector2( 0, 35 )
+
+[node name="Title" type="LineEdit" parent="VBoxContainer/HBoxContainer/ExtraInfoPreview"]
+margin_top = 74.0
+margin_right = 300.0
+margin_bottom = 98.0
+editable = false
+placeholder_text = "Title"
+
+[node name="Text" type="TextEdit" parent="VBoxContainer/HBoxContainer/ExtraInfoPreview"]
+margin_top = 102.0
+margin_right = 300.0
+margin_bottom = 202.0
+rect_min_size = Vector2( 0, 100 )
+size_flags_vertical = 3
+readonly = true
+wrap_enabled = true
+
+[node name="Extra" type="LineEdit" parent="VBoxContainer/HBoxContainer/ExtraInfoPreview"]
+margin_top = 206.0
+margin_right = 300.0
+margin_bottom = 230.0
+editable = false
+placeholder_text = "Extra"
+
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/ExtraInfo/Title" to="." method="_on_Title_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/ExtraInfo/Text" to="." method="_on_Text_text_changed"]
+[connection signal="text_changed" from="VBoxContainer/HBoxContainer/ExtraInfo/Extra" to="." method="_on_Extra_text_changed"]

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -10,6 +10,12 @@ onready var nodes = {
 	
 	# Dialog
 	'text_event_audio_default_bus' : $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus/AudioBus,
+	'translations': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/SettingsCheckbox7/CheckBox,
+	'translations_preview': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer8/PreviewTranslations/CheckBox,
+	'translations_preview_file': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer8/TranslationFileButton,
+	
+	# Save
+	'autosave': $VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3/SettingsCheckbox8/CheckBox,
 
 	# Input Settings
 	'delay_after_options': $VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer/LineEdit,
@@ -42,6 +48,22 @@ var INPUT_KEYS := [
 	'choice_hotkey_4',
 	]
 
+var DIALOG_KEYS := [
+	'translations',
+	'translations_preview',
+	'translations_preview_file',
+	'new_lines', 
+	'remove_empty_messages',
+	'auto_color_names',
+	'propagate_input',
+	'dim_characters',
+	'text_event_audio_enable',
+	]
+
+var SAVING_KEYS := [
+	'autosave', 
+	]
+
 func _ready():
 	editor_reference = find_parent('EditorView')
 	update_bus_selector()
@@ -52,7 +74,10 @@ func _ready():
 	nodes['themes'].connect('item_selected', self, '_on_default_theme_selected')
 	# TODO move to theme section later
 	nodes['canvas_layer'].connect('text_changed', self, '_on_canvas_layer_text_changed')
-
+	
+	# Dialog
+	nodes['translations_preview'].connect('pressed', self, '_on_PreviewTranslations_pressed')
+	
 	# Input
 	nodes['delay_after_options'].connect('text_changed', self, '_on_delay_options_text_changed')
 	nodes['default_action_key'].connect('pressed', self, '_on_default_action_key_presssed')
@@ -87,6 +112,7 @@ func update_data():
 	refresh_themes(settings)
 	load_values(settings, "input", INPUT_KEYS)
 	select_bus(settings.get_value("dialog", 'text_event_audio_default_bus', "Master"))
+	nodes["translations_preview_file"].disabled = not nodes["translations_preview"].pressed
 
 
 func load_values(settings: ConfigFile, section: String, key: Array):
@@ -95,6 +121,8 @@ func load_values(settings: ConfigFile, section: String, key: Array):
 			if nodes[k] is LineEdit:
 				nodes[k].text = settings.get_value(section, k)
 			elif nodes[k] is OptionButton:
+				nodes[k].text = settings.get_value(section, k)
+			elif k in ['translations_preview_file']:
 				nodes[k].text = settings.get_value(section, k)
 			else:
 				nodes[k].pressed = settings.get_value(section, k, false)
@@ -185,6 +213,22 @@ func select_bus(text):
 func _on_text_audio_default_bus_item_selected(index):
 	var text = nodes['text_event_audio_default_bus'].get_item_text(index)
 	set_value('dialog', 'text_event_audio_default_bus', text)
+
+func _on_PreviewTranslations_pressed() -> void:
+	nodes["translations_preview_file"].disabled = not nodes["translations_preview"].pressed
+
+
+func _on_TranslationFileButton_pressed() -> void:
+	editor_reference.godot_dialog("*.csv")
+	editor_reference.godot_dialog_connect(self, "_on_translation_file_selected")
+
+
+func _on_translation_file_selected(path, target) -> void:
+	nodes["translations_preview_file"].text = path
+	
+	set_value('dialog', 'translations_preview_file', path)
+	
+	DialogicResources.serialize_translations()
 
 
 ################################################################################

--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -223,6 +223,27 @@ text = "Inputs for text events will be treated as keys for tr()"
 settings_section = "dialog"
 settings_key = "translations"
 
+[node name="HBoxContainer8" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
+margin_top = 302.0
+margin_right = 356.0
+margin_bottom = 326.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="PreviewTranslations" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer8" instance=ExtResource( 4 )]
+margin_right = 215.0
+margin_bottom = 24.0
+text = "Preview translations in editor"
+settings_section = "dialog"
+settings_key = "translations_preview"
+
+[node name="TranslationFileButton" type="Button" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer8"]
+margin_left = 219.0
+margin_right = 300.0
+margin_bottom = 24.0
+text = "Choose translation file..."
+
 [node name="VBoxContainer3" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 400.0
 margin_right = 356.0
@@ -537,3 +558,5 @@ text = "Cancel"
 margin_top = 312.0
 margin_right = 304.0
 margin_bottom = 312.0
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/HBoxContainer8/TranslationFileButton" to="." method="_on_TranslationFileButton_pressed"]


### PR DESCRIPTION
As per #343:
This adds the possibility to preview the translations when using localisation keys for text events, choices, and glossary entries.

![image](https://user-images.githubusercontent.com/3739611/145892834-1aa62711-57b9-446c-98d1-43843eab09b9.png)
![image](https://user-images.githubusercontent.com/3739611/145892895-8df005ce-f781-4675-a8bf-0ffeef7828b2.png)

Main changes/features:
 - A new setting is added to tell Dialogic where the translation CSV file is located
 - This file is converted into a more optimized JSON
 - On load, this JSON is loaded as a dictionary and is used for returning the proper translations.
 - Each text illegible text field now has a duplicate field for the preview; it is readonly.
 - The preview is updated on each field update
 - If the key is not found, it is returned as is -- similar to tr().

I've tried to re-use the existing code as much as possible; hopefully this should fit the current conventions of the project.