### PR TITLE
Fix TextBubble BBCode/Tag Regex

### DIFF
--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -317,5 +317,4 @@ func _ready():
 	text_label.meta_underlined = false
 	regex.compile("\\[(nw|(nw|speed|signal|play|pause)=(.+?))\\](.*?)")
 	
-	bbcoderemoverregex.compile("\\[\\/*(b|i|u|s|code|center|right|fill|indent|url|img|font|color|table|cell|wave|tornado|shake|fade|rainbow)[^]]*\\]")
-
+	bbcoderemoverregex.compile("\\[\\/*((b|i|u|s)|(code|center|right|fill|indent|url|img|font|color|table|cell|wave|tornado|shake|fade|rainbow)[^]]*)\\]")


### PR DESCRIPTION
Know that whenever you made a regex that looks like it works: 
-> IT DOESN'T

You can be sure that there is something you missed.

The s in the beginning of speed and signal where picked up as a [s] (strikethrough) tag from bbcode (which get's removed before checking for the dialogic tags. So it didn't consider these as tags.

This should fix #660