### PR TITLE
add method to clear all variables

### DIFF
--- a/addons/dialogic/Documentation/Content/Reference/001.md
+++ b/addons/dialogic/Documentation/Content/Reference/001.md
@@ -111,6 +111,10 @@ Sets the value of the value definition named `@param name` to `@param value`.
 
 Returns the current (not default) value of the value definition named `@param name` or `@param default` if no value definition like that was named.
 
+### clear_all_variables()
+`clear_all_variables()`
+
+Clears all configured variables.
 
 ## Game State
 The game state is custom information that you can access with the following functions and that will be saved and loaded alongside the other dialogic data.

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -203,6 +203,11 @@ static func import(data: Dictionary) -> void:
 ## 						DEFINITIONS
 ## +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+# clears all variables
+static func clear_all_variables():
+	for d in _get_definitions()['variables']:
+		d['value'] = ""
+
 # sets the value of the value definition with the given name
 static func set_variable(name: String, value):
 	var exists = false


### PR DESCRIPTION
When using Dialogic with multiple save games we need to somehow "reset" Dialogic, as each save game will have its own state that will be populated on savegame load. Currently, it is difficult to reset variables from gdscript so I introduced a new utility method to do exactly that.