### PR TITLE
Add Method to Change Timeline

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -706,8 +706,7 @@ func event_handler(event: Dictionary):
 		# TIMELINE EVENTS
 		# Change Timeline event
 		'dialogic_020':
-			dialog_script = set_current_dialog(event['change_timeline'])
-			_init_dialog()
+			change_timeline(event['change_timeline'])
 		# Change Backround event
 		'dialogic_021':
 			emit_signal("event_start", "background", event)
@@ -889,6 +888,11 @@ func event_handler(event: Dictionary):
 				handler.handle_event(event, self)
 			else:
 				visible = false
+				
+func change_timeline(timeline):
+	dialog_script = set_current_dialog(timeline)
+	_init_dialog()
+
 
 ## -----------------------------------------------------------------------------
 ## 					TEXTBOX-FUNCTIONALITY

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -93,6 +93,19 @@ static func start(timeline: String = '', default_timeline: String ='', dialog_sc
 	# Just in case everything else fails.
 	return returned_dialog_node
 
+static func change_timeline(timeline):
+	# Set Timeline
+	set_current_timeline(timeline)
+	
+	# If there is a dialog node
+	if has_current_dialog_node():
+		var dialog_node = Engine.get_main_loop().get_meta('latest_dialogic_node')
+		
+		# Get file name
+		var timeline_file = _get_timeline_file_from_name(timeline)
+		
+		dialog_node.change_timeline(timeline_file)
+
 
 
 ################################################################################


### PR DESCRIPTION
With this PR, you can call `Dialogic.change_timeline(new_timeline)` to make the dialog node change timeline and load its new event on the spot.

To-do next while waiting for approval:
- [ ] Update Documentation
- [ ] Provide test project