### PR TITLE
Fix signal connection delay

### DIFF
--- a/addons/dialogic/Nodes/canvas_dialog_node.gd
+++ b/addons/dialogic/Nodes/canvas_dialog_node.gd
@@ -22,23 +22,6 @@ var dialog_node = null
 func set_dialog_node_scene(scene) -> void:
 	_dialog_node_scene = scene
 	dialog_node = _dialog_node_scene.instance()
-  
-
-func _enter_tree() -> void:  
-	if dialog_node:
-		add_child(dialog_node)
-		dialog_node.connect('tree_exited', self, 'dialog_finished')
-
-
-func dialog_finished():
-	queue_free()
-
-
-func _ready() -> void:
-	# change the canvas layer
-	var config = DialogicResources.get_settings_config()	
-	layer = int(config.get_value("theme", "canvas_layer", 1))
-	
 	var _err:int
 	if dialog_node:
 		_err = dialog_node.connect("event_start", self, "_on_event_start")
@@ -53,6 +36,22 @@ func _ready() -> void:
 		assert(_err == OK)
 		_err = dialog_node.connect("dialogic_signal", self, "_on_dialogic_signal")
 		assert(_err == OK)
+
+func _enter_tree() -> void:  
+	if dialog_node:
+		add_child(dialog_node)
+		dialog_node.connect('tree_exited', self, 'dialog_finished')
+
+func dialog_finished():
+	queue_free()
+
+
+func _ready() -> void:
+	# change the canvas layer
+	var config = DialogicResources.get_settings_config()	
+	layer = int(config.get_value("theme", "canvas_layer", 1))
+	
+	
 
 
 func _on_event_start(type, event) -> void:


### PR DESCRIPTION
Should fix #717
It was due to the canvas layer node connecting on ready but being further up in the tree than the Dialog Node an thus connecting a moment after the DialogNode ready function.