### PR TITLE
Add reset-saves functionality to Proxy node

### DIFF
--- a/addons/dialogic/Nodes/DialogProxy.gd
+++ b/addons/dialogic/Nodes/DialogProxy.gd
@@ -7,9 +7,11 @@ export(bool) var add_canvas = true
 export(bool) var reset_saves = true
 
 func _ready():
+	if reset_saves:
+		Dialogic.reset_saves()
 	var d = Dialogic.start(timeline, '', "res://addons/dialogic/Nodes/DialogNode.tscn", add_canvas)
 	get_parent().call_deferred('add_child', d)
-	_copy_signals(d if not add_canvas else d.dialog_node)
+	_copy_signals(d if not add_canvas else d.dialog_node)	
 	queue_free()
 
 func _copy_signals(dialogic:Node):


### PR DESCRIPTION
The proxy node still had the reset_saves property but it wouldn't do anything anymore, because we removed the reset_saves parameter of the start function. This should make it work again meaning it resets all changes to definitions. 