### PR TITLE
Check if Change Timeline has a selected timeline

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -706,7 +706,8 @@ func event_handler(event: Dictionary):
 		# TIMELINE EVENTS
 		# Change Timeline event
 		'dialogic_020':
-			change_timeline(event['change_timeline'])
+			if !event['change_timeline'].empty():
+				change_timeline(event['change_timeline'])
 		# Change Backround event
 		'dialogic_021':
 			emit_signal("event_start", "background", event)


### PR DESCRIPTION
While testing I noticed that if you have a empty `Change Timeline` event it will result in crash, while it should actually just ignore it.