### PR TITLE
Animation and z_index for the Character Join Event 

### DIFF
--- a/addons/dialogic/Editor/Events/CharacterJoin.tscn
+++ b/addons/dialogic/Editor/Events/CharacterJoin.tscn
@@ -1,10 +1,26 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Events/Templates/EventTemplate.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/CharacterJoinSettings.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/CharacterJoining.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Images/Event Icons/Main Icons/character-join.svg" type="Texture" id=4]
 
-[sub_resource type="Image" id=3]
+[sub_resource type="Image" id=7]
+data = {
+"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+"format": "LumAlpha8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id=4]
+flags = 4
+flags = 4
+image = SubResource( 7 )
+size = Vector2( 16, 16 )
+
+[sub_resource type="Image" id=8]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -16,8 +32,10 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 3 )
+image = SubResource( 8 )
 size = Vector2( 16, 16 )
+
+[sub_resource type="StyleBoxEmpty" id=6]
 
 [node name="CharacterJoin" instance=ExtResource( 1 )]
 event_name = "Character "
@@ -38,19 +56,21 @@ event_data = {
 event_color = Color( 0.0705882, 0.717647, 0.415686, 1 )
 event_icon = ExtResource( 4 )
 header_scene = ExtResource( 3 )
+body_scene = ExtResource( 2 )
+expand_on_default = false
 help_page_path = "res://addons/dialogic/Documentation/Content/Events/001.md"
 
 [node name="PanelContainer" parent="." index="1"]
-margin_right = 518.0
+margin_right = 557.0
 
 [node name="MarginContainer" parent="PanelContainer" index="1"]
-margin_right = 518.0
+margin_right = 557.0
 
 [node name="VBoxContainer" parent="PanelContainer/MarginContainer" index="0"]
-margin_right = 512.0
+margin_right = 551.0
 
 [node name="Header" parent="PanelContainer/MarginContainer/VBoxContainer" index="0"]
-margin_right = 506.0
+margin_right = 541.0
 
 [node name="IconPanel" parent="PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer" index="0"]
 self_modulate = Color( 0.0705882, 0.717647, 0.415686, 1 )
@@ -59,20 +79,24 @@ self_modulate = Color( 0.0705882, 0.717647, 0.415686, 1 )
 self_modulate = Color( 0, 0, 0, 1 )
 texture = ExtResource( 4 )
 
-[node name="TitleLabel" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="2"]
-margin_right = 72.0
+[node name="Warning" parent="PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer/IconPanel" index="1"]
+texture = SubResource( 4 )
+
+[node name="TitleLabel" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="1"]
+margin_right = 64.0
 text = "Character "
 
-[node name="Content" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="3"]
-margin_left = 76.0
-margin_right = 502.0
+[node name="Content" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="2"]
+margin_left = 64.0
+margin_right = 541.0
 
-[node name="Spacer" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="5"]
-margin_left = 506.0
-margin_right = 506.0
+[node name="Spacer" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="4"]
+margin_left = 541.0
+margin_right = 541.0
 
-[node name="HelpButton" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="6"]
+[node name="HelpButton" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="5"]
 icon = SubResource( 2 )
 
 [node name="PopupMenu" parent="." index="2"]
-items = [ "Move Up", null, 0, false, false, 0, 0, null, "", false, "Move Down", null, 0, false, false, 1, 0, null, "", false, "", null, 0, false, false, 2, 0, null, "", true, "Remove", null, 0, false, false, 3, 0, null, "", false ]
+custom_styles/hover = SubResource( 6 )
+items = [ "Documentation", SubResource( 4 ), 0, false, false, 0, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Move up", SubResource( 4 ), 0, false, false, 2, 0, null, "", false, "Move down", SubResource( 4 ), 0, false, false, 3, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Delete", SubResource( 4 ), 0, false, false, 5, 0, null, "", false ]

--- a/addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/CharacterJoinSettings.tscn
+++ b/addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/CharacterJoinSettings.tscn
@@ -1,0 +1,69 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/Text/GreyLabel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/EventPart_CharacterJoinSettings.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/ResourcePickers/ResourcePickerMenu.tscn" type="PackedScene" id=3]
+
+[node name="CharacterJoinSettings" type="VBoxContainer"]
+margin_right = 40.0
+margin_bottom = 40.0
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+margin_right = 297.0
+margin_bottom = 24.0
+
+[node name="Label" parent="HBoxContainer" instance=ExtResource( 1 )]
+margin_top = 5.0
+margin_right = 70.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+text = "Animation:"
+
+[node name="AnimationPicker" parent="HBoxContainer" instance=ExtResource( 3 )]
+margin_left = 74.0
+margin_top = 1.0
+margin_right = 168.0
+margin_bottom = 23.0
+
+[node name="Label2" parent="HBoxContainer" instance=ExtResource( 1 )]
+margin_left = 172.0
+margin_top = 5.0
+margin_right = 219.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+text = "Length:"
+
+[node name="AnimationLength" type="SpinBox" parent="HBoxContainer"]
+margin_left = 223.0
+margin_right = 297.0
+margin_bottom = 24.0
+step = 0.2
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="HBoxContainer1" type="HBoxContainer" parent="."]
+margin_top = 28.0
+margin_right = 297.0
+margin_bottom = 52.0
+
+[node name="Label" parent="HBoxContainer1" instance=ExtResource( 1 )]
+margin_top = 5.0
+margin_right = 52.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+text = "Z-index:"
+
+[node name="Z_Index" type="SpinBox" parent="HBoxContainer1"]
+margin_left = 56.0
+margin_right = 130.0
+margin_bottom = 24.0
+min_value = -100.0
+rounded = true
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/EventPart_CharacterJoinSettings.gd
+++ b/addons/dialogic/Editor/Events/Parts/ResourcePickers/Characters/EventPart_CharacterJoinSettings.gd
@@ -1,0 +1,62 @@
+tool
+extends "res://addons/dialogic/Editor/Events/Parts/EventPart.gd"
+
+# has an event_data variable that stores the current data!!!
+
+## node references
+onready var animation_picker = $HBoxContainer/AnimationPicker
+onready var animation_length = $HBoxContainer/AnimationLength
+onready var z_index = $HBoxContainer1/Z_Index
+
+# used to connect the signals
+func _ready():
+	animation_picker.connect("about_to_show", self, "_on_AnimationPicker_about_to_show")
+	animation_picker.get_popup().connect("index_pressed", self, "_on_AnimationPicker_index_pressed")
+	animation_length.connect("value_changed", self, "_on_AnimationLength_value_changed")
+	z_index.connect("value_changed", self, "_on_ZIndex_value_changed")
+	
+	animation_picker.custom_icon = get_icon("Animation", "EditorIcons")
+
+# called by the event block
+func load_data(data:Dictionary):
+	# First set the event_data
+	.load_data(data)
+	
+	# Now update the ui nodes to display the data. 
+	animation_picker.text = DialogicUtil.get_animation_data(event_data.get('animation', 0))['name']
+	animation_length.value = event_data.get('animation_length', 1)
+	z_index.value = event_data.get('z_index', 0)
+
+# has to return the wanted preview, only useful for body parts
+func get_preview():
+	return ''
+
+func _on_AnimationPicker_about_to_show():
+	animation_picker.get_popup().clear()
+	var animations = DialogicUtil.get_animation_names()
+	for element in animations.keys():
+		animation_picker.get_popup().add_icon_item(get_icon("Animation", "EditorIcons"), element, animations[element])
+
+
+func _on_AnimationPicker_index_pressed(index):
+	event_data['animation'] = animation_picker.get_popup().get_item_id(index)
+	
+	var data = DialogicUtil.get_animation_data(event_data['animation'])
+	if animation_picker.text != data['name']:
+		animation_picker.text = data['name']
+		animation_length.value = data['default_length']
+	
+	# informs the parent about the changes!
+	data_changed()
+
+func _on_AnimationLength_value_changed(value):
+	event_data['animation_length'] = value
+	
+	# informs the parent about the changes!
+	data_changed()
+
+func _on_ZIndex_value_changed(value):
+	event_data['z_index'] = value
+	
+	# informs the parent about the changes!
+	data_changed()

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -592,8 +592,9 @@ func event_handler(event: Dictionary):
 				var character_data = DialogicUtil.get_character(event['character'])
 				if portrait_exists(character_data):
 					for portrait in $Portraits.get_children():
-						if portrait.character_data == character_data:
+						if portrait.character_data.get('file', true) == character_data.get('file', false):
 							portrait.move_to_position(get_character_position(event['position']), event.get('animation', 0), event.get('animation_length', 1))
+							$Portraits.move_child(portrait, get_portrait_z_index_point(event.get('z_index', 0)))
 							portrait.set_mirror(event.get('mirror', false))
 							portrait.current_state['position'] = event['position']
 				else:
@@ -1173,7 +1174,7 @@ func grab_portrait_focus(character_data, event: Dictionary = {}) -> bool:
 func portrait_exists(character_data) -> bool:
 	var exists = false
 	for portrait in $Portraits.get_children():
-		if portrait.character_data == character_data:
+		if portrait.character_data.get('file', true) == character_data.get('file', false):
 			exists = true
 	return exists
 
@@ -1203,6 +1204,7 @@ func get_portrait_z_index_point(z_index):
 	for i in range($Portraits.get_child_count()):
 		if $Portraits.get_child(i).z_index >= z_index:
 			return i
+	return $Portraits.get_child_count()
 ## -----------------------------------------------------------------------------
 ## 						GLOSSARY POPUP
 ## -----------------------------------------------------------------------------

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -593,7 +593,7 @@ func event_handler(event: Dictionary):
 				if portrait_exists(character_data):
 					for portrait in $Portraits.get_children():
 						if portrait.character_data == character_data:
-							portrait.move_to_position(get_character_position(event['position']))
+							portrait.move_to_position(get_character_position(event['position']), event.get('animation', 0), event.get('animation_length', 1))
 							portrait.set_mirror(event.get('mirror', false))
 							portrait.current_state['position'] = event['position']
 				else:
@@ -614,9 +614,11 @@ func event_handler(event: Dictionary):
 						p.single_portrait_mode = true
 					p.character_data = character_data
 					p.init(char_portrait)
+					p.z_index = event.get('z_index', 0)
 					p.set_mirror(event.get('mirror', false))
 					$Portraits.add_child(p)
-					p.move_to_position(get_character_position(event['position']))
+					$Portraits.move_child(p, get_portrait_z_index_point(event.get('z_index', 0)))
+					p.move_to_position(get_character_position(event['position']), event.get('animation', 0), event.get('animation_length', 1))
 					p.current_state['character'] = event['character']
 					p.current_state['position'] = event['position']
 			_load_next_event()
@@ -1196,6 +1198,11 @@ func characters_leave_all():
 		for p in portraits.get_children():
 			p.fade_out()
 
+# returns where to move the portrait, so the fake-z-index looks good 
+func get_portrait_z_index_point(z_index):
+	for i in range($Portraits.get_child_count()):
+		if $Portraits.get_child(i).z_index >= z_index:
+			return i
 ## -----------------------------------------------------------------------------
 ## 						GLOSSARY POPUP
 ## -----------------------------------------------------------------------------
@@ -1294,6 +1301,7 @@ func get_current_state_info():
 	state["portraits"] = []
 	for portrait in $Portraits.get_children():
 		state['portraits'].append(portrait.current_state)
+		state['portraits'][-1]['z_index'] = portrait.z_index
 
 	# background music:
 	state['background_music'] = $FX/BackgroundMusic.get_current_info()
@@ -1326,7 +1334,7 @@ func resume_state_from_info(state_info):
 		if portrait_exists(character_data):
 			for portrait in $Portraits.get_children():
 				if portrait.character_data == character_data:
-					portrait.move_to_position(get_character_position(event['position']))
+					portrait.move_to_position(get_character_position(event['position']), 0,0)
 					portrait.set_mirror(event.get('mirror', false))
 		else:
 			var p = Portrait.instance()
@@ -1349,7 +1357,8 @@ func resume_state_from_info(state_info):
 
 			p.set_mirror(event.get('mirror', false))
 			$Portraits.add_child(p)
-			p.move_to_position(get_character_position(event['position']), 0)
+			$Portraits.move_child(p, get_portrait_z_index_point(saved_portrait.get('z_index', 0)))
+			p.move_to_position(get_character_position(event['position']), 0, 0)
 			# this info is only used to save the state later
 			p.current_state['character'] = event['character']
 			p.current_state['position'] = event['position']

--- a/addons/dialogic/Nodes/Portrait.tscn
+++ b/addons/dialogic/Nodes/Portrait.tscn
@@ -3,6 +3,7 @@
 [ext_resource path="res://addons/dialogic/Nodes/Portrait.gd" type="Script" id=2]
 
 [node name="Portrait" type="Control"]
+rect_scale = Vector2( 0.7, 0.7 )
 script = ExtResource( 2 )
 __meta__ = {
 "_edit_use_anchors_": false

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -530,6 +530,30 @@ static func list_dir(path: String) -> Array:
 	return files
 
 ## *****************************************************************************
+##							ANIMATION-HELPERS
+## *****************************************************************************
+static func animations():
+	return {
+	0:{"name":"[Default]", "default_length":1},
+	1:{"name": "Instant Appear", "default_length": 0},
+	2:{"name": "Float Up", "default_length": 1},
+	3:{"name": "Fade", "default_length": 1},
+	4:{"name": "Pop", "default_length": 1},
+	}
+
+static func get_animation_names():
+	var dict = {}
+	for id in animations().keys():
+		dict[animations()[id]['name']] = id
+	return dict
+
+static func get_animation_data(id):
+	return animations()[int(id)]
+
+static func get_default_animation_id():
+	return 2
+
+## *****************************************************************************
 ##							DIALOGIC_SORTER CLASS
 ## *****************************************************************************
 


### PR DESCRIPTION
Adds a body to the character join event that allows to select an animation and it's length as well as a fake z-index. 

Should fix #712 and somewhat #639

I think it would be nice to be able to change the default animation. 

Also I noticed that you could make a character join multiple times right now, because it somehow wouldn't recognize that it was already joined, so I updated that. 

Characters will NOT come to the front anymore when talking. if this is wanted again, it should be relatively easy to add an option.