### PR TITLE
Fixes for addressing Variables and Timelines by folder path

### DIFF
--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -117,6 +117,10 @@ static func change_timeline(timeline: String) -> void:
 ## 						Test to see if a timeline exists
 ################################################################################
 
+## Check to see if a timeline with a given name/path exists. Useful for verifying
+## before calling a timeline, or for automated tests to make sure timeline calls 
+## are valid. Returns a boolean of true if the timeline exists, and false if it 
+## does not. 
 static func timeline_exists(timeline: String):
 	var timeline_file = _get_timeline_file_from_name(timeline)
 	if timeline_file:

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -113,7 +113,16 @@ static func change_timeline(timeline: String) -> void:
 	else:
 		print("[D] Tried to change timeline, but no DialogNode exists!")
 
+################################################################################
+## 						Test to see if a timeline exists
+################################################################################
 
+static func timeline_exists(timeline: String):
+	var timeline_file = _get_timeline_file_from_name(timeline)
+	if timeline_file:
+		return true
+	else:
+		return false
 
 ################################################################################
 ## 						BUILT-IN SAVING/LOADING
@@ -231,10 +240,19 @@ static func clear_all_variables():
 # sets the value of the value definition with the given name
 static func set_variable(name: String, value):
 	var exists = false
-	for d in _get_definitions()['variables']:
-		if d['name'] == name:
-			d['value'] = str(value)
-			exists = true
+	
+	if '/' in name:
+		var variable_id = _get_variable_from_file_name(name)
+		if variable_id != '':
+			for d in _get_definitions()['variables']:
+				if d['id'] == variable_id:
+					d['value'] = str(value)
+					exists = true
+	else:		
+		for d in _get_definitions()['variables']:
+			if d['name'] == name:
+				d['value'] = str(value)
+				exists = true
 	if exists == false:
 		# TODO it would be great to automatically generate that missing variable here so they don't
 		# have to create it from the editor. 
@@ -243,11 +261,19 @@ static func set_variable(name: String, value):
 
 # returns the value of the value definition with the given name
 static func get_variable(name: String, default = null):
-	for d in _get_definitions()['variables']:
-		if d['name'] == name:
-			return d['value']
-	print("[Dialogic] Warning! the variable [" + name + "] doesn't exists.")
-	return default
+	if '/' in name:
+		var variable_id = _get_variable_from_file_name(name)
+		for d in _get_definitions()['variables']:
+			if d['id'] == variable_id:
+				return d['value']
+		print("[Dialogic] Warning! the variable [" + name + "] doesn't exists.")
+		return default
+	else:
+		for d in _get_definitions()['variables']:
+			if d['name'] == name:
+				return d['value']
+		print("[Dialogic] Warning! the variable [" + name + "] doesn't exists.")
+		return default
 
 
 ## +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -386,29 +412,84 @@ static func set_variable_from_id(id: String, value: String, operation: String) -
 # tries to find the path of a given timeline 
 static func _get_timeline_file_from_name(timeline_name_path: String) -> String:
 	var timelines = DialogicUtil.get_full_resource_folder_structure()['folders']['Timelines']
-	var parts = timeline_name_path.split('/', false)
+	
+	# Checks for slash in the name, and uses the folder search if there is 
+	if '/' in timeline_name_path:
+		#Add leading slash if its a path and it is missing, for paths that have subfolders but no leading slash 
+		if(timeline_name_path.left(1) != '/'):
+			timeline_name_path = "/" + timeline_name_path
+		var parts = timeline_name_path.split('/', false)
+	
+		# First check if it's a timeline in the root folder
+		if parts.size() == 1:
+			for t in DialogicUtil.get_timeline_list():
+				for f in timelines['files']:
+					if t['file'] == f && t['name'] == parts[0]:
+						return t['file']
+		if parts.size() > 1:
+			var current_data
+			var current_depth = 0
+			for p in parts:
+				if current_depth == 0:
+					# Starting the crawl
+					if (timelines['folders'].has(p) ):
+						current_data = timelines['folders'][p]
+					else:
+						return ''
+				elif current_depth == parts.size() - 1:
+					# The final destination
+					for t in DialogicUtil.get_timeline_list():
+						for f in current_data['files']:
+							if t['file'] == f && t['name'] == p:
+								return t['file']
+							
+				else:
+					# Still going deeper
+					current_data = current_data['folders'][p]
+				current_depth += 1
+		return ''
+	else:
+		# Searching for any timeline that could match that name
+		for t in DialogicUtil.get_timeline_list():
+			if t['name'] == timeline_name_path:
+				return t['file']
+	return ''
+
+static func _get_variable_from_file_name(variable_name_path: String) -> String:
+	#First add the leading slash if it is missing so algorithm works properly
+	if(variable_name_path.left(1) != '/'):
+		variable_name_path = "/" + variable_name_path
+
+	var definitions = DialogicUtil.get_full_resource_folder_structure()['folders']['Definitions']
+	var parts = variable_name_path.split('/', false)
+	
+	# Check the root if it's a variable in the root folder 
+	if parts.size() == 1:
+		for t in _get_definitions()['variables']:
+			for f in definitions['files']:
+				if t['id'] == f && t['name'] == parts[0]:
+					return t['id']
 	if parts.size() > 1:
 		var current_data
 		var current_depth = 0
+		
 		for p in parts:
 			if current_depth == 0:
+
 				# Starting the crawl
-				current_data = timelines['folders'][p]
+				if (definitions['folders'].has(p)):
+					current_data = definitions['folders'][p]
+				else:
+					return ''
 			elif current_depth == parts.size() - 1:
 				# The final destination
-				for t in DialogicUtil.get_timeline_list():
+				for t in _get_definitions()['variables']:
 					for f in current_data['files']:
-						if t['file'] == f && t['name'] == p:
-							return t['file']
+						if t['id'] == f && t['name'] == p:
+							return t['id']
 							
 			else:
 				# Still going deeper
 				current_data = current_data['folders'][p]
 			current_depth += 1
-	else:
-		# Searching for any timeline that could match that name
-		for t in DialogicUtil.get_timeline_list():
-			if parts.size():
-				if t['name'] == parts[0]:
-					return t['file']
 	return ''

--- a/addons/dialogic/Parser/DialogicParser.gd
+++ b/addons/dialogic/Parser/DialogicParser.gd
@@ -208,9 +208,17 @@ static func _insert_variable_definitions(current_dialog, text: String):
 			else:
 				# Replace the name of a value [whatever] with the result
 				var r_string_array = r_string.replace('[', '').replace(']', '')
-				for d in current_dialog.definitions['variables']:
-					if d['name'] == r_string_array:
-						final_text = final_text.replace(r_string, d['value'])
+				
+				# Find the ID if it's got an absolute path
+				if '/' in r_string_array:
+					var variable_id=Dialogic._get_variable_from_file_name(r_string_array)
+					for d in current_dialog.definitions['variables']:
+						if d['id'] == variable_id:
+							final_text = final_text.replace(r_string, d['value'])
+				else:					
+					for d in current_dialog.definitions['variables']:
+						if d['name'] == r_string_array:
+							final_text = final_text.replace(r_string, d['value'])
 	
 	return final_text
 


### PR DESCRIPTION
This is to add the features for getting/setting and display in a text block for a variable by the folder path name, as in #746. Also, as this was based on the function for doing so in timelines, fixes a bug in the existing timeline folder search code as mentioned in #739 which prevented either that or the new variable search to work on the root of the folder tree

Also included is the command to test if a timeline exists, as requested in #739 