### PR TITLE
Add new dialogic_default_action and fix bug #736

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.gd
@@ -254,11 +254,10 @@ func _spinbox_val_changed(newValue :float, spinbox_name):
 func _on_default_action_key_presssed(nodeName = 'default_action_key') -> void:
 	var settings = DialogicResources.get_settings_config()
 	nodes[nodeName].clear()
-	nodes[nodeName].add_item(settings.get_value('input', nodeName, '[Default]'))
-	nodes[nodeName].add_item('[Default]')
-	InputMap.load_from_globals()
-	for a in InputMap.get_actions():
-		nodes[nodeName].add_item(a)
+	nodes[nodeName].add_item(settings.get_value('input', nodeName, 'dialogic_default_action'))
+	for prop in ProjectSettings.get_property_list():
+		if prop.name.begins_with('input/'):
+			nodes[nodeName].add_item(prop.name.trim_prefix('input/'))
 
 
 func _on_default_action_key_item_selected(index, nodeName = 'default_action_key') -> void:

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -360,8 +360,7 @@ static func get_current_timeline():
 
 # Returns a string with the action button set on the project settings
 static func get_action_button():
-	var action_button = DialogicResources.get_settings_value('input', 'default_action_key', 'ui_accept')
-	return action_button if action_button != "[Default]" else "ui_accept"
+	return DialogicResources.get_settings_value('input', 'default_action_key', 'dialogic_default_action')
 
 ################################################################################
 ## 					NOT TO BE USED FROM OUTSIDE

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -548,7 +548,27 @@ static func resource_fixer():
 					events[i] = new_event
 			timeline['events'] = events
 			DialogicResources.set_timeline(timeline)
+	
 	DialogicResources.set_settings_value("updates", "updatenumber", 3)
+	
+	if !ProjectSettings.has_setting('input/dialogic_default_action'):
+		print("[D] Added the 'dialogic_default_action' to the InputMap. This is the default if you didn't select a different one in the dialogic settings. You will have to force the InputMap editor to update before you can see the action (reload project or add a new input action).")
+		var input_enter = InputEventKey.new()
+		input_enter.scancode = KEY_ENTER
+		var input_left_click = InputEventMouseButton.new()
+		input_left_click.button_index = BUTTON_LEFT
+		input_left_click.pressed = true
+		var input_space = InputEventKey.new()
+		input_space.scancode = KEY_SPACE
+		var input_x = InputEventKey.new()
+		input_x.scancode = KEY_X
+		var input_controller = InputEventJoypadButton.new()
+		input_controller.button_index = JOY_BUTTON_0
+	
+		ProjectSettings.set_setting('input/dialogic_default_action', {'deadzone':0.5, 'events':[input_enter, input_left_click, input_space, input_x, input_controller]})
+		ProjectSettings.save()
+		if DialogicResources.get_settings_value('input', 'default_action_key', '[Default]') == '[Default]':
+			DialogicResources.set_settings_value('input', 'default_action_key', 'dialogic_default_action')
 
 static func get_editor_scale(ref) -> float:
 	# There hasn't been a proper way of reliably getting the editor scale


### PR DESCRIPTION
There is now a dialogic_default_action automatically created in the InputMap. It is now also the new default. 
Unfortunately you have to force the editor to update by reloading the project or adding another action to able to see this action. But this is only a problem the first time you open the project (or if you delete the action).

Also the editors internal InputMap will no longer be messed up when setting the action key (#736).