### PR TITLE
Rework the states of the dialog box fade in animation

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -448,7 +448,7 @@ func _input(event: InputEvent) -> void:
 			else:
 				if current_event.has('options') and !is_state(state.WAITING_INPUT):
 					pass
-				elif is_state(state.WAITING_INPUT):
+				elif is_state(state.WAITING_INPUT) or is_state(state.ANIMATING):
 					pass
 				elif $TextBubble/NextIndicatorContainer/NextIndicator.is_visible():
 					$FX/CharacterVoice.stop_voice() # stop the current voice as well
@@ -632,7 +632,8 @@ func event_handler(event: Dictionary):
 		# Text Event
 		'dialogic_001':
 			emit_signal("event_start", "text", event)
-			fade_in_dialog()
+			if fade_in_dialog():
+				yield(get_node('fade_in_tween_show_time'), 'tween_completed')
 			set_state(state.TYPING)
 			if event.has('character'):
 				var character_data = DialogicUtil.get_character(event['character'])
@@ -738,7 +739,8 @@ func event_handler(event: Dictionary):
 		# Question event
 		'dialogic_010':
 			emit_signal("event_start", "question", event)
-			fade_in_dialog()
+			if fade_in_dialog():
+				yield(get_node('fade_in_tween_show_time'), 'tween_completed')
 			set_state(state.TYPING)
 			if event.has('name'):
 				update_name(event['name'])
@@ -1378,7 +1380,7 @@ func _on_Definition_Timer_timeout():
 # This will reset the text, reset any modulation it might have, and
 # set the variables that handle the fade in to the start position
 func _hide_dialog():
-	$TextBubble.update_text('') # Clearing the text
+	$TextBubble.clear() # Clearing the text
 	$TextBubble.modulate = Color(1,1,1,0)
 	dialog_faded_in_already = false
 
@@ -1406,6 +1408,8 @@ func fade_in_dialog(time = 0.5):
 		if has_tween:
 			set_state(state.ANIMATING)
 			dialog_faded_in_already = true
+			return true
+	return false
 
 # at the end of fade animation, reset flags
 func finished_fade_in_dialog(object, key, node):

--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -48,6 +48,10 @@ func update_name(name: String, color: Color = Color.white, autocolor: bool=false
 	else:
 		name_label.visible = false
 
+func clear():
+	text_label.bbcode_text = ""
+	name_label.text = ""
+	$WritingTimer.stop()
 
 func update_text(text:String):
 	
@@ -267,23 +271,20 @@ func load_theme(theme: ConfigFile):
 
 
 func _on_writing_timer_timeout():
-	# Checks for the 'fade_in_tween_show_time' which only exists during the fade in animation
-	# if that node doesn't exists, it won't start the letter by letter animation.
-	if get_parent().has_node('fade_in_tween_show_time') == false:
-		if _finished == false:
-			text_label.visible_characters += 1
-			if(commands.size()>0 && commands[0][0] <= text_label.visible_characters):
-				handle_command(commands.pop_front()) #handles the command, and removes it from the queue
-			if text_label.visible_characters > text_label.get_total_character_count():
-				_handle_text_completed()
-			elif (
-				text_label.visible_characters > 0 and 
-				#text_label.text.length() > text_label.visible_characters-1 and 
-				text_label.text[text_label.visible_characters-1] != " "
-			):
-				emit_signal('letter_written')
-		else:
-			$WritingTimer.stop()
+	if _finished == false:
+		text_label.visible_characters += 1
+		if(commands.size()>0 && commands[0][0] <= text_label.visible_characters):
+			handle_command(commands.pop_front()) #handles the command, and removes it from the queue
+		if text_label.visible_characters > text_label.get_total_character_count():
+			_handle_text_completed()
+		elif (
+			text_label.visible_characters > 0 and 
+			#text_label.text.length() > text_label.visible_characters-1 and 
+			text_label.text[text_label.visible_characters-1] != " "
+		):
+			emit_signal('letter_written')
+	else:
+		$WritingTimer.stop()
 
 
 func start_text_timer():


### PR DESCRIPTION
The way the fade in animation was working, together with some calls to TextBubble.update_text("") meant, that on the first event the state would get messed up. I have reworked this whole procedure to something that is cleaner imo and removes these problems.  This should fix #794