### PR TITLE
Add overridable focus() function for EventParts and use it on Text Event

### DIFF
--- a/addons/dialogic/Editor/Events/Parts/EventPart.gd
+++ b/addons/dialogic/Editor/Events/Parts/EventPart.gd
@@ -36,6 +36,9 @@ func load_data(data:Dictionary):
 func get_preview_text():
 	return ''
 
+# to be overwritten by the body-parts if some kind of focus (on event creation) is wanted
+func focus():
+	pass
 
 # has to be called everytime the data got changed
 func data_changed():

--- a/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextAndVoicePicker.gd
+++ b/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextAndVoicePicker.gd
@@ -50,3 +50,6 @@ func _on_voice_editor_data_changed(data) -> void:
 	voice_editor.visible = use_voices()
 	# informs the parent 
 	data_changed()
+
+func focus():
+	text_editor.focus()

--- a/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextEditor.gd
+++ b/addons/dialogic/Editor/Events/Parts/Text/EventPart_TextEditor.gd
@@ -122,3 +122,6 @@ func _on_TextEdit_focus_exited():
 	# Remove text selection to visually notify the user that the text will not 
 	# be copied if they use a hotkey like CTRL + C 
 	$TextEdit.deselect()
+
+func focus():
+	$TextEdit.grab_focus()

--- a/addons/dialogic/Editor/Events/Templates/EventBlock.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventBlock.gd
@@ -64,6 +64,12 @@ func visual_deselect():
 func load_data(data):
 	event_data = data
 
+# called to inform event parts, that a focus is wanted
+func focus():
+	if get_header():
+		get_header().focus()
+	if get_body():
+		get_body().focus()
 
 func get_body():
 	return body_node

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -832,6 +832,10 @@ func create_event(event_id: String, data: Dictionary = {'no-data': true} , inden
 	# Indent on create
 	if indent:
 		indent_events()
+	
+	if not building_timeline:
+		piece.focus()
+	
 	return piece
 
 


### PR DESCRIPTION
This new function (focus()) is called when an event is newly created on all the direct EventParts of the event (body/header). This allows them to do anything they would like. It' s not called when the timeline is loaded. 

This PR also implements this on the TextAndVoicePicker and it's sub-event-part the TextEditor to make it focus the TextEdit when you create the Text or Question event. This fixes #811