### PR TITLE
Replace `call` with `callv` in event 042

### DIFF
--- a/addons/dialogic/Documentation/Content/Changelog.md
+++ b/addons/dialogic/Documentation/Content/Changelog.md
@@ -8,6 +8,7 @@
   - You can now make a list of words like this: `[word1,word2,word3]` and Dialogic will pick a random word from the list. If the word is a Dialogic variable name and it gets picked it will show the value of that variable.
   - New commands [signal=argument], [pause=wait_time], [play=soundname], [nv=v] (for waiting until the audio finishes) added to the Text Event [[KvaGram](https://github.com/KvaGram)]
 - The Character Join and Character Leave events have been removed in favor of the new `Character Event`. They will be converted automatically. The new events allows for more customization including animations. These use the anima system. Learn more about the [event](./Events/002.md) and the [animations](./Tutorials/AddNewAnimations.md) [[Jowan-Spooner](https://github.com/Jowan-Spooner)]
+- The `Call Node Event` now sends arguments instead of a single array. If you were using it in one of your timelines you will need to update the functions you are calling to accommodate this. [[AnidemDex](https://github.com/AnidemDex)]
 
 
 #### Settings/Themes

--- a/addons/dialogic/Documentation/Content/Tutorials/Updating.md
+++ b/addons/dialogic/Documentation/Content/Tutorials/Updating.md
@@ -6,9 +6,12 @@ This assumes you are upgrading from version 1.3.
 Here is everything you need to do to successfully updated (as far as we know):
 
 ## 1. Make a backup of your project
-- Close your project/Godot
-- Make a full project backup just in case you lose some data while upgrading
-- Remove the `/addons/dialogic` folder from your project 
-- Paste the new Dialogic 1.4 into the addons folder
-- Open your project/Godot again
-- Enable the new Dialogic from the plugin menu (Project Settings/Plugins)
+  - Close your project/Godot
+  - Make a full project backup just in case you lose some data while upgrading
+  - Remove the `/addons/dialogic` folder from your project 
+  - Paste the new Dialogic 1.4 into the addons folder
+  - Open your project/Godot again
+  - Enable the new Dialogic from the plugin menu (Project Settings/Plugins)
+
+## Update the call node events target functions
+  - The `Call Node Event` now sends arguments instead of a single array. If you were using it in one of your timelines you will need to update the functions you are calling to accommodate this. So if the function you were calling before was something like `func hello(Array)` now it should be `func hello(argument1, argument2, argument3, ...)` with as many arguments as you have in the event settings.

--- a/addons/dialogic/Editor/Events/Parts/CallNode/CallNodePicker.tscn
+++ b/addons/dialogic/Editor/Events/Parts/CallNode/CallNodePicker.tscn
@@ -16,57 +16,57 @@ __meta__ = {
 
 [node name="Label" parent="." instance=ExtResource( 2 )]
 margin_top = 0.0
-margin_right = 792.0
+margin_right = 782.0
 margin_bottom = 14.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
-text = "This event calls the method [Method Name] on the node [Target Node]. It passes an array to the method."
+text = "This event calls the function [Function Name] on the [Target Node] (use full path!). It also passes a number of arguments."
 
 [node name="Properties" type="HBoxContainer" parent="."]
 margin_top = 18.0
-margin_right = 792.0
-margin_bottom = 52.0
+margin_right = 782.0
+margin_bottom = 45.0
 custom_constants/separation = 8
 
 [node name="TargetNodeLabel" type="Label" parent="Properties"]
-margin_top = 10.0
+margin_top = 6.0
 margin_right = 81.0
-margin_bottom = 24.0
+margin_bottom = 20.0
 text = "Target Node:"
 
 [node name="TargetNodeEdit" parent="Properties" instance=ExtResource( 3 )]
 margin_left = 89.0
 margin_right = 329.0
-margin_bottom = 34.0
+margin_bottom = 27.0
 rect_min_size = Vector2( 240, 27 )
 
 [node name="CallMethodLabel" type="Label" parent="Properties"]
 margin_left = 337.0
-margin_top = 10.0
+margin_top = 6.0
 margin_right = 432.0
-margin_bottom = 24.0
+margin_bottom = 20.0
 text = "Method Name:"
 
 [node name="CallMethodEdit" parent="Properties" instance=ExtResource( 3 )]
 margin_left = 440.0
 margin_right = 620.0
-margin_bottom = 34.0
+margin_bottom = 27.0
 rect_min_size = Vector2( 180, 27 )
 
 [node name="ArgumentsLabel" type="Label" parent="Properties"]
 margin_left = 628.0
-margin_top = 10.0
-margin_right = 708.0
-margin_bottom = 24.0
-text = "ArrayLength:"
+margin_top = 6.0
+margin_right = 698.0
+margin_bottom = 20.0
+text = "Arguments"
 
 [node name="ArgumentsSpinBox" type="SpinBox" parent="Properties"]
-margin_left = 716.0
-margin_right = 792.0
-margin_bottom = 34.0
+margin_left = 706.0
+margin_right = 782.0
+margin_bottom = 27.0
 max_value = 99.0
 
 [node name="Arguments" type="VBoxContainer" parent="."]
-margin_top = 56.0
-margin_right = 792.0
-margin_bottom = 56.0
+margin_top = 49.0
+margin_right = 782.0
+margin_bottom = 49.0
 custom_constants/separation = 5

--- a/addons/dialogic/Editor/Events/Parts/CallNode/EventPart_CallNodePicker.gd
+++ b/addons/dialogic/Editor/Events/Parts/CallNode/EventPart_CallNodePicker.gd
@@ -91,7 +91,7 @@ func _create_argument_controls():
 		
 		var label = Label.new()
 		label.name = "IndexLabel"
-		label.text = "Index %s:" % index
+		label.text = "Argument %s:" % index
 		label.rect_min_size.x = 100
 		container.add_child(label)
 		

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -978,16 +978,12 @@ func event_handler(event: Dictionary):
 			if (not args is Array):
 				args = []
 
-			if (target != null):
-				if (target.has_method(method_name)):
-					if (args.empty()):
-						var func_result = target.call(method_name)
-						if (func_result is GDScriptFunctionState):
-							yield(func_result, "completed")
-					else:
-						var func_result = target.call(method_name, args)
-						if (func_result is GDScriptFunctionState):
-							yield(func_result, "completed")
+			if is_instance_valid(target):
+				if target.has_method(method_name):
+					var func_result = target.callv(method_name, args)
+					
+					if (func_result is GDScriptFunctionState):
+						yield(func_result, "completed")
 
 			set_state(state.IDLE)
 			$TextBubble.visible = true


### PR DESCRIPTION
This makes call event pass each argument in the array instead of passing the whole array.

As an example, consider call event `my_method` with `["1","2","3"]` values to an arbitrary node

```
func my_method(args) <- Current behaviour: call event pass the whole array, so you need to split it manually
```
```
func my_method(arg1, arg2, arg3) <- PR behaviour: each value in the array is passed as an argument
```

### But wait
I consider this can be annoying to people that already uses call event and split arguments manually, so maybe thay should be notified about this change? No idea