### PR TITLE
Add setting to disable the mouse block of the dialog node 

### DIFF
--- a/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/SettingsEditor/SettingsEditor.tscn
@@ -8,7 +8,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Events/Parts/ResourcePickers/ResourcePickerMenu.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=7]
 
-[sub_resource type="Image" id=1]
+[sub_resource type="Image" id=3]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -20,7 +20,7 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 1 )
+image = SubResource( 3 )
 size = Vector2( 16, 16 )
 
 [node name="SettingsEditor" type="ScrollContainer"]
@@ -34,31 +34,31 @@ __meta__ = {
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 margin_right = 1012.0
-margin_bottom = 632.0
+margin_bottom = 716.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer"]
 margin_right = 1012.0
-margin_bottom = 632.0
+margin_bottom = 716.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
-margin_right = 426.0
-margin_bottom = 632.0
+margin_right = 398.0
+margin_bottom = 716.0
 custom_constants/separation = 16
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 78.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer" instance=ExtResource( 2 )]
-margin_right = 426.0
+margin_right = 398.0
 text = "Theme"
 text_key = "Theme"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer"]
 margin_top = 26.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 50.0
 
 [node name="TLabel" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource( 3 )]
@@ -72,13 +72,13 @@ text_key = "Default"
 
 [node name="ThemePicker" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer" instance=ExtResource( 6 )]
 margin_left = 102.0
-margin_right = 251.0
+margin_right = 225.0
 custom_colors/font_color = Color( 0.8, 0.807843, 0.827451, 1 )
-text = "Default Theme"
+text = "something"
 
 [node name="HBoxContainer3" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer"]
 margin_top = 54.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 78.0
 
 [node name="TLabel3" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer/HBoxContainer3" instance=ExtResource( 3 )]
@@ -101,17 +101,17 @@ rounded = true
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 94.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 360.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 2 )]
-margin_right = 426.0
+margin_right = 398.0
 text = "Dialog"
 text_key = "Dialog"
 
 [node name="SettingsCheckbox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 26.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 50.0
 text = "New lines will create extra messages"
 default = true
@@ -120,7 +120,7 @@ settings_key = "new_lines"
 
 [node name="SettingsCheckbox2" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 54.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 78.0
 text = "Remove empty messages"
 default = true
@@ -129,7 +129,7 @@ settings_key = "remove_empty_messages"
 
 [node name="SettingsCheckbox3" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 82.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 106.0
 text = "Auto color character names in messages"
 default = true
@@ -138,7 +138,7 @@ settings_key = "auto_color_names"
 
 [node name="SettingsCheckbox5" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 110.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 134.0
 hint_tooltip = "If disabled, background images use \"Aspect covered\" mode."
 text = "Stretch background images "
@@ -148,21 +148,21 @@ settings_key = "stretch_backgrounds"
 
 [node name="HSeparator2" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 138.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 142.0
 
 [node name="TLabel6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 146.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 160.0
 text = "Audio for Text events:"
 text_key = "Audio for Text events:"
 
 [node name="SettingsCheckbox6" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 164.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 188.0
 text = "Enable audio for Text events"
 settings_section = "dialog"
@@ -170,7 +170,7 @@ settings_key = "text_event_audio_enable"
 
 [node name="TextAudioDefaultBus" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 192.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 212.0
 
 [node name="TLabel8" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2/TextAudioDefaultBus" instance=ExtResource( 3 )]
@@ -187,26 +187,26 @@ margin_left = 208.0
 margin_right = 281.0
 margin_bottom = 20.0
 text = "Master"
-items = [ "Master", null, false, 0, null ]
+items = [ "Master", null, false, 0, null, "SoundEffect", null, false, 1, null ]
 selected = 0
 
 [node name="HSeparator" type="HSeparator" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2"]
 margin_top = 216.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 220.0
 
 [node name="TLabel9" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 224.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 238.0
 text = "Experimental Translations:"
 text_key = "Experimental Translations:"
 
 [node name="SettingsCheckbox7" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer2" instance=ExtResource( 4 )]
 margin_top = 242.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 266.0
 text = "Inputs for text events will be treated as keys for tr()"
 settings_section = "dialog"
@@ -214,17 +214,17 @@ settings_key = "translations"
 
 [node name="VBoxContainer3" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 376.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 426.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3" instance=ExtResource( 2 )]
-margin_right = 426.0
+margin_right = 398.0
 text = "Game saving"
 text_key = "Saving"
 
 [node name="SettingsCheckbox8" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer3" instance=ExtResource( 4 )]
 margin_top = 26.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 50.0
 text = "Autosave"
 default = true
@@ -233,45 +233,45 @@ settings_key = "autosave"
 
 [node name="VBoxContainer4" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer"]
 margin_top = 442.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 520.0
 
 [node name="SectionTitle2" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4" instance=ExtResource( 2 )]
-margin_right = 426.0
+margin_right = 398.0
 text = "Animations"
 text_key = "Animations"
 
 [node name="DefaultJoinAnimation" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4"]
 margin_top = 26.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 50.0
 
 [node name="TLabel" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultJoinAnimation" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 5.0
-margin_right = 210.0
+margin_right = 212.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 text = "Default Join Animation:"
 text_key = "Default Join Animation:"
 
 [node name="JoinAnimationPicker" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultJoinAnimation" instance=ExtResource( 6 )]
-margin_left = 214.0
-margin_right = 346.0
+margin_left = 216.0
+margin_right = 318.0
 custom_colors/font_color = Color( 0.8, 0.807843, 0.827451, 1 )
-text = "1-fade_in.gd"
+text = "Fade In"
 
 [node name="AnimationLengthPicker" type="SpinBox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultJoinAnimation"]
-margin_left = 350.0
-margin_right = 426.0
+margin_left = 322.0
+margin_right = 398.0
 margin_bottom = 24.0
 step = 0.01
 value = 0.5
 
 [node name="DefaultLeaveAnimation" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4"]
 margin_top = 54.0
-margin_right = 426.0
+margin_right = 398.0
 margin_bottom = 78.0
 
 [node name="TLabel" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultLeaveAnimation" instance=ExtResource( 3 )]
@@ -286,34 +286,34 @@ text_key = "Default Leave Animation:"
 
 [node name="LeaveAnimationPicker" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultLeaveAnimation" instance=ExtResource( 6 )]
 margin_left = 165.0
-margin_right = 346.0
+margin_right = 318.0
 custom_colors/font_color = Color( 0.8, 0.807843, 0.827451, 1 )
-text = "5-fade_out_down.gd"
+text = "Fade Out Down"
 
 [node name="AnimationLengthPicker" type="SpinBox" parent="VBoxContainer/HBoxContainer3/VBoxContainer/VBoxContainer4/DefaultLeaveAnimation"]
-margin_left = 350.0
-margin_right = 426.0
+margin_left = 322.0
+margin_right = 398.0
 margin_bottom = 24.0
 step = 0.01
 value = 0.5
 
 [node name="VBoxContainer2" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3"]
-margin_left = 430.0
-margin_right = 748.0
-margin_bottom = 632.0
+margin_left = 402.0
+margin_right = 738.0
+margin_bottom = 716.0
 
 [node name="VBoxContainer" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
-margin_right = 318.0
-margin_bottom = 282.0
+margin_right = 336.0
+margin_bottom = 310.0
 
 [node name="SectionTitle2" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 2 )]
-margin_right = 318.0
+margin_right = 336.0
 text = "Input"
 text_key = "Input"
 
 [node name="SettingsCheckbox2" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 26.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 50.0
 text = "Autofocus choice buttons"
 default = true
@@ -322,7 +322,7 @@ settings_key = "autofocus_choices"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 54.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 78.0
 
 [node name="TLabel14" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer" instance=ExtResource( 3 )]
@@ -352,7 +352,7 @@ text_key = " seconds"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 82.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 102.0
 
 [node name="TLabel16" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer2" instance=ExtResource( 3 )]
@@ -366,14 +366,14 @@ text_key = "Default action key"
 
 [node name="DefaultActionKey" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer2"]
 margin_left = 119.0
-margin_right = 177.0
+margin_right = 292.0
 margin_bottom = 20.0
 hint_tooltip = "The default value is \"ui_accept\""
-text = "right"
+text = "dialogic_default_action"
 
 [node name="SettingsCheckbox" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 106.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 130.0
 text = "Tapping on the dialog to continue"
 default = true
@@ -382,7 +382,7 @@ settings_key = "clicking_dialog_action"
 
 [node name="SettingsCheckbox3" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 134.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 158.0
 text = "Enable default choice hotkeys"
 settings_section = "input"
@@ -390,128 +390,137 @@ settings_key = "enable_default_shortcut"
 
 [node name="HBoxContainer4" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 162.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 182.0
 alignment = 2
 
 [node name="TLabel18" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer4" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 123.0
+margin_left = 147.0
 margin_top = 3.0
-margin_right = 225.0
+margin_right = 249.0
 margin_bottom = 17.0
 text = "Choice 1 hotkey"
 text_key = "Choice 1 hotkey"
 
 [node name="Choice1Hotkey" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer4"]
-margin_left = 229.0
-margin_right = 318.0
+margin_left = 253.0
+margin_right = 336.0
 margin_bottom = 20.0
 hint_tooltip = "The default value is No Hotkey"
-text = "ui_accept"
+text = "[Default]"
 
 [node name="HBoxContainer5" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 186.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 206.0
 alignment = 2
 
 [node name="TLabel19" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer5" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 154.0
+margin_left = 172.0
 margin_top = 3.0
-margin_right = 256.0
+margin_right = 274.0
 margin_bottom = 17.0
 text = "Choice 2 hotkey"
 text_key = "Choice 2 hotkey"
 
 [node name="Choice2Hotkey" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer5"]
-margin_left = 260.0
-margin_right = 318.0
+margin_left = 278.0
+margin_right = 336.0
 margin_bottom = 20.0
 hint_tooltip = "The default value is No Hotkey"
 text = "click"
 
 [node name="HBoxContainer6" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 210.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 230.0
 alignment = 2
 
 [node name="TLabel20" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer6" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 129.0
+margin_left = 147.0
 margin_top = 3.0
-margin_right = 231.0
+margin_right = 249.0
 margin_bottom = 17.0
 text = "Choice 3 hotkey"
 text_key = "Choice 3 hotkey"
 
 [node name="Choice3Hotkey" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer6"]
-margin_left = 235.0
-margin_right = 318.0
+margin_left = 253.0
+margin_right = 336.0
 margin_bottom = 20.0
 hint_tooltip = "The default value is No Hotkey"
 text = "[Default]"
 
 [node name="HBoxContainer7" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer"]
 margin_top = 234.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 254.0
 alignment = 2
 
 [node name="TLabel21" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer7" instance=ExtResource( 3 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 129.0
+margin_left = 147.0
 margin_top = 3.0
-margin_right = 231.0
+margin_right = 249.0
 margin_bottom = 17.0
 text = "Choice 4 hotkey"
 text_key = "Choice 4 hotkey"
 
 [node name="Choice4Hotkey" type="OptionButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer/HBoxContainer7"]
-margin_left = 235.0
-margin_right = 318.0
+margin_left = 253.0
+margin_right = 336.0
 margin_bottom = 20.0
 hint_tooltip = "The default value is No Hotkey"
 text = "[Default]"
 
 [node name="SettingsCheckbox4" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 258.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 282.0
 text = "Propagate input to rest of the Tree"
 default = true
 settings_section = "dialog"
 settings_key = "propagate_input"
 
-[node name="HistorySettings" parent="VBoxContainer/HBoxContainer3/VBoxContainer2" instance=ExtResource( 5 )]
+[node name="SettingsCheckbox5" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/VBoxContainer" instance=ExtResource( 4 )]
 margin_top = 286.0
-margin_right = 318.0
-margin_bottom = 574.0
+margin_right = 336.0
+margin_bottom = 310.0
+text = "Stop Mouse Clicks"
+default = true
+settings_section = "dialog"
+settings_key = "stop_mouse"
+
+[node name="HistorySettings" parent="VBoxContainer/HBoxContainer3/VBoxContainer2" instance=ExtResource( 5 )]
+margin_top = 314.0
+margin_right = 336.0
+margin_bottom = 658.0
 
 [node name="CustomEvents" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
-margin_top = 578.0
-margin_right = 318.0
-margin_bottom = 628.0
+margin_top = 662.0
+margin_right = 336.0
+margin_bottom = 712.0
 
 [node name="SectionTitle" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/CustomEvents" instance=ExtResource( 2 )]
-margin_right = 318.0
+margin_right = 336.0
 text = "Custom events"
 text_key = "Custom events"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/CustomEvents"]
 margin_top = 26.0
-margin_right = 318.0
+margin_right = 336.0
 margin_bottom = 50.0
 
 [node name="Message" type="Label" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/CustomEvents/HBoxContainer"]
 margin_top = 5.0
-margin_right = 242.0
+margin_right = 260.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 custom_colors/font_color = Color( 0, 0, 0, 1 )
@@ -520,14 +529,14 @@ __meta__ = {
 }
 
 [node name="NewCustomEvent" type="Button" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/CustomEvents/HBoxContainer"]
-margin_left = 246.0
-margin_right = 286.0
+margin_left = 264.0
+margin_right = 304.0
 margin_bottom = 24.0
 text = "New"
 
 [node name="CustomEventsDocs" type="ToolButton" parent="VBoxContainer/HBoxContainer3/VBoxContainer2/CustomEvents/HBoxContainer"]
-margin_left = 290.0
-margin_right = 318.0
+margin_left = 308.0
+margin_right = 336.0
 margin_bottom = 24.0
 icon = SubResource( 2 )
 
@@ -611,6 +620,6 @@ margin_bottom = 20.0
 text = "Cancel"
 
 [node name="CustomEvents" type="VBoxContainer" parent="VBoxContainer/HBoxContainer3/VBoxContainer2"]
-margin_top = 632.0
-margin_right = 318.0
-margin_bottom = 632.0
+margin_top = 716.0
+margin_right = 336.0
+margin_bottom = 716.0

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -110,6 +110,8 @@ func _ready():
 	# Connecting resize signal
 	get_viewport().connect("size_changed", self, "resize_main")
 	resize_main()
+	if !DialogicResources.get_settings_value('dialog', 'stop_mouse', true):
+		mouse_filter = Control.MOUSE_FILTER_IGNORE
 	# Connecting some other timers
 	$OptionsDelayedInput.connect("timeout", self, '_on_OptionsDelayedInput_timeout')
 	# Setting everything up for the node to be default


### PR DESCRIPTION
The setting will set the dialog nodes controls mouse_filter to MOUSE_FILTER_IGNORE.

This enables you to add other clickable elements and buttons in the background of your scene. 