### PR TITLE
Portrait-Animation fixes

### DIFF
--- a/addons/dialogic/Nodes/Anima/animations/attention_seeker/bounce.gd
+++ b/addons/dialogic/Nodes/Anima/animations/attention_seeker/bounce.gd
@@ -11,17 +11,18 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 90, to = -4 },
 		{ percentage = 100, to = +4 },
 	]
-
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, to = 1 * data.node.scale.y },
-		{ percentage = 20, to = 1 * data.node.scale.y },
-		{ percentage = 40, to = 1.1 * data.node.scale.y, easing_points = [0.7555, 0.5, 0.8555, 0.06] },
-		{ percentage = 43, to = 1.1 * data.node.scale.y, easing_points = [0.7555, 0.5, 0.8555, 0.06] },
-		{ percentage = 53, to = 1 * data.node.scale.y },
-		{ percentage = 70, to = 1.05 * data.node.scale.y, easing_points = [0.755, 0.05, 0.855, 0.06] },
-		{ percentage = 80, to = 0.95 * data.node.scale.y },
-		{ percentage = 90, to = 1.02 * data.node.scale.y },
-		{ percentage = 100, to = 1 * data.node.scale.y },
+		{ percentage = 0, to = 1 * scale.y },
+		{ percentage = 20, to = 1 * scale.y },
+		{ percentage = 40, to = 1.1 * scale.y, easing_points = [0.7555, 0.5, 0.8555, 0.06] },
+		{ percentage = 43, to = 1.1 * scale.y, easing_points = [0.7555, 0.5, 0.8555, 0.06] },
+		{ percentage = 53, to = 1 * scale.y },
+		{ percentage = 70, to = 1.05 * scale.y, easing_points = [0.755, 0.05, 0.855, 0.06] },
+		{ percentage = 80, to = 0.95 * scale.y },
+		{ percentage = 90, to = 1.02 * scale.y },
+		{ percentage = 100, to = 1 * scale.y },
 	]
 
 	anima_tween.add_relative_frames(data, "Y", bounce_frames)

--- a/addons/dialogic/Nodes/Anima/animations/attention_seeker/heartbeat.gd
+++ b/addons/dialogic/Nodes/Anima/animations/attention_seeker/heartbeat.gd
@@ -1,11 +1,12 @@
 func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 14, to = data.node.scale * Vector2(1.3, 1.3) },
-		{ percentage = 28, to = data.node.scale * Vector2(1, 1) },
-		{ percentage = 42, to = data.node.scale * Vector2(1.3, 1.3) },
-		{ percentage = 70, to = data.node.scale * Vector2(1, 1) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 14, to = scale * Vector2(1.3, 1.3) },
+		{ percentage = 28, to = scale * Vector2(1, 1) },
+		{ percentage = 42, to = scale * Vector2(1.3, 1.3) },
+		{ percentage = 70, to = scale * Vector2(1, 1) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	DialogicAnimaPropertiesHelper.set_2D_pivot(data.node, DialogicAnimaPropertiesHelper.PIVOT.CENTER)

--- a/addons/dialogic/Nodes/Anima/animations/attention_seeker/pulse.gd
+++ b/addons/dialogic/Nodes/Anima/animations/attention_seeker/pulse.gd
@@ -1,8 +1,10 @@
 func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 50, to = data.node.scale * Vector2(1.05, 1.05), easing = anima_tween.EASING.EASE_IN_OUT_SINE },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 50, to = scale * Vector2(1.05, 1.05), easing = anima_tween.EASING.EASE_IN_OUT_SINE },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	DialogicAnimaPropertiesHelper.set_2D_pivot(data.node, DialogicAnimaPropertiesHelper.PIVOT.CENTER)

--- a/addons/dialogic/Nodes/Anima/animations/attention_seeker/rubber_band.gd
+++ b/addons/dialogic/Nodes/Anima/animations/attention_seeker/rubber_band.gd
@@ -1,12 +1,13 @@
 func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 30, to = data.node.scale * Vector2(1.25, 0.75) },
-		{ percentage = 40, to = data.node.scale * Vector2(0.75, 1.25) },
-		{ percentage = 50, to = data.node.scale * Vector2(1.15, 0.85) },
-		{ percentage = 65, to = data.node.scale * Vector2(0.95, 1.05) },
-		{ percentage = 75, to = data.node.scale * Vector2(1.05, 0.95) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 30, to = scale * Vector2(1.25, 0.75) },
+		{ percentage = 40, to = scale * Vector2(0.75, 1.25) },
+		{ percentage = 50, to = scale * Vector2(1.15, 0.85) },
+		{ percentage = 65, to = scale * Vector2(0.95, 1.05) },
+		{ percentage = 75, to = scale * Vector2(1.05, 0.95) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	DialogicAnimaPropertiesHelper.set_2D_pivot(data.node, DialogicAnimaPropertiesHelper.PIVOT.CENTER)

--- a/addons/dialogic/Nodes/Anima/animations/attention_seeker/tada.gd
+++ b/addons/dialogic/Nodes/Anima/animations/attention_seeker/tada.gd
@@ -3,7 +3,7 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 0, from = 0 },
 	]
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = DialogicAnimaPropertiesHelper.get_scale(data.node) * Vector2(1, 1) },
 	]
 
 	for index in range(2, 9):

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_down.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_down.gd
@@ -5,10 +5,11 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 100, to = 0 },
 	]
 	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 80, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(0.7, 0.7) },
+		{ percentage = 80, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_left.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_left.gd
@@ -5,10 +5,11 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 100, to = 0 },
 	]
 	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 80, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(0.7, 0.7) },
+		{ percentage = 80, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_right.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_right.gd
@@ -5,10 +5,11 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 100, to = 0 },
 	]
 	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 80, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(0.7, 0.7) },
+		{ percentage = 80, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_up.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_in_up.gd
@@ -5,10 +5,11 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 100, to = 0 },
 	]
 	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale *  Vector2(0.7, 0.7) },
-		{ percentage = 80, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale *  Vector2(0.7, 0.7) },
+		{ percentage = 80, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_down.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_down.gd
@@ -4,11 +4,12 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 20, to = 0 },
 		{ percentage = 100, to = -700 },
 	]
-
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 20, to = data.node.scale *  Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(0.7, 0.7) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 20, to = scale *  Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(0.7, 0.7) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_left.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_left.gd
@@ -5,10 +5,11 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 100, to = -2000 },
 	]
 
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 20, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(0.7, 0.7) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 20, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(0.7, 0.7) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_right.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_right.gd
@@ -4,11 +4,12 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 20, to = 0 },
 		{ percentage = 100, to = 2000 },
 	]
-
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(1, 1) },
-		{ percentage = 20, to = data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to = data.node.scale * Vector2(0.7, 0.7) },
+		{ percentage = 0, from = scale * Vector2(1, 1) },
+		{ percentage = 20, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(0.7, 0.7) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_up.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/back_out_up.gd
@@ -4,11 +4,12 @@ func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
 		{ percentage = 20, to = 0 },
 		{ percentage = 100, to = 700 },
 	]
-
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from =  data.node.scale * Vector2(1, 1) },
-		{ percentage = 20, to =  data.node.scale * Vector2(0.7, 0.7) },
-		{ percentage = 100, to =  data.node.scale * Vector2(0.7, 0.7) },
+		{ percentage = 0, from =  scale * Vector2(1, 1) },
+		{ percentage = 20, to =  scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to =  scale * Vector2(0.7, 0.7) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/bouncing_in.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/bouncing_in.gd
@@ -1,11 +1,12 @@
 func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
 	var scale_frames = [
-		{ percentage = 0, from = data.node.scale * Vector2(0.3, 0.3), easing_points = [0.215, 0.61, 0.355, 1] },
-		{ percentage = 20, to = data.node.scale * Vector2(1, 1), easing_points = [0.215, 0.61, 0.355, 1] },
-		{ percentage = 40, to = data.node.scale * Vector2(0.9, 0.9), easing_points = [0.215, 0.61, 0.355, 1] },
-		{ percentage = 60, to = data.node.scale * Vector2(1.03, 1.03), easing_points = [0.215, 0.61, 0.355, 1] },
-		{ percentage = 80, to = data.node.scale * Vector2(0.97, 0.97), easing_points = [0.215, 0.61, 0.355, 1] },
-		{ percentage = 100, to = data.node.scale * Vector2(1, 1) },
+		{ percentage = 0, from = scale * Vector2(0.3, 0.3), easing_points = [0.215, 0.61, 0.355, 1] },
+		{ percentage = 20, to = scale * Vector2(1, 1), easing_points = [0.215, 0.61, 0.355, 1] },
+		{ percentage = 40, to = scale * Vector2(0.9, 0.9), easing_points = [0.215, 0.61, 0.355, 1] },
+		{ percentage = 60, to = scale * Vector2(1.03, 1.03), easing_points = [0.215, 0.61, 0.355, 1] },
+		{ percentage = 80, to = scale * Vector2(0.97, 0.97), easing_points = [0.215, 0.61, 0.355, 1] },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
 	]
 
 	var opacity_frames = [

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -730,7 +730,7 @@ func event_handler(event: Dictionary):
 								
 								portrait.animate(event.get('animation', '[No Animation]'), event.get('animation_length', 1), event.get('animation_repeat', 1))
 								
-								if event.get('animation_wait', false):
+								if event.get('animation_wait', false) and event.get('animation', '[No Animation]') != "[No Animation]":
 									yield(portrait, 'animation_finished')
 				set_state(state.READY)
 				_load_next_event()


### PR DESCRIPTION
The animations now use DialogicAnimaPropertiesHelper.get_scale(node) instead of just node.scale, because this doesn't work for Control nodes. This should fix #834

I would like this to be tested by @miguel, because I'm not sure it still works like he wanted for Custom Portraits.

Small other fix: When enabeling "Wait for animation" but having no animation selected, it would just stop there, with no way to continue the game. This setting is now ignored in this case.