### PR TITLE
Improvements (including Characters, Resource Picker, Changed Extensions)

### DIFF
--- a/Emilio.dch
+++ b/Emilio.dch
@@ -1,0 +1,3 @@
+Emilio
+Emi
+ff307fae

--- a/John.dch
+++ b/John.dch
@@ -1,0 +1,3 @@
+John
+The President
+ffcb3e3e

--- a/addons/dialogic/Editor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor.gd
@@ -1,0 +1,8 @@
+tool
+extends Control
+
+func new_character(path):
+	print('hi')
+	var resource = DialogicCharacter.new()
+	resource.resource_path = path
+	ResourceSaver.save(path, resource)

--- a/addons/dialogic/Editor/Common/Toolbar.gd
+++ b/addons/dialogic/Editor/Common/Toolbar.gd
@@ -11,8 +11,15 @@ func _ready():
 
 
 	$AddTimeline.icon = load("res://addons/dialogic/Images/Toolbar/add-timeline.svg")
-	
 
 
 func _on_AddTimeline_pressed():
 	get_node("%TimelineEditor").new_timeline()
+
+func set_resource_saved():
+	if $CurrentResource.text.ends_with(("(*)")):
+		$CurrentResource.text = $CurrentResource.text.trim_suffix("(*)")
+
+func set_resource_unsaved():
+	if not $CurrentResource.text.ends_with(("(*)")):
+		$CurrentResource.text += "(*)"

--- a/addons/dialogic/Editor/Common/Toolbar.gd
+++ b/addons/dialogic/Editor/Common/Toolbar.gd
@@ -16,6 +16,9 @@ func _ready():
 func _on_AddTimeline_pressed():
 	get_node("%TimelineEditor").new_timeline()
 
+func _on_AddCharacter_pressed():
+	get_parent().get_parent().get_parent().godot_file_dialog(get_parent().get_node("CharacterEditor"), 'new_character', '*.dch; DialogicCharacter', EditorFileDialog.MODE_SAVE_FILE)
+
 func set_resource_saved():
 	if $CurrentResource.text.ends_with(("(*)")):
 		$CurrentResource.text = $CurrentResource.text.trim_suffix("(*)")

--- a/addons/dialogic/Editor/Common/Toolbar.tscn
+++ b/addons/dialogic/Editor/Common/Toolbar.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Common/Toolbar.gd" type="Script" id=2]
 [ext_resource path="res://addons/dialogic/Images/Toolbar/add-timeline.svg" type="Texture" id=3]
+[ext_resource path="res://addons/dialogic/Images/Toolbar/add-character.svg" type="Texture" id=4]
 
 [node name="Toolbar" type="HBoxContainer"]
 margin_right = 1024.0
@@ -16,25 +17,33 @@ hint_tooltip = "Add Timeline"
 icon = ExtResource( 3 )
 flat = true
 
+[node name="AddCharacter" type="Button" parent="."]
+margin_left = 32.0
+margin_right = 60.0
+margin_bottom = 22.0
+hint_tooltip = "Add Timeline"
+icon = ExtResource( 4 )
+flat = true
+
 [node name="TLabel" parent="." instance=ExtResource( 1 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 32.0
+margin_left = 64.0
 margin_top = 4.0
-margin_right = 83.0
+margin_right = 115.0
 margin_bottom = 18.0
 text = "Current:"
 text_key = "Current:"
 
 [node name="CurrentResource" type="Label" parent="."]
-margin_left = 87.0
+margin_left = 119.0
 margin_top = 4.0
-margin_right = 121.0
+margin_right = 153.0
 margin_bottom = 18.0
 text = "None"
 
 [node name="Spacer" type="Control" parent="."]
-margin_left = 125.0
+margin_left = 157.0
 margin_right = 885.0
 margin_bottom = 22.0
 size_flags_horizontal = 3
@@ -54,3 +63,4 @@ custom_colors/font_color = Color( 0, 0, 0, 1 )
 text = "v2.0-Alpha"
 
 [connection signal="pressed" from="AddTimeline" to="." method="_on_AddTimeline_pressed"]
+[connection signal="pressed" from="AddCharacter" to="." method="_on_AddCharacter_pressed"]

--- a/addons/dialogic/Editor/Common/Toolbar.tscn
+++ b/addons/dialogic/Editor/Common/Toolbar.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Common/Toolbar.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Images/Toolbar/add-timeline.svg" type="Texture" id=3]
 
 [node name="Toolbar" type="HBoxContainer"]
 margin_right = 1024.0
@@ -9,30 +10,31 @@ margin_bottom = 22.0
 script = ExtResource( 2 )
 
 [node name="AddTimeline" type="Button" parent="."]
-margin_right = 12.0
+margin_right = 28.0
 margin_bottom = 22.0
 hint_tooltip = "Add Timeline"
+icon = ExtResource( 3 )
 flat = true
 
 [node name="TLabel" parent="." instance=ExtResource( 1 )]
 anchor_right = 0.0
 anchor_bottom = 0.0
-margin_left = 16.0
+margin_left = 32.0
 margin_top = 4.0
-margin_right = 127.0
+margin_right = 83.0
 margin_bottom = 18.0
-text = "Current Timeline:"
-text_key = "Current Timeline:"
+text = "Current:"
+text_key = "Current:"
 
-[node name="Label" type="Label" parent="."]
-margin_left = 131.0
+[node name="CurrentResource" type="Label" parent="."]
+margin_left = 87.0
 margin_top = 4.0
-margin_right = 165.0
+margin_right = 121.0
 margin_bottom = 18.0
 text = "None"
 
 [node name="Spacer" type="Control" parent="."]
-margin_left = 169.0
+margin_left = 125.0
 margin_right = 885.0
 margin_bottom = 22.0
 size_flags_horizontal = 3

--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -1,9 +1,15 @@
 tool
 extends Control
 
+var editor_file_dialog:EditorFileDialog
+
 func _ready():
 	$MarginContainer/VBoxContainer/Toolbar/Settings.connect("button_up", self, "show_settings")
 	set_current_margin($MarginContainer, get_constant("separation", "BoxContainer") - 1)
+	
+	# File dialog
+	editor_file_dialog = EditorFileDialog.new()
+	add_child(editor_file_dialog)
 
 
 func edit_timeline(object):
@@ -18,3 +24,20 @@ func set_current_margin(node, separation):
 
 func show_settings():
 	$SettingsEditor.popup_centered()
+
+
+func godot_file_dialog(object, method, filter, mode = EditorFileDialog.MODE_OPEN_FILE):
+	for connection in editor_file_dialog.get_signal_connection_list('file_selected'):
+		editor_file_dialog.disconnect('file_selected', connection.target, connection.method)
+	editor_file_dialog.mode = mode
+	editor_file_dialog.clear_filters()
+	editor_file_dialog.popup_centered_ratio(0.75)
+	editor_file_dialog.add_filter(filter)
+	editor_file_dialog.window_title = "Save new Timeline"
+	editor_file_dialog.current_file = "New_Timeline"
+	if mode == EditorFileDialog.MODE_OPEN_FILE or EditorFileDialog.MODE_SAVE_FILE:
+		editor_file_dialog.connect('file_selected', object, method)
+	elif mode == EditorFileDialog.MODE_OPEN_DIR:
+		editor_file_dialog.connect('dir_selected', object, method)
+	return editor_file_dialog
+	

--- a/addons/dialogic/Editor/EditorView.tscn
+++ b/addons/dialogic/Editor/EditorView.tscn
@@ -29,6 +29,7 @@ margin_right = 1028.0
 margin_bottom = 604.0
 
 [node name="Toolbar" parent="MarginContainer/VBoxContainer" instance=ExtResource( 4 )]
+unique_name_in_owner = true
 margin_right = 1028.0
 
 [node name="TimelineEditor" parent="MarginContainer/VBoxContainer" instance=ExtResource( 1 )]

--- a/addons/dialogic/Editor/EditorView.tscn
+++ b/addons/dialogic/Editor/EditorView.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/TimelineEditor/TimelineEditor.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Editor/EditorView.gd" type="Script" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Settings/SettingsEditor.tscn" type="PackedScene" id=3]
 [ext_resource path="res://addons/dialogic/Editor/Common/Toolbar.tscn" type="PackedScene" id=4]
+[ext_resource path="res://addons/dialogic/Editor/CharacterEditor.gd" type="Script" id=5]
 
 [node name="EditorView" type="Control"]
 anchor_right = 1.0
@@ -38,9 +39,15 @@ anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 26.0
 margin_right = 1028.0
-margin_bottom = 604.0
+margin_bottom = 600.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
+
+[node name="CharacterEditor" type="Control" parent="MarginContainer/VBoxContainer"]
+margin_top = 604.0
+margin_right = 1028.0
+margin_bottom = 604.0
+script = ExtResource( 5 )
 
 [node name="SettingsEditor" parent="." instance=ExtResource( 3 )]
 visible = false

--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
@@ -1,69 +1,142 @@
 tool
 extends Control
 
-var event_resource : DialogicEvent = null
-var resource_type = null
 
+## SETTINGS FOR THE RESOURCE PICKER
+enum resource_types {Characters, Timelines, Themes, Portraits}
+var resource_type = resource_types.Characters
+
+var file_extensions : Dictionary = {
+	resource_types.Characters : '.dch',
+	resource_types.Timelines : '.dtl',
+	}
+# I'm so sorry for this, but the popup_hide signal get's triggered if the popup is hidden by me,
+# and I don't want it to change the resource, if one was just selected by clicking
+var ignore_popup_hide_once = false
+
+
+## STORING VALUE AND REFERENCE TO RESOURCE
+var event_resource : DialogicEvent = null
 var property_name : String
+var current_value
+
+# this signal is on all event parts and informs the event that a change happened.
 signal value_changed
 
-func _ready():
-	pass#list_resources_of_type()
-	
+################################################################################
+## 						BASIC EVENT PART FUNCTIONS
+################################################################################
+# These functions have to be implemented by all scenes that are used to display 
+# values on the events.
+
 func set_hint(value):
 	$Hint.text = str(value)
 
 func set_value(value):
-	if value is DialogicTimeline:
-		$Search.text = value._to_string()
+	if value is DialogicCharacter:
+		$Search.text = value.name
+		$Search/OpenButton.show()
 	else:
 		$Search.text = "Nothing selected"
+		$Search/OpenButton.hide()
+	current_value = value
 
-func _on_Search_text_entered(new_text):
-	pass#emit_signal("value_changed", property_name, $Search.text)
 
+################################################################################
+## 						BASIC
+################################################################################
+func _ready():
+	$Search/Suggestions.hide()
+	$Search/Suggestions.connect("index_pressed", self, 'suggestion_selected')
+	$Search/Suggestions.connect("popup_hide", self, 'popup_hide')
+	$Search/OpenButton.icon = get_icon("EditResource", "EditorIcons")
+
+
+################################################################################
+## 						SEARCH & SUGGESTION POPUP
+################################################################################
+func _on_Search_text_entered(new_text = ""):
+	if $Search/Suggestions.get_item_count() and not $Search.text.empty():
+		suggestion_selected(0)
+	else:
+		set_value(current_value)
 
 func _on_Search_text_changed(new_text):
+	$Search/Suggestions.clear()
+	
 	if new_text != "":
-		$Search/Suggestions.show()
+		var ext = ""
+		if resource_type in file_extensions:
+			ext = file_extensions[resource_type]
+		else:
+			return
+		var resources = DialogicUtil.list_resources_of_type(ext)
+		#print(characters)
+		var idx = 0
+		for element in resources:
+			if new_text.to_lower() in element.to_lower().get_file().trim_suffix(ext):
+				$Search/Suggestions.add_item(element.get_file().trim_suffix(ext))
+				$Search/Suggestions.set_item_metadata(idx, element)
+				idx += 1
+		
+		if not $Search/Suggestions.visible:
+			$Search/Suggestions.popup(Rect2($Search.rect_global_position + Vector2(0,1)*$Search.rect_size, Vector2($Search.rect_size.x, 100)))
+			$Search.grab_focus()
+	else:
+		$Search/Suggestions.hide()
+	
+func suggestion_selected(index):
+	var file = load($Search/Suggestions.get_item_metadata(index))
+	$Search.text = file.name
+	current_value = file
+	emit_signal("value_changed", property_name, file)
+	ignore_popup_hide_once = true
+	$Search/Suggestions.hide()
+	
+	$Search/OpenButton.show()
+
+func popup_hide():
+	if ignore_popup_hide_once:
+		ignore_popup_hide_once = false
+		return
+	if $Search/Suggestions.get_item_count() and not $Search.text.empty():
+		suggestion_selected(0)
+	else:
+		set_value(current_value)
+
+
+################################################################################
+##	 					DRAG AND DROP
+################################################################################
 
 func can_drop_data(position, data):
-	#print(position)
-	print(data)
 	if typeof(data) == TYPE_DICTIONARY and data.has('files') and len(data.files) == 1:
-		var file = load(data.files[0])
-		print(file)
-		if file is DialogicTimeline:
-			print("true")
-			return true
-		
+		if resource_type in file_extensions:
+			if data.files[0].ends_with(file_extensions[resource_type]):
+				return true
+		else:
+			return false
 	return false
 	
 func drop_data(position, data):
-	print("DATA DROPPED")
-	print(data)
 	var file = load(data.files[0])
-	$Search.text = file.to_string()
+	$Search.text = file.name
+	current_value = file
 	emit_signal("value_changed", property_name, file)
 
-func list_resources_of_type():
-	var dialogic_plugin = get_tree().root.get_node('EditorNode/DialogicPlugin')
-	dialogic_plugin.connect('dialogic_save', self, 'save_timeline')
-	scan_folder('res://', dialogic_plugin)
+	$Search/OpenButton.show()
 
-func scan_folder(folder_path, d_plugin):
-	var dir = Directory.new()
-	if dir.open(folder_path) == OK:
-		dir.list_dir_begin()
-		var file_name = dir.get_next()
-		while file_name != "":
-			if dir.current_is_dir():
-				print("Found directory: ", file_name )
-			else:
-				print("Found file: " + file_name)
-				print("It's of type ", d_plugin._editor_interface.get_resource_filesystem().get_file_type("res://"+file_name))
-			file_name = dir.get_next()
-	else:
-		print("An error occurred when trying to access the path.")
 
-	
+
+################################################################################
+##	 					OPEN RESOURCE BUTTON
+################################################################################
+
+# This function triggers the resource to be opened in the inspector and possible editors provided by plugins
+func _on_OpenButton_pressed():
+	if current_value:
+		var dialogic_plugin = get_tree().root.get_node('EditorNode/DialogicPlugin')
+		if typeof(current_value) == TYPE_STRING and not current_value.empty():
+			dialogic_plugin._editor_interface.inspect_object(load(current_value))
+		elif typeof(current_value) == TYPE_OBJECT:
+			dialogic_plugin._editor_interface.inspect_object(current_value)

--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
@@ -37,7 +37,7 @@ func set_value(value):
 		$Search.text = value.name
 		$Search/OpenButton.show()
 	else:
-		$Search.text = "Nothing selected"
+		$Search.text = ""
 		$Search/OpenButton.hide()
 	current_value = value
 

--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
@@ -15,26 +15,40 @@ script = ExtResource( 1 )
 margin_top = 5.0
 margin_bottom = 19.0
 
-[node name="Search" type="LineEdit" parent="."]
+[node name="Control" type="Control" parent="."]
 margin_left = 4.0
+margin_right = 4.0
+margin_bottom = 24.0
+
+[node name="Search" type="LineEdit" parent="."]
+margin_left = 8.0
 margin_right = 503.0
 margin_bottom = 24.0
 rect_min_size = Vector2( 200, 0 )
+focus_next = NodePath("Suggestions")
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme = ExtResource( 2 )
+placeholder_text = "Character"
 caret_blink = true
 caret_blink_speed = 0.5
 
 [node name="Suggestions" type="PopupMenu" parent="Search"]
-anchor_top = 1.0
+margin_left = 6.0
+margin_top = 27.0
+margin_right = 440.0
+margin_bottom = 139.0
+
+[node name="OpenButton" type="ToolButton" parent="Search"]
+anchor_left = 1.0
+anchor_top = 0.5
 anchor_right = 1.0
-anchor_bottom = 1.0
-margin_left = 1.0
-margin_top = 3.0
-margin_right = 1.0
-margin_bottom = 23.0
+anchor_bottom = 0.5
+margin_left = -25.0
+margin_top = -12.0
+margin_bottom = 12.0
 
 [connection signal="text_changed" from="Search" to="." method="_on_Search_text_changed"]
 [connection signal="text_entered" from="Search" to="." method="_on_Search_text_entered"]
+[connection signal="pressed" from="Search/OpenButton" to="." method="_on_OpenButton_pressed"]

--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
@@ -24,13 +24,14 @@ margin_bottom = 24.0
 margin_left = 8.0
 margin_right = 503.0
 margin_bottom = 24.0
-rect_min_size = Vector2( 200, 0 )
+rect_min_size = Vector2( 140, 0 )
+focus_neighbour_bottom = NodePath("Suggestions")
 focus_next = NodePath("Suggestions")
 mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme = ExtResource( 2 )
-placeholder_text = "Character"
+placeholder_text = "Select Resource"
 caret_blink = true
 caret_blink_speed = 0.5
 

--- a/addons/dialogic/Editor/Events/Fields/Number.gd
+++ b/addons/dialogic/Editor/Events/Fields/Number.gd
@@ -1,0 +1,19 @@
+tool
+extends Control
+
+var property_name : String
+signal value_changed
+
+func _ready():
+	$Value.connect("value_changed", self,  'value_changed')
+
+
+func value_changed(value):
+	emit_signal("value_changed", property_name, $Value.value)
+
+
+func set_hint(value):
+	$Hint.text = str(value)
+
+func set_value(value):
+	$Value.value = str(value)

--- a/addons/dialogic/Editor/Events/Fields/Number.tscn
+++ b/addons/dialogic/Editor/Events/Fields/Number.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Events/Fields/Number.gd" type="Script" id=1]
+
+[node name="NumberValue" type="HBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 1 )
+
+[node name="Hint" type="Label" parent="."]
+margin_top = 293.0
+margin_bottom = 307.0
+
+[node name="Value" type="SpinBox" parent="."]
+margin_left = 4.0
+margin_right = 78.0
+margin_bottom = 600.0
+
+[connection signal="value_changed" from="Value" to="." method="_on_Value_value_changed"]

--- a/addons/dialogic/Editor/Events/Fields/OptionSelector.gd
+++ b/addons/dialogic/Editor/Events/Fields/OptionSelector.gd
@@ -1,0 +1,34 @@
+tool
+extends Control
+
+var property_name : String
+signal value_changed
+
+var options : Dictionary
+
+func _ready():
+	$MenuButton.connect("about_to_show", self,  'insert_options')
+	$MenuButton.get_popup().connect("index_pressed", self,  'index_pressed')
+
+func set_hint(value):
+	$Hint.text = str(value)
+
+func set_value(value):
+	for element in options:
+		if options[element] == value:
+			$MenuButton.text = element
+
+
+func insert_options():
+	$MenuButton.get_popup().clear()
+	
+	var idx = 0
+	for option in options:
+		$MenuButton.get_popup().add_item(option)
+		$MenuButton.get_popup().set_item_metadata(idx, options[option])
+		idx += 1
+
+func index_pressed(idx):
+	$MenuButton.text = $MenuButton.get_popup().get_item_text(idx)
+	
+	emit_signal("value_changed", property_name, $MenuButton.get_popup().get_item_metadata(idx))

--- a/addons/dialogic/Editor/Events/Fields/OptionSelector.tscn
+++ b/addons/dialogic/Editor/Events/Fields/OptionSelector.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Events/Fields/OptionSelector.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Events/styles/SimpleButtonHover.tres" type="StyleBox" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Events/styles/SimpleButtonNormal.tres" type="StyleBox" id=3]
+
+[node name="OptionSelector" type="HBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_right = -261.0
+margin_bottom = -538.0
+script = ExtResource( 1 )
+
+[node name="Hint" type="Label" parent="."]
+margin_top = 24.0
+margin_bottom = 38.0
+
+[node name="MenuButton" type="MenuButton" parent="."]
+margin_left = 4.0
+margin_top = 21.0
+margin_right = 84.0
+margin_bottom = 41.0
+rect_min_size = Vector2( 80, 0 )
+size_flags_vertical = 4
+custom_styles/hover = ExtResource( 2 )
+custom_styles/normal = ExtResource( 3 )
+flat = false

--- a/addons/dialogic/Editor/Events/Templates/EventNode.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.gd
@@ -184,7 +184,13 @@ func build_editor():
 		elif p.type == TYPE_OBJECT and p.has('dialogic_type'):
 			if p.dialogic_type == resource.DialogicValueType.Character:
 				editor_node = load("res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn").instance()
-		
+		elif p.type == TYPE_INT:
+			if not p.has('dialogic_type') or p.dialogic_type == resource.DialogicValueType.Integer:
+				editor_node = load("res://addons/dialogic/Editor/Events/Fields/Number.tscn").instance()
+			elif p.dialogic_type == resource.DialogicValueType.FixedOptionSelector:
+				editor_node = load("res://addons/dialogic/Editor/Events/Fields/OptionSelector.tscn").instance()
+				if p.has('selector_options'):
+					editor_node.options = p.selector_options
 		else:
 			editor_node = Label.new()
 			editor_node.text = p.name

--- a/addons/dialogic/Editor/Events/Templates/EventNode.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.gd
@@ -4,6 +4,7 @@ extends HBoxContainer
 var event_name
 
 signal option_action(action_name)
+signal content_changed()
 
 # Resource
 var resource : DialogicEvent
@@ -219,6 +220,7 @@ func build_editor():
 
 func set_property(property_name, value):
 	resource.set(property_name, value)
+	emit_signal('content_changed')
 
 ## *****************************************************************************
 ##								OVERRIDES
@@ -241,37 +243,6 @@ func _ready():
 		_set_event_icon(resource.event_icon)
 	if event_name != null:
 		_set_event_name(event_name)
-	
-	var label_editor = load("res://addons/dialogic/Editor/Events/Fields/Label.tscn")
-	var text_area = load("res://addons/dialogic/Editor/Events/Fields/TextArea.tscn")
-	if resource.header != null:
-		#print('resource.header: ', resource.header)
-		for r in resource.header:
-			var new_node = label_editor.instance()
-
-			if r.type == 0: # Label
-				new_node = label_editor.instance()
-				new_node.text = r.key
-			if r.type == 1: # Text
-				new_node = text_area.instance()
-
-			header_content_container.add_child(new_node)
-			new_node.owner = self
-
-	if resource.body != null:
-		#print('resource.body: ', resource.body)
-		for r in resource.body:
-			var new_node = label_editor.instance()
-			if r.type:
-				if r.type == 0: # Label
-					new_node = label_editor.instance()
-					new_node.text = r.key
-				if r.type == 1: # Text
-					new_node = text_area.instance()
-
-			body_content_container.add_child(new_node)
-			new_node.owner = self
-		body_content_container.add_constant_override('margin_left', 40*DialogicUtil.get_editor_scale(self))
 
 	$PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer/IconPanel.set("self_modulate", resource.event_color)
 	

--- a/addons/dialogic/Editor/Events/test.gd
+++ b/addons/dialogic/Editor/Events/test.gd
@@ -2,6 +2,9 @@ tool
 extends DialogicEvent
 class_name MyCustomEvent
 
+
+
+
 func _init() -> void:
 	event_name = "Custom Event Test"
 

--- a/addons/dialogic/Editor/Events/text.gd
+++ b/addons/dialogic/Editor/Events/text.gd
@@ -5,7 +5,7 @@ extends DialogicEvent
 
 
 var Text:String = "" setget set_text
-var Character:String = ""
+var Character:DialogicCharacter
 
 # _init is the constructor
 # is called everytime the resource is being created
@@ -31,18 +31,23 @@ func _execute() -> void:
 
 ## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
 func get_as_string_to_store() -> String:
-	if not Character.empty():
-		return Character+": "+Text
+	if Character:
+		return Character.name+": "+Text
 	return Text
 
 ## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
 func load_from_string_to_store(string):
 	if ":" in string:
-		var char_name = string.split(": ", 1)[0]
-		Character = char_name
+		var char_name = string.get_slice(": ", 0)
+		var character = DialogicUtil.guess_resource('.dch', char_name)
+		if character:
+			Character = load(character)
+		else:
+			Character = null
+			print("When importing timeline, we couldn't identify what character you meant with ", char_name, ".")
 		Text = string.split(": ", 1)[1]
 	else:
-		Character = ""
+		Character = null
 		Text = string
 
 
@@ -50,10 +55,10 @@ func _get_property_list() -> Array:
 	var p_list = []
 	p_list.append({
 		"name":"Character",
-		"type":TYPE_STRING,
+		"type":TYPE_OBJECT,
 		"location": Location.HEADER,
 		"usage":PROPERTY_USAGE_DEFAULT,
-		"dialogic_type":DialogicValueType.SinglelineText,
+		"dialogic_type":DialogicValueType.Character,
 		"hint_string":"Character:"
 		})
 	p_list.append({

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -66,10 +66,10 @@ func _ready():
 	
 	# Event buttons
 	var buttonScene = load("res://addons/dialogic/Editor/TimelineEditor/SmallEventButton.tscn")
-	var file_list = DialogicUtil.listdir("res://addons/dialogic/Editor/Events/")
+	var file_list = DialogicUtil.listdir("res://addons/dialogic/Resources/Events/")
 	for file in file_list:
 		if '.gd' in file:
-			var event_script = load("res://addons/dialogic/Editor/Events/" + file)
+			var event_script = load("res://addons/dialogic/Resources/Events/" + file)
 			var event_resource = event_script.new()
 			var button = buttonScene.instance()
 			button.resource = event_resource

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -1,8 +1,6 @@
 tool
 extends VBoxContainer
 
-var editor_file_dialog
-
 var current_timeline: DialogicTimeline
 
 var TimelineUndoRedo := UndoRedo.new()
@@ -40,11 +38,6 @@ func _ready():
 
 	
 	connect("batch_loaded", self, '_on_batch_loaded')
-	
-	# File dialog
-	editor_file_dialog = EditorFileDialog.new()
-	add_child(editor_file_dialog)
-	editor_file_dialog.connect('file_selected', self, 'create_and_save_new_timeline')
 	
 	# Margins
 	var modifier = ''
@@ -768,7 +761,7 @@ func add_event_to_timeline(event_resource:Resource, at_index:int = -1, auto_sele
 func new_timeline() -> void:
 	save_timeline()
 	clear_timeline()
-	godot_file_dialog('*.timeline; DialogicTimeline', EditorFileDialog.MODE_SAVE_FILE)
+	get_parent().get_parent().get_parent().godot_file_dialog(self,  'create_and_save_new_timeline', '*.dtl; DialogicTimeline', EditorFileDialog.MODE_SAVE_FILE)
 
 # Saving
 func save_timeline() -> void:
@@ -780,20 +773,11 @@ func save_timeline() -> void:
 	if current_timeline:
 		current_timeline.set_events(new_events)
 		ResourceSaver.save(current_timeline.resource_path, current_timeline)
+		get_node("%Toolbar").set_resource_saved()
 	else:
 		if new_events.size() > 0:
-			godot_file_dialog('*.timeline; DialogicTimeline', EditorFileDialog.MODE_SAVE_FILE)
-	get_node("%Toolbar").set_resource_saved()
+			get_parent().get_parent().get_parent().godot_file_dialog(self, 'create_and_save_new_timeline', '*.dtl; DialogicTimeline', EditorFileDialog.MODE_SAVE_FILE)
 
-func godot_file_dialog(filter, mode = EditorFileDialog.MODE_OPEN_FILE):
-	editor_file_dialog.mode = mode
-	editor_file_dialog.clear_filters()
-	editor_file_dialog.popup_centered_ratio(0.75)
-	editor_file_dialog.add_filter(filter)
-	editor_file_dialog.window_title = "Save new Timeline"
-	editor_file_dialog.current_file = "New_Timeline"
-	return editor_file_dialog
-	
 
 func create_and_save_new_timeline(path):
 	var new_timeline = DialogicTimeline.new()

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -733,7 +733,7 @@ func add_event_to_timeline(event_resource:Resource, at_index:int = -1, auto_sele
 	var piece = event_node.instance()
 	var resource = event_resource
 	piece.resource = event_resource
-	
+	piece.connect('content_changed', self, 'something_changed')
 	if at_index == -1:
 		if len(selected_items) != 0:
 			timeline.add_child_below_node(selected_items[0], piece)
@@ -783,7 +783,7 @@ func save_timeline() -> void:
 	else:
 		if new_events.size() > 0:
 			godot_file_dialog('*.timeline; DialogicTimeline', EditorFileDialog.MODE_SAVE_FILE)
-
+	get_node("%Toolbar").set_resource_saved()
 
 func godot_file_dialog(filter, mode = EditorFileDialog.MODE_OPEN_FILE):
 	editor_file_dialog.mode = mode
@@ -807,7 +807,7 @@ func create_and_save_new_timeline(path):
 func load_timeline(object) -> void:
 	#print('[D] Load timeline: ', object)
 	clear_timeline()
-	get_parent().get_node('Toolbar/Label').text = object.resource_path
+	get_node('%Toolbar/CurrentResource').text = object.resource_path
 	current_timeline = object
 	var data = object.get_events()
 	var page = 1
@@ -818,6 +818,10 @@ func load_timeline(object) -> void:
 	load_batch(batches)
 	# Reset the scroll position
 	timeline_area.scroll_vertical = 0
+
+
+func something_changed():
+	get_node('%Toolbar').set_resource_unsaved()
 
 
 func batch_events(array, size, batch_number):

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -63,3 +63,32 @@ static func listdir(path: String) -> Array:
 static func get_dialogic_plugin() -> Node:
 	var tree: SceneTree = Engine.get_main_loop()
 	return tree.get_root().get_node('EditorNode/DialogicPlugin')
+
+
+
+static func list_resources_of_type(extension):
+	var all_resources = scan_folder('res://', extension)
+	return all_resources
+
+static func scan_folder(folder_path:String, extension:String):
+	var dir = Directory.new()
+	var list = []
+	if dir.open(folder_path) == OK:
+		dir.list_dir_begin()
+		var file_name = dir.get_next()
+		while file_name != "":
+			if dir.current_is_dir() and not file_name.begins_with("."):
+				list += scan_folder(folder_path+"/"+file_name, extension)
+			else:
+				if file_name.ends_with(extension):
+					list.append(folder_path+"/"+file_name)
+			file_name = dir.get_next()
+	else:
+		print("An error occurred when trying to access the path.")
+	return list
+
+static func guess_resource(extension, identifier):
+	var resources = list_resources_of_type(extension)
+	for resource_path in resources:
+		if resource_path.get_file().trim_suffix(extension) == identifier:
+			return resource_path

--- a/addons/dialogic/Resources/CharacterResourceLoader.gd
+++ b/addons/dialogic/Resources/CharacterResourceLoader.gd
@@ -6,7 +6,7 @@ extends ResourceFormatLoader
 
 # Docs says that it needs a class_name in order to register it in ResourceLoader
 # Who am I to judge the docs?
-class_name DialogicTimelineFormatLoader
+class_name DialogicCharacterFormatLoader
 
 # Preload to avoid problems with project.godot
 #const TimelineResource = preload("res://addons/dialogic/Resources/timeline.gd")
@@ -14,7 +14,7 @@ class_name DialogicTimelineFormatLoader
 # Dude, look at the docs, I'm not going to explain each function... 
 # Specially when they are self explainatory...
 func get_recognized_extensions() -> PoolStringArray:
-	return PoolStringArray(["dtl"])
+	return PoolStringArray(["dch"])
 
 
 # Ok, if custom resources were a thing this would be even useful.
@@ -27,7 +27,7 @@ func get_resource_type(path: String) -> String:
 	# and you return "Resource" (or whatever you're working on) if you handle it.
 	# Everything else ""
 	var ext = path.get_extension().to_lower()
-	if ext == "dtl":
+	if ext == "dch":
 		return "Resource"
 	
 	return ""
@@ -52,7 +52,7 @@ func load(path: String, original_path: String):
 	print('load ' , path)
 	var err:int
 	
-	var res := DialogicTimeline.new()
+	var res := DialogicCharacter.new()
 	
 	err = file.open(path, File.READ)
 	if err != OK:
@@ -60,14 +60,16 @@ func load(path: String, original_path: String):
 		# You has to return the error constant
 		return err
 	
+	var idx = 0
 	# Parse the lines as seperate events and recreate them as resources
-	var events = []
-	for line in file.get_as_text().split("\n", false):
-		var event = load("res://addons/dialogic/Editor/Events/text.gd").new()
-		event.load_from_string_to_store(line)
-		events.append(event)
-	
-	res.events = events
+	for line in file.get_as_text().split("\n", true):
+		if idx == 0:
+			res.name = line
+		elif idx == 1:
+			res.display_name = line
+		elif idx == 2:
+			res.color = Color(line)
+		idx += 1
 	
 	# Everything went well, and you parsed your file data into your resource. Life is good, return it
 	return res

--- a/addons/dialogic/Resources/CharacterResourceSaver.gd
+++ b/addons/dialogic/Resources/CharacterResourceSaver.gd
@@ -1,13 +1,13 @@
 tool
 extends ResourceFormatSaver
-class_name DialogicTimelineFormatSaver
+class_name DialogicCharacterFormatSaver
 
 # Preload to avoid problems with project.godot
 #const TimelineResource = preload("res://addons/custom_resource/resource_class.gd")
 
 
 func get_recognized_extensions(resource: Resource) -> PoolStringArray:
-	return PoolStringArray(["dtl"])
+	return PoolStringArray(["dch"])
 
 
 # Here you see if that resource is the type you need.
@@ -17,7 +17,7 @@ func get_recognized_extensions(resource: Resource) -> PoolStringArray:
 # You let other ResourceFormatSaver deal with it.
 func recognize(resource: Resource) -> bool:
 	# Cast instead of using "is" keyword in case is a subclass
-	resource = resource as DialogicTimeline
+	resource = resource as DialogicCharacter
 	
 	if resource:
 		return true
@@ -42,10 +42,7 @@ func save(path: String, resource: Resource, flags: int) -> int:
 		return err
 	
 	var result = ""
-	for event in resource.events:
-		if event != null:
-			result += event.get_as_string_to_store() + "\n"
-	
+	result = resource.name+"\n"+resource.display_name+"\n"+resource.color.to_html()+"\n"
 	file.store_string(result)
 	file.close()
 	return OK

--- a/addons/dialogic/Resources/Events/event_character.gd
+++ b/addons/dialogic/Resources/Events/event_character.gd
@@ -1,0 +1,101 @@
+tool
+extends DialogicEvent
+
+enum ActionTypes {Join, Leave, Update}
+
+# DEFINE ALL PROPERTIES OF THE EVENT
+var ActionType = ActionTypes.Join
+var Character : DialogicCharacter
+var Portrait = ""
+var Position = 0
+var Animation = ""
+
+func _execute() -> void:
+	# I have no idea how this event works
+	pass
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+# SET ALL VALUES THAT SHOULD NEVER CHANGE HERE
+func _init() -> void:
+	event_name = "Character"
+	event_icon = load("res://addons/dialogic/Images/Event Icons/Main Icons/character.svg")
+	event_color = Color(0.613488, 0.734375, 0.235229)
+	event_category = Category.MAIN
+	event_sorting_index = 2
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+
+## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
+func get_as_string_to_store() -> String:
+	var result_string = ""
+	
+	match ActionType:
+		ActionTypes.Join: result_string += "Join "
+		ActionTypes.Leave: result_string += "Leave "
+		ActionTypes.Update: result_string += "Update "
+	
+	if Character:
+		result_string += Character.name
+	
+	return result_string
+
+
+## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
+func load_from_string_to_store(string:String):
+	if string.begins_with("Join "):
+		ActionType = ActionTypes.Join
+		string = string.trim_prefix("Join ")
+	elif string.begins_with("Leave "):
+		ActionType = ActionTypes.Leave
+		string = string.trim_prefix("Leave ")
+	elif string.begins_with("Update "):
+		ActionType = ActionTypes.Update
+		string = string.trim_prefix("Update ")
+	var char_guess = DialogicUtil.guess_resource('.dch', string.strip_edges())
+	if char_guess:
+		Character = load(char_guess)
+
+
+# RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
+static func is_valid_event_string(string:String):
+	
+	if string.begins_with("Join ") or string.begins_with("Leave ") or string.begins_with("Update "):
+		return true
+	return false
+
+
+################################################################################
+## 						EDITOR REPRESENTATION
+################################################################################
+
+func _get_property_list() -> Array:
+	var p_list = []
+	
+	# fill the p_list with dictionaries like this one:
+	p_list.append({
+		"name":"ActionType", # Must be the same as the corresponding property that it edits!
+		"type":TYPE_INT,	# Defines the type of editor (LineEdit, Selector, etc.)
+		"location": Location.HEADER,	# Definest the location
+		"usage":PROPERTY_USAGE_DEFAULT,	
+		"dialogic_type":DialogicValueType.FixedOptionSelector,	# Additional information for value displays
+		"selector_options":{"Join":ActionTypes.Join, "Leave":ActionTypes.Leave, "Update":ActionTypes.Update},
+		"hint_string":"Action:"		# Text that will be displayed in front of the field
+		})
+	p_list.append({
+		"name":"Character", # Must be the same as the corresponding property that it edits!
+		"type":TYPE_OBJECT,	# Defines the type of editor (LineEdit, Selector, etc.)
+		"location": Location.HEADER,	# Definest the location
+		"usage":PROPERTY_USAGE_DEFAULT,	
+		"dialogic_type":DialogicValueType.Character,	# Additional information for value displays
+		"hint_string":"Character:"		# Text that will be displayed in front of the field
+		})
+	
+	
+	return p_list

--- a/addons/dialogic/Resources/Events/event_comment.gd
+++ b/addons/dialogic/Resources/Events/event_comment.gd
@@ -1,0 +1,71 @@
+tool
+extends DialogicEvent
+
+
+# DEFINE ALL PROPERTIES OF THE EVENT
+var Text :String = ""
+
+func _execute() -> void:
+	# I have no idea how this event works
+	pass
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+# SET ALL VALUES THAT SHOULD NEVER CHANGE HERE
+func _init() -> void:
+	event_name = "Comment"
+	event_icon = load("res://addons/dialogic/Images/Event Icons/Main Icons/label.svg")
+	event_color = Color(0.53125, 0.53125, 0.53125)
+	event_category = Category.OTHER
+	event_sorting_index = 0
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+
+## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
+func get_as_string_to_store() -> String:
+	var result_string = "# "+Text
+	return result_string
+
+
+## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
+func load_from_string_to_store(string:String):
+	Text = string.trim_prefix("# ")
+
+
+# RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
+static func is_valid_event_string(string:String):
+	if string.strip_edges().begins_with('#'):
+		return true
+	return false
+
+
+################################################################################
+## 						EDITOR REPRESENTATION
+################################################################################
+
+func _get_property_list() -> Array:
+	var p_list = []
+	
+	# fill the p_list with dictionaries like this one:
+#	p_list.append({
+#		"name":"Character", # Must be the same as the corresponding property that it edits!
+#		"type":TYPE_OBJECT,	# Defines the type of editor (LineEdit, Selector, etc.)
+#		"location": Location.HEADER,	# Definest the location
+#		"usage":PROPERTY_USAGE_DEFAULT,	
+#		"dialogic_type":DialogicValueType.Character,	# Additional information for resource pickers
+#		"hint_string":"Character:"		# Text that will be displayed in front of the field
+#		})
+	p_list.append({
+		"name":"Text", # Must be the same as the corresponding property that it edits!
+		"type":TYPE_STRING,	# Defines the type of editor (LineEdit, Selector, etc.)
+		"location": Location.HEADER,	# Definest the location
+		"usage":PROPERTY_USAGE_DEFAULT,	
+		"hint_string":"Comment:"		# Text that will be displayed in front of the field
+		})
+	return p_list

--- a/addons/dialogic/Resources/Events/event_text.gd
+++ b/addons/dialogic/Resources/Events/event_text.gd
@@ -32,8 +32,8 @@ func _execute() -> void:
 ## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
 func get_as_string_to_store() -> String:
 	if Character:
-		return Character.name+": "+Text
-	return Text
+		return Character.name+": "+Text.replace("\n", "<br>")
+	return Text.replace("\n", "<br>")
 
 ## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
 func load_from_string_to_store(string):
@@ -45,11 +45,13 @@ func load_from_string_to_store(string):
 		else:
 			Character = null
 			print("When importing timeline, we couldn't identify what character you meant with ", char_name, ".")
-		Text = string.split(": ", 1)[1]
+		Text = string.split(": ", 1)[1].replace("<br>", "\n")
 	else:
 		Character = null
-		Text = string
+		Text = string.replace("<br>", "\n")
 
+static func is_valid_event_string(string):
+	return true
 
 func _get_property_list() -> Array:
 	var p_list = []

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -63,7 +63,7 @@ func load(path: String, original_path: String):
 	# Parse the lines as seperate events and recreate them as resources
 	var events = []
 	for line in file.get_as_text().split("\n", false):
-		var event = load("res://addons/dialogic/Editor/Events/text.gd").new()
+		var event = load(identify_event(line)).new()
 		event.load_from_string_to_store(line)
 		events.append(event)
 	
@@ -72,3 +72,13 @@ func load(path: String, original_path: String):
 	# Everything went well, and you parsed your file data into your resource. Life is good, return it
 	return res
 
+func identify_event(line:String, prev_line:String = "", next_line:String = ""):
+	for event in [ # the text event should always be last. 
+		# Every event that isn't identified as something else, will end up as text
+		# We should get this list from a folder or something, but then we'll have to sort it somehow
+		"res://addons/dialogic/Resources/Events/event_character.gd",
+		"res://addons/dialogic/Resources/Events/event_comment.gd",
+		"res://addons/dialogic/Resources/Events/event_text.gd"
+	]:
+		if load(event).is_valid_event_string(line):
+			return event

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -43,7 +43,8 @@ func save(path: String, resource: Resource, flags: int) -> int:
 	
 	var result = ""
 	for event in resource.events:
-		result += event.get_as_string_to_store() + "\n"
+		if event != null:
+			result += event.get_as_string_to_store() + "\n"
 	
 	file.store_string(result)
 	file.close()

--- a/addons/dialogic/Resources/character.gd
+++ b/addons/dialogic/Resources/character.gd
@@ -1,0 +1,33 @@
+tool
+extends Resource
+class_name DialogicCharacter
+
+
+export (String) var name = ""
+export (String) var display_name = ""
+
+export (Color) var color = Color()
+
+export (Dictionary) var portraits = {}
+
+func __get_property_list() -> Array:
+	return []
+
+
+func property_can_revert(property:String) -> bool:
+	if property == "event_node_path":
+		return true
+	return false
+
+
+func property_get_revert(property:String):
+	if property == "event_node_path":
+		return NodePath()
+
+
+func _to_string() -> String:
+	return "[{name}:{id}]".format({"name":name, "id":get_instance_id()})
+
+
+func _hide_script_from_inspector():
+	return true

--- a/addons/dialogic/Resources/default_event.gd
+++ b/addons/dialogic/Resources/default_event.gd
@@ -1,0 +1,72 @@
+tool
+extends DialogicEvent
+
+
+# DEFINE ALL PROPERTIES OF THE EVENT
+# var MySetting :String = ""
+
+func _execute() -> void:
+	# I have no idea how this event works
+	pass
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+# SET ALL VALUES THAT SHOULD NEVER CHANGE HERE
+func _init() -> void:
+	event_name = "Default"
+	event_icon = load("res://addons/dialogic/Images/Event Icons/Portrait.svg")
+	event_color = Color("#ffffff")
+	event_category = Category.MAIN
+	event_sorting_index = 0
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+
+## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
+func get_as_string_to_store() -> String:
+	var result_string = ""
+	
+	# fill the result_string with the properties
+	
+	return result_string
+
+
+## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
+func load_from_string_to_store(string:String):
+	
+	# fill your properies by interpreting the string
+	
+	pass
+
+
+# RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
+static func is_valid_event_string(string:String):
+	
+	# check the string and maybe return true
+	
+	return false
+
+
+################################################################################
+## 						EDITOR REPRESENTATION
+################################################################################
+
+func _get_property_list() -> Array:
+	var p_list = []
+	
+	# fill the p_list with dictionaries like this one:
+#	p_list.append({
+#		"name":"Character", # Must be the same as the corresponding property that it edits!
+#		"type":TYPE_OBJECT,	# Defines the type of editor (LineEdit, Selector, etc.)
+#		"location": Location.HEADER,	# Definest the location
+#		"usage":PROPERTY_USAGE_DEFAULT,	
+#		"dialogic_type":DialogicValueType.Character,	# Additional information for resource pickers
+#		"hint_string":"Character:"		# Text that will be displayed in front of the field
+#		})
+	
+	return p_list

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -16,16 +16,26 @@ enum Location {
 	BODY
 }
 
+# This is necessary to distinguish different ways value types might need to be represented
+# It's used to communicate between the event resource and the event node, how a value
+#    should be shown
 enum DialogicValueType {
+	# STRINGS
 	Label,
 	MultilineText,
 	SinglelineText,
+	
+	# OBJECTS ? (for the ResourcePicker)
 	Timeline,
 	Character,
 	Theme,
 	Portrait,
 	Position,
 	Animation,
+	
+	# INTEGERS
+	FixedOptionSelector,
+	Integer,
 }
 
 # Hopefully we can replace this with a cleaner system

--- a/timelines/Chapter1.dtl
+++ b/timelines/Chapter1.dtl
@@ -1,3 +1,7 @@
-John: Something Something
-John: This text wasn't written in godot.
-Emilio: Wait what? That's so cool.
+Join Emilio
+John: Something Something<br>Another line? Wow, this is fancy.
+# This is where it get's interesting
+Update 
+Emilio: Audio:<br>Wait? What?
+Emilio: What is this?
+Update John

--- a/timelines/Chapter1.dtl
+++ b/timelines/Chapter1.dtl
@@ -1,0 +1,3 @@
+John: Something Something
+John: This text wasn't written in godot.
+Emilio: Wait what? That's so cool.

--- a/timelines/Chapter1.timeline
+++ b/timelines/Chapter1.timeline
@@ -1,4 +1,0 @@
-Emilio: This is something.
-Jowan: Wow, so cool! I love it!
-This is text without a character.
-Wowie: What?


### PR DESCRIPTION
## Commit 1
I added a (*) mark to the resource name in the toolbar, if it was edited. 

## Commit 2
Adds a character resource as well as a CharcacterResourceLoader and a CharacterResourceSaver. I'm not yet sure in what format it would be best to save the character (currently the values are just stored line by line), maybe also in a way that is easy to edit from the outside. These resources are stored as '.dch' files.

I've changed the extension of the timeline resource to '.dtl'. Thus I had to replace the test timelines.

## Commit 3
You can now create new character resources with a button from the toolbar. There isn't really an character editor yet, although there is a placeholder node managing the creation.

To simplify the code I moved the EditorFileDialog to be a child of the EditorView so that it can be used by all the editors, not just the timeline editor.

The text event now uses the character resource. Thus the import and export had to be ajusted a bit. When importing, the text event will GUESS the resource, currently based on it's file name. We could change this to account for the actual name property. The guessing code is in the DialogicUtil, so that other events can use it easily as well. 

There has also been a developement on the ResourcePicker (as the character was a string previously). The resource picker allows to search and shows suggestions (filtered only by the file name currently, we might want to account for display name as well). Hitting enter or clicking somewhere else will act as if the first suggestion was selected. You can also drag and drop resources on the picker.

## Commit 4
- Moved all currently usable events into addons/dialogic/Resources/Events (and adjusted all references to use this path)

- Added a `Comment event` (starts with a # in the text format)
- Added an initial version of a `Character event` to expand the event builder function:
     -> you can now create selectors in the event
     -  there is also a probably working number selector for the events
     - In the text format the Character event currently starts with either "Join", "Leave" or "Update" followed by a character name. Other settings aren't yet implemented.

- Created a `"default event"` script in addons/dialogic/Resources. This is like a blueprint just containing all necessary methods and some explenation of what they do. This should make it easier to create new events, but we'll see.

- All events now have another static method called `is_valid_event_string(string)` that should return true if the given string should be interpreted as event the method was called on. 
     - the text event always returns true but is asked last
     - the comment event for example checks if the string starts with a # 

Maybe we'll want to change the "one line per event" approach of saving, idk, but until we do, I've decided to convert all \n breaks into <br> characters on save and vice versa on load, so we can have multiple lines in a text event. This isn't nice to write in the text format tho, so who knows how it will end up.

Also renamed all event scripts to start with 'event_', cause then they are in one place in the scripts list and it's easier to see, what they are (in contrast to just text.gd).