### PR TITLE
Dialogic 2.0: Condition event and folding (and more)

### DIFF
--- a/addons/dialogic/Editor/Events/BranchEnd.gd
+++ b/addons/dialogic/Editor/Events/BranchEnd.gd
@@ -33,7 +33,12 @@ func set_indent(indent: int):
 	update()
 
 func parent_node_changed():
-	if parent_node and parent_node.resource is DialogicChoiceEvent:
-		$Label.text = "End of choice '"+parent_node.resource.Text+"'"
+	if parent_node:
+		if parent_node.resource is DialogicChoiceEvent:
+			$Label.text = "End of choice '"+parent_node.resource.Text+"'"
+		elif parent_node.resource is DialogicConditionEvent:
+			$Label.text = "End of condition '"+parent_node.resource.Condition+"'"
+			
+	
 
 

--- a/addons/dialogic/Editor/Events/Fields/SinglelineText.tscn
+++ b/addons/dialogic/Editor/Events/Fields/SinglelineText.tscn
@@ -1,12 +1,14 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/Events/Fields/Text.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=2]
 
 [node name="SinglelineText" type="HBoxContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 rect_min_size = Vector2( 300, 30 )
 size_flags_horizontal = 3
+theme = ExtResource( 2 )
 script = ExtResource( 1 )
 
 [node name="Hint" type="Label" parent="."]

--- a/addons/dialogic/Editor/Events/Templates/EventNode.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.gd
@@ -21,7 +21,8 @@ onready var body_container = $PanelContainer/MarginContainer/VBoxContainer/Body
 onready var body_content_container = $PanelContainer/MarginContainer/VBoxContainer/Body/Content
 onready var indent_node = $Indent
 
-var end_node = null
+var end_node = null setget set_end_node
+var collapsed = false
 
 ### extarnal node references
 var editor_reference
@@ -168,8 +169,21 @@ func focus():
 	#if resource.body_scene:
 	#	resource.body_scene.focus()
 
+func toggle_collapse(toggled):
+	collapsed = toggled
+	print("TOGGLED ", toggled)
+	var timeline_editor = find_parent('TimelineEditor')
+	if (timeline_editor != null):
+		# @todo select item and clear selection is marked as "private" in TimelineEditor.gd
+		# consider to make it "public" or add a public helper function
+		timeline_editor.indent_events()
 
-# 
+
+func set_end_node(node):
+	end_node = node
+	$PanelContainer/MarginContainer/VBoxContainer/Header/CollapseButton.visible = true if end_node else false
+
+
 func build_editor():
 	#print('Building event node')
 	var p_list = resource._get_property_list()
@@ -264,6 +278,7 @@ func _ready():
 	if event_name != null:
 		_set_event_name(event_name)
 
+	
 	$PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer/IconPanel.set("self_modulate", resource.event_color)
 	
 	set_focus_mode(1) # Allowing this node to grab focus
@@ -274,3 +289,6 @@ func _ready():
 	$PopupMenu.connect("index_pressed", self, "_on_OptionsControl_action")
 	
 	_on_Indent_visibility_changed()
+	$PanelContainer/MarginContainer/VBoxContainer/Header/CollapseButton.connect('toggled', self, 'toggle_collapse')
+	$PanelContainer/MarginContainer/VBoxContainer/Header/CollapseButton.icon = get_icon("Collapse", "EditorIcons")
+	$PanelContainer/MarginContainer/VBoxContainer/Header/CollapseButton.hide()

--- a/addons/dialogic/Editor/Events/Templates/EventNode.tscn
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.tscn
@@ -133,7 +133,7 @@ margin_bottom = 37.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
 
 [node name="Content" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer/Header"]
-margin_right = 43.0
+margin_right = 37.0
 margin_bottom = 60.0
 size_flags_horizontal = 3
 
@@ -142,14 +142,20 @@ margin_left = 178.0
 margin_right = 242.0
 
 [node name="Spacer" type="Control" parent="PanelContainer/MarginContainer/VBoxContainer/Header"]
-margin_left = 43.0
-margin_right = 86.0
+margin_left = 37.0
+margin_right = 74.0
 margin_bottom = 60.0
 mouse_filter = 1
 size_flags_horizontal = 3
 __meta__ = {
 "_edit_use_anchors_": false
 }
+
+[node name="CollapseButton" type="ToolButton" parent="PanelContainer/MarginContainer/VBoxContainer/Header"]
+margin_left = 74.0
+margin_right = 86.0
+margin_bottom = 60.0
+toggle_mode = true
 
 [node name="Body" type="HBoxContainer" parent="PanelContainer/MarginContainer/VBoxContainer"]
 unique_name_in_owner = true
@@ -177,7 +183,7 @@ custom_colors/font_color_hover = Color( 0, 0, 0, 1 )
 custom_constants/vseparation = 0
 custom_styles/hover = SubResource( 4 )
 custom_styles/panel = ExtResource( 5 )
-items = [ "Documentation", SubResource( 3 ), 0, false, false, 0, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Move up", SubResource( 3 ), 0, false, false, 2, 0, null, "", false, "Move down", SubResource( 3 ), 0, false, false, 3, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Delete", SubResource( 3 ), 0, false, false, 5, 0, null, "", false ]
+items = [ "Documentation", SubResource( 3 ), 0, false, false, -1, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Move up", SubResource( 3 ), 0, false, false, 1, 0, null, "", false, "Move down", SubResource( 3 ), 0, false, false, 2, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Delete", SubResource( 3 ), 0, false, false, 4, 0, null, "", false ]
 script = ExtResource( 8 )
 
 [connection signal="visibility_changed" from="Indent" to="." method="_on_Indent_visibility_changed"]

--- a/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
@@ -96,9 +96,6 @@ func _draw():
 	pos = rendering_scale_correction(_scale, pos)
 	
 	for event in $TimeLine.get_children():
-		#if not 'event_data' in event:
-		#	continue
-		
 		# If the event is the last one, don't draw anything aftwards
 		if timeline_children[timeline_lenght-1] == event:
 			return
@@ -107,9 +104,7 @@ func _draw():
 			continue
 		
 		# Drawing long lines on questions and conditions
-		if is_question(event):# or event.event_name == 'Condition':
-			#print("wowie, question")
-
+		if is_question(event) or event.resource is DialogicConditionEvent:
 			var end_reference
 			var idx = event.get_index() +1
 			while true:
@@ -117,15 +112,13 @@ func _draw():
 					end_reference = $TimeLine.get_child(idx)
 					break
 				
-#				if $TimeLine.get_child(idx).resource is DialogicEndBranchEvent:
-#					if not $TimeLine.get_child(idx+1).resource is DialogicChoiceEvent:
-#						end_reference = $TimeLine.get_child(idx+1)
-#						break
-				if $TimeLine.get_child(idx).resource is DialogicChoiceEvent and $TimeLine.get_child(idx).current_indent_level == event.current_indent_level-1:
-					end_reference = $TimeLine.get_child(idx)
+				if not event.resource is DialogicConditionEvent:
+					if $TimeLine.get_child(idx).resource is DialogicChoiceEvent and $TimeLine.get_child(idx).current_indent_level == event.current_indent_level+1:
+						end_reference = $TimeLine.get_child(idx)
 				idx += 1
 				if $TimeLine.get_child_count() == idx:
 					break
+			
 			if end_reference:
 				# This line_size thing should be fixed, not sure why it is different when
 				# the indent level is 0 and when it is bigger. 
@@ -141,7 +134,7 @@ func _draw():
 							(end_reference.rect_global_position.y - event.rect_global_position.y) - (43 * _scale))
 						),
 						line_color, true)
-
+		
 		# Drawing other lines and archs
 		var next_event = timeline_children[event.get_index() + 1]
 		if event.current_indent_level > 0:
@@ -174,6 +167,7 @@ func _draw():
 				(event.indent_size * (event.current_indent_level)) + (16.2 * _scale),
 				5
 			)
+		
 			var arc_point_count = 12 * _scale
 			var arc_radius = 24 * _scale
 			var start_angle = 90

--- a/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineArea.gd
@@ -102,7 +102,10 @@ func _draw():
 		# If the event is the last one, don't draw anything aftwards
 		if timeline_children[timeline_lenght-1] == event:
 			return
-
+		
+		if not event.visible:
+			continue
+		
 		# Drawing long lines on questions and conditions
 		if is_question(event):# or event.event_name == 'Condition':
 			#print("wowie, question")
@@ -118,7 +121,7 @@ func _draw():
 #					if not $TimeLine.get_child(idx+1).resource is DialogicChoiceEvent:
 #						end_reference = $TimeLine.get_child(idx+1)
 #						break
-				if $TimeLine.get_child(idx).resource is DialogicChoiceEvent:
+				if $TimeLine.get_child(idx).resource is DialogicChoiceEvent and $TimeLine.get_child(idx).current_indent_level == event.current_indent_level-1:
 					end_reference = $TimeLine.get_child(idx)
 				idx += 1
 				if $TimeLine.get_child_count() == idx:

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -984,12 +984,26 @@ func indent_events() -> void:
 		var indent_node
 		
 		event.set_indent(0)
+		
+	var currently_hidden = false
+	var hidden_until = null
 	# Adding new indents
 	for event in event_list:
 		# since there are indicators now, not all elements
 		# in this list have an event_data property
 		if (not "resource" in event):
 			continue
+			
+		if (not currently_hidden) and 'end_node' in event and event.end_node and event.collapsed:
+			currently_hidden = true
+			hidden_until = event.end_node
+		elif currently_hidden and event == hidden_until:
+			currently_hidden = false
+			hidden_until = null
+		elif currently_hidden:
+			event.hide()
+		else:
+			event.show()
 		
 		## DETECT QUESTIONS
 		if event.resource is DialogicTextEvent: #  also add Condition here later

--- a/addons/dialogic/Other/DefaultDialogNode.gd
+++ b/addons/dialogic/Other/DefaultDialogNode.gd
@@ -6,4 +6,4 @@ func _ready():
 		DialogicGameHandler.start_timeline(DialogicUtil.get_setting('QuickTimelineTest', 'timeline_file'))
 	else:
 		DialogicGameHandler.start_timeline("res://timelines/Chapter1.dtl")
-
+	DialogicGameHandler.connect("timeline_ended", get_tree(), 'quit')

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -15,6 +15,7 @@ var current_name
 var current_text
 
 signal state_changed(new_state)
+signal timeline_ended()
 
 ################################################################################
 ## 						INPUT (WIP)
@@ -48,6 +49,7 @@ func handle_next_event(ignore_argument = ""):
 func handle_event(event_index):
 	hide_all_choices()
 	if event_index >= len(current_timeline_events):
+		emit_signal('timeline_ended')
 		return
 	
 	current_event_idx = event_index
@@ -137,6 +139,8 @@ func get_current_choice_indexes() -> Array:
 		if current_timeline_events[evt_idx] is DialogicChoiceEvent:
 			if ignore == 0:
 				choices.append(evt_idx)
+			ignore += 1
+		if current_timeline_events[evt_idx] is DialogicConditionEvent:
 			ignore += 1
 		else:
 			if ignore == 0:

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -72,6 +72,7 @@ static func get_event_by_string(string:String) -> Resource:
 	for event in [ # the text event should always be last. 
 		# Every event that isn't identified as something else, will end up as text
 		# We should get this list from a folder or something, but then we'll have to sort it somehow
+		"res://addons/dialogic/Resources/Events/event_condition.gd",
 		"res://addons/dialogic/Resources/Events/event_end_branch.gd",
 		"res://addons/dialogic/Resources/Events/event_choice.gd",
 		"res://addons/dialogic/Resources/Events/event_character.gd",

--- a/addons/dialogic/Resources/Events/event_condition.gd
+++ b/addons/dialogic/Resources/Events/event_condition.gd
@@ -1,0 +1,90 @@
+tool
+extends DialogicEvent
+
+class_name DialogicConditionEvent
+
+# DEFINE ALL PROPERTIES OF THE EVENT
+var Condition :String = "true"
+
+func _execute() -> void:
+	var expr = Expression.new()
+	expr.parse(Condition)
+	var result = expr.execute()
+	if not result:
+		var idx = dialogic_game_handler.current_event_idx
+		var ignore = 1
+		# this will go through the next events, until there is a event that is not a choice and on the same level as this one
+		while true:
+			idx += 1
+			if dialogic_game_handler.current_timeline.get_event(idx) is DialogicChoiceEvent:
+				ignore += 1
+			# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
+			elif 'Condition' in dialogic_game_handler.current_timeline.get_event(idx):
+				ignore += 1
+			elif ignore == 1:
+				break
+			elif dialogic_game_handler.current_timeline.get_event(idx) is DialogicEndBranchEvent:
+				ignore -= 1
+			
+		dialogic_game_handler.current_event_idx = idx
+	finish()
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+# SET ALL VALUES THAT SHOULD NEVER CHANGE HERE
+func _init() -> void:
+	event_name = "Condition"
+	event_icon = load("res://addons/dialogic/Images/Event Icons/Main Icons/condition.svg")
+	event_color = Color(0.914063, 0.439178, 0.439178)
+	event_category = Category.LOGIC
+	event_sorting_index = 0
+	continue_at_end = true
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+
+## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
+func get_as_string_to_store() -> String:
+	var result_string = ""
+	
+	result_string = 'if '+Condition+':'
+
+	return result_string
+
+
+## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
+func load_from_string_to_store(string:String):
+	
+	Condition = string.strip_edges().trim_prefix('if ').trim_suffix(':').strip_edges()
+
+
+# RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
+static func is_valid_event_string(string:String):
+	if string.strip_edges().begins_with('if ') and string.strip_edges().ends_with(':'):
+		return true
+	return false
+
+
+################################################################################
+## 						EDITOR REPRESENTATION
+################################################################################
+
+func _get_property_list() -> Array:
+	var p_list = []
+	
+	# fill the p_list with dictionaries like this one:
+	p_list.append({
+		"name":"Condition", # Must be the same as the corresponding property that it edits!
+		"type":TYPE_STRING,	# Defines the type of editor (LineEdit, Selector, etc.)
+		"location": Location.HEADER,	# Definest the location
+		"usage":PROPERTY_USAGE_DEFAULT,	
+		"dialogic_type":DialogicValueType.SinglelineText,	# Additional information for resource pickers
+		"hint_string":""		# Text that will be displayed in front of the field
+		})
+	
+	return p_list

--- a/addons/dialogic/Resources/Events/event_end_branch.gd
+++ b/addons/dialogic/Resources/Events/event_end_branch.gd
@@ -15,12 +15,19 @@ func find_next_index():
 	if not dialogic_game_handler.current_timeline.get_event(idx+1) is DialogicChoiceEvent:
 		return idx+1
 	var ignore = 1
+	# this will go through the next events, until there is a event that's ONE INDENT LESS and NOT A CHOICE
 	while true:
 		idx += 1
+		if not dialogic_game_handler.current_timeline.get_event(idx):
+			idx -= 1
+			break 
 		if dialogic_game_handler.current_timeline.get_event(idx) is DialogicChoiceEvent:
 			ignore += 1
+		# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
 		elif ignore == 1:
 			break
+		elif 'Condition' in dialogic_game_handler.current_timeline.get_event(idx):
+			ignore += 1
 		# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
 		elif 'this_is_an_end_event' in dialogic_game_handler.current_timeline.get_event(idx):
 			ignore -= 1
@@ -63,7 +70,7 @@ func load_from_string_to_store(string:String):
 # RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
 static func is_valid_event_string(string:String):
 	
-	if string.strip_edges() == "<<END BRANCH>>":
+	if string.strip_edges().begins_with("<<END BRANCH>>"):
 		return true
 	return false
 

--- a/addons/dialogic/Resources/Events/event_text.gd
+++ b/addons/dialogic/Resources/Events/event_text.gd
@@ -56,7 +56,7 @@ func load_from_string_to_store(string):
 	var reg = RegEx.new()
 	reg.compile("((?<name>[^:()\\n]*)?(?=(\\([^()]*\\))?:)(\\((?<portrait>[^()]*)\\))?)?:?(?<text>[^\\n]+)")
 	var result = reg.search(string)
-	if !result.get_string('name').empty():
+	if result and !result.get_string('name').empty():
 		var character = DialogicUtil.guess_resource('.dch', result.get_string('name').strip_edges())
 		if character:
 			Character = load(character)

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -65,18 +65,25 @@ func load(path: String, original_path: String):
 	var events = []
 	for line in file.get_as_text().split("\n", false):
 		var stripped_line = line.strip_edges(true, false)
+		
 		if stripped_line.empty():
 			continue
+			
 		var indent = line.substr(0,len(line)-len(stripped_line))
 		if len(indent) < len(prev_indent):
 			for i in range(len(prev_indent)-len(indent)):
-				print('End branch')
 				events.append(DialogicEndBranchEvent.new())
+		
 		prev_indent = indent
 		line = stripped_line
 		var event = DialogicUtil.get_event_by_string(line).new()
 		event.load_from_string_to_store(line)
 		events.append(event)
+	
+	if !prev_indent.empty():
+		for i in range(len(prev_indent)):
+			events.append(DialogicEndBranchEvent.new())
+	
 	
 	res.events = events
 	

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -47,16 +47,15 @@ func save(path: String, resource: Resource, flags: int) -> int:
 		var event = resource.events[idx]
 		
 		if event is DialogicEndBranchEvent:
-			if idx < len(resource.events)-1:
-				if resource.events[idx+1] is DialogicChoiceEvent:
-					indent -= 1
-				else:
-					indent -= 1
-					result += "\n"
-				continue
+			if idx < len(resource.events)-1 and resource.events[idx+1] is DialogicChoiceEvent:
+				indent -= 1
+			else:
+				indent -= 1
+				result += "\n"
+			continue
 		if event != null:
 			result += "\t".repeat(indent)+event.get_as_string_to_store() + "\n"
-		if event is DialogicChoiceEvent:
+		if event is DialogicChoiceEvent or event is DialogicConditionEvent:
 			indent += 1
 		if indent < 0: indent = 0
 	file.store_string(result)

--- a/timelines/Chapter1.dtl
+++ b/timelines/Chapter1.dtl
@@ -1,17 +1,19 @@
-Emilio (Sad): This is so CraZY
-Emilio (Sad): This is so cool
-- Wow do I choose this?
-	John: Some text
-	Emilio: Can you answer this question?
-	- Yeah, sure.
-		John: Wow, so cool
-	- Nope
-		What? Oh no
+The timeline begins.
+- Yes!
+	if true:
+		This is always true.
 
-	Emilio: What a cool question.
-- Nope, no way
-	Emilio: Other text
-- Aye!
-	Wow, this is so sick, right?
+- NO!
+	if "".empty():
+		NO PLAY 1
+		if "Hello".empty():
+			NO PLAY 2
 
-John (Slick): The last sentence.
+
+
+if 4>2:
+	Emilio: 4 is bigger than 2
+	if 2>4:
+		Emilio: 2 is bigger than 4???
+
+


### PR DESCRIPTION
# Condition event
Adds a new condition event. Conditions can be anything the Expression class can parse INCLUDING methods. Currently you can not use variables oc and there is only a text input. 
Conditions should work as expected in game, but I could be wrong.

# Event folding
The condition and choice event can now be folded. The hiding logic is done in `TimelineEditor.indent_events()`. More info in the commit.

# Fixed the undo command a bit
You can now delete and undo the deletion again. Duplication, copy/paste/cut are on the todo list.

# Other stuff
- added a timeline_ended signal to the DialogicGameHandler and made the preview scene hide on timeline end
- updated the single-line style to be the same as the resource picker. not optimal, but better looking than before. Sorry UI/UX is not my concern right now.