### PR TITLE
2.0: Add elif and else mode to conditions

### DIFF
--- a/addons/dialogic/Editor/Events/BranchEnd.gd
+++ b/addons/dialogic/Editor/Events/BranchEnd.gd
@@ -10,6 +10,8 @@ var current_indent_level = 1
 
 func _ready():
 	parent_node_changed()
+	$ConditionButtons/Elif.connect('pressed', self, 'add_elif')
+	$ConditionButtons/Else.connect('pressed', self, 'add_else')
 
 func visual_select():
 	modulate = get_color("accent_color", "Editor")
@@ -37,8 +39,23 @@ func parent_node_changed():
 		if parent_node.resource is DialogicChoiceEvent:
 			$Label.text = "End of choice '"+parent_node.resource.Text+"'"
 		elif parent_node.resource is DialogicConditionEvent:
-			$Label.text = "End of condition '"+parent_node.resource.Condition+"'"
+			if parent_node.resource.ConditionType != DialogicConditionEvent.ConditionTypes.ELSE:
+				$ConditionButtons.show()
+				$Label.text = "End of condition '"+parent_node.resource.Condition+"'"
+			else:
+				$ConditionButtons.hide()
+				$Label.text = "End of else"
+				
 			
-	
+func add_elif():
+	var timeline = find_parent('TimelineEditor')
+	if timeline:
+		timeline.add_condition_pressed(get_index()+1, DialogicConditionEvent.ConditionTypes.ELIF)
+		timeline.indent_events()
 
+func add_else():
+	var timeline = find_parent('TimelineEditor')
+	if timeline:
+		timeline.add_condition_pressed(get_index()+1, DialogicConditionEvent.ConditionTypes.ELSE)
+		timeline.indent_events()
 

--- a/addons/dialogic/Editor/Events/BranchEnd.tscn
+++ b/addons/dialogic/Editor/Events/BranchEnd.tscn
@@ -31,7 +31,7 @@ rect_min_size = Vector2( 30, 0 )
 [node name="PanelContainer2" type="PanelContainer" parent="."]
 margin_left = 38.0
 margin_top = 20.0
-margin_right = 243.0
+margin_right = 212.0
 margin_bottom = 20.0
 size_flags_horizontal = 7
 size_flags_vertical = 4
@@ -39,14 +39,34 @@ size_flags_stretch_ratio = 0.3
 custom_styles/panel = SubResource( 1 )
 
 [node name="Label" type="Label" parent="."]
-margin_left = 247.0
+margin_left = 216.0
 margin_top = 13.0
-margin_right = 334.0
+margin_right = 303.0
 margin_bottom = 27.0
 text = "End of Branch"
 
+[node name="ConditionButtons" type="HBoxContainer" parent="."]
+margin_left = 307.0
+margin_right = 438.0
+margin_bottom = 40.0
+
+[node name="Elif" type="Button" parent="ConditionButtons"]
+margin_top = 10.0
+margin_right = 60.0
+margin_bottom = 30.0
+size_flags_vertical = 4
+text = "Add Elif"
+
+[node name="Else" type="Button" parent="ConditionButtons"]
+margin_left = 64.0
+margin_top = 10.0
+margin_right = 131.0
+margin_bottom = 30.0
+size_flags_vertical = 4
+text = "Add Else"
+
 [node name="PanelContainer" type="PanelContainer" parent="."]
-margin_left = 338.0
+margin_left = 442.0
 margin_top = 20.0
 margin_right = 1024.0
 margin_bottom = 20.0

--- a/addons/dialogic/Editor/Events/Fields/OptionSelector.gd
+++ b/addons/dialogic/Editor/Events/Fields/OptionSelector.gd
@@ -5,10 +5,12 @@ var property_name : String
 signal value_changed
 
 var options : Dictionary
+var disabled = false setget set_disabled
 
 func _ready():
 	$MenuButton.connect("about_to_show", self,  'insert_options')
 	$MenuButton.get_popup().connect("index_pressed", self,  'index_pressed')
+
 
 func set_hint(value):
 	$Hint.text = str(value)
@@ -32,3 +34,7 @@ func index_pressed(idx):
 	$MenuButton.text = $MenuButton.get_popup().get_item_text(idx)
 	
 	emit_signal("value_changed", property_name, $MenuButton.get_popup().get_item_metadata(idx))
+
+func set_disabled(_disabled):
+	disabled = _disabled
+	$MenuButton.disabled = disabled

--- a/addons/dialogic/Editor/Events/Fields/OptionSelector.tscn
+++ b/addons/dialogic/Editor/Events/Fields/OptionSelector.tscn
@@ -18,10 +18,11 @@ margin_bottom = 38.0
 [node name="MenuButton" type="MenuButton" parent="."]
 margin_left = 4.0
 margin_top = 21.0
-margin_right = 84.0
+margin_right = 14.0
 margin_bottom = 41.0
-rect_min_size = Vector2( 80, 0 )
+rect_min_size = Vector2( 10, 0 )
 size_flags_vertical = 4
+custom_colors/font_color_disabled = Color( 0.811765, 0.690196, 0.427451, 1 )
 custom_styles/hover = ExtResource( 2 )
 custom_styles/normal = ExtResource( 3 )
 flat = false

--- a/addons/dialogic/Editor/Events/Templates/EventNode.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.gd
@@ -212,6 +212,8 @@ func build_editor():
 				editor_node = load("res://addons/dialogic/Editor/Events/Fields/OptionSelector.tscn").instance()
 				if p.has('selector_options'):
 					editor_node.options = p.selector_options
+				if p.has('disabled'):
+					editor_node.disabled = p.disabled
 		else:
 			editor_node = Label.new()
 			editor_node.text = p.name

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -653,10 +653,7 @@ func _add_event_button_pressed(event_script):
 		TimelineUndoRedo.add_undo_method(self, "remove_events_at_index", at_index, 2)
 		TimelineUndoRedo.commit_action()
 	elif event_script.new() is DialogicConditionEvent:
-		TimelineUndoRedo.create_action("[D] Add condition event.")
-		TimelineUndoRedo.add_do_method(self, "add_condition", at_index)
-		TimelineUndoRedo.add_undo_method(self, "remove_events_at_index", at_index, 2)
-		TimelineUndoRedo.commit_action()
+		add_condition_pressed(at_index, DialogicConditionEvent.ConditionTypes.IF)
 	else:
 		TimelineUndoRedo.create_action("[D] Add event.")
 		TimelineUndoRedo.add_do_method(self, "add_event_to_timeline", event_script.new(), at_index, true, true)
@@ -670,8 +667,17 @@ func add_choice(at_index):
 	var choice = add_event_to_timeline(DialogicChoiceEvent.new(), at_index)
 	create_end_branch_event(at_index+1, choice)
 
-func add_condition(at_index):
-	var condition = add_event_to_timeline(DialogicConditionEvent.new(), at_index)
+# this is a seperate function, because it's also called from the EndBranch buttons.
+func add_condition_pressed(at_index, type):
+	TimelineUndoRedo.create_action("[D] Add condition event.")
+	TimelineUndoRedo.add_do_method(self, "add_condition", at_index, type)
+	TimelineUndoRedo.add_undo_method(self, "remove_events_at_index", at_index, 2)
+	TimelineUndoRedo.commit_action()
+
+func add_condition(at_index, type = DialogicConditionEvent.ConditionTypes.IF):
+	var resource = DialogicConditionEvent.new()
+	resource.ConditionType = type
+	var condition = add_event_to_timeline(resource, at_index)
 	create_end_branch_event(at_index+1, condition)
 
 func create_end_branch_event(at_index, parent_node):

--- a/addons/dialogic/Resources/Events/event_condition.gd
+++ b/addons/dialogic/Resources/Events/event_condition.gd
@@ -3,10 +3,17 @@ extends DialogicEvent
 
 class_name DialogicConditionEvent
 
+enum ConditionTypes {IF, ELIF, ELSE}
+
 # DEFINE ALL PROPERTIES OF THE EVENT
+var ConditionType = ConditionTypes.IF
 var Condition :String = "true"
 
 func _execute() -> void:
+	if ConditionType == ConditionTypes.ELSE:
+		finish()
+		return
+	
 	var expr = Expression.new()
 	expr.parse(Condition)
 	var result = expr.execute()
@@ -18,15 +25,15 @@ func _execute() -> void:
 			idx += 1
 			if dialogic_game_handler.current_timeline.get_event(idx) is DialogicChoiceEvent:
 				ignore += 1
+			elif dialogic_game_handler.current_timeline.get_event(idx) is DialogicEndBranchEvent:
+				ignore -= 1
+			elif ignore == 0:
+				break
 			# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
 			elif 'Condition' in dialogic_game_handler.current_timeline.get_event(idx):
 				ignore += 1
-			elif ignore == 1:
-				break
-			elif dialogic_game_handler.current_timeline.get_event(idx) is DialogicEndBranchEvent:
-				ignore -= 1
 			
-		dialogic_game_handler.current_event_idx = idx
+		dialogic_game_handler.current_event_idx = idx-1
 	finish()
 
 
@@ -37,7 +44,7 @@ func _execute() -> void:
 # SET ALL VALUES THAT SHOULD NEVER CHANGE HERE
 func _init() -> void:
 	event_name = "Condition"
-	event_icon = load("res://addons/dialogic/Images/Event Icons/Main Icons/condition.svg")
+	event_icon = load("res://addons/dialogic/Images/Event Icons/Main Icons/question.svg")
 	event_color = Color(0.914063, 0.439178, 0.439178)
 	event_category = Category.LOGIC
 	event_sorting_index = 0
@@ -52,20 +59,34 @@ func _init() -> void:
 func get_as_string_to_store() -> String:
 	var result_string = ""
 	
-	result_string = 'if '+Condition+':'
-
+	match ConditionType:
+		ConditionTypes.IF:
+			result_string = 'if '+Condition+':'
+		ConditionTypes.ELIF:
+			result_string = 'elif '+Condition+':'
+		ConditionTypes.ELSE:
+			result_string = 'else:'
+	
 	return result_string
 
 
 ## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
 func load_from_string_to_store(string:String):
 	
-	Condition = string.strip_edges().trim_prefix('if ').trim_suffix(':').strip_edges()
+	if string.strip_edges().begins_with('if'):
+		Condition = string.strip_edges().trim_prefix('if ').trim_suffix(':').strip_edges()
+		ConditionType = ConditionTypes.IF
+	elif string.strip_edges().begins_with('elif'):
+		Condition = string.strip_edges().trim_prefix('elif ').trim_suffix(':').strip_edges()
+		ConditionType = ConditionTypes.ELIF
+	elif string.strip_edges().begins_with('else'):
+		Condition = ""
+		ConditionType = ConditionTypes.ELSE
 
 
 # RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
 static func is_valid_event_string(string:String):
-	if string.strip_edges().begins_with('if ') and string.strip_edges().ends_with(':'):
+	if (string.strip_edges().begins_with('if ') or string.strip_edges().begins_with('elif ') or string.strip_edges().begins_with('else')) and string.strip_edges().ends_with(':'):
 		return true
 	return false
 
@@ -78,6 +99,16 @@ func _get_property_list() -> Array:
 	var p_list = []
 	
 	# fill the p_list with dictionaries like this one:
+	p_list.append({
+		"name":"ConditionType", # Must be the same as the corresponding property that it edits!
+		"type":TYPE_INT,	# Defines the type of editor (LineEdit, Selector, etc.)
+		"location": Location.HEADER,	# Definest the location
+		"usage":PROPERTY_USAGE_DEFAULT,	
+		"dialogic_type":DialogicValueType.FixedOptionSelector,	# Additional information for resource pickers
+		"selector_options":{"if":ConditionTypes.IF, "elif":ConditionTypes.ELIF, "else":ConditionTypes.ELSE},
+		'disabled': true,
+		"hint_string":""		# Text that will be displayed in front of the field
+		})
 	p_list.append({
 		"name":"Condition", # Must be the same as the corresponding property that it edits!
 		"type":TYPE_STRING,	# Defines the type of editor (LineEdit, Selector, etc.)

--- a/addons/dialogic/Resources/Events/event_end_branch.gd
+++ b/addons/dialogic/Resources/Events/event_end_branch.gd
@@ -12,21 +12,32 @@ func _execute() -> void:
 
 func find_next_index():
 	var idx = dialogic_game_handler.current_event_idx
-	if not dialogic_game_handler.current_timeline.get_event(idx+1) is DialogicChoiceEvent:
-		return idx+1
+	
+	# In case the next event is not a choice or ELIF/ELSE event, just go to the next one
+	# excuse this, checking like normally creates a FUCKING CYCLIC DEPENDENCY....
+	if not (dialogic_game_handler.current_timeline.get_event(idx+1) and 'Condition' in dialogic_game_handler.current_timeline.get_event(idx+1) and dialogic_game_handler.current_timeline.get_event(idx+1).ConditionType != 0):
+		if not dialogic_game_handler.current_timeline.get_event(idx+1) is DialogicChoiceEvent:
+			return idx+1
+			
+	
 	var ignore = 1
-	# this will go through the next events, until there is a event that's ONE INDENT LESS and NOT A CHOICE
+	# this will go through the next events, until 
+	# there is a event that's ONE INDENT LESS and NOT A CHOICE and NOT an ELIF or ELSE event
 	while true:
 		idx += 1
-		if not dialogic_game_handler.current_timeline.get_event(idx):
+		var event = dialogic_game_handler.current_timeline.get_event(idx)
+		if not event:
 			idx -= 1
-			break 
-		if dialogic_game_handler.current_timeline.get_event(idx) is DialogicChoiceEvent:
+			break
+		if event is DialogicChoiceEvent:
 			ignore += 1
-		# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
+		# if we get to a condition that is of type elif or else
+		elif 'Condition' in event and event.ConditionType != 0:
+			pass
 		elif ignore == 1:
 			break
-		elif 'Condition' in dialogic_game_handler.current_timeline.get_event(idx):
+		# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
+		if 'Condition' in dialogic_game_handler.current_timeline.get_event(idx):
 			ignore += 1
 		# excuse this, checking like above creates a FUCKING CYCLIC DEPENDENCY....
 		elif 'this_is_an_end_event' in dialogic_game_handler.current_timeline.get_event(idx):


### PR DESCRIPTION
Adds a ConditionType to the condition event that is either IF, ELIF, or ELSE.

Like before most of the acutal LOGIC is done by the end branch event.

You cannot add elif and else events manually (in the editor), only by using the buttons on the end branch events of if and elif events.

Currently the else event still shows an input for a condition (even though it is ignored). This will change when I add the simplified condition picker.

Please test this a lot, especially together with choices and questions to make sure the logic I implemented for finding the next right event after an end_branch_event is correct! 