### PR TITLE
2.0: Auto detect choice button order + empty choices fix

### DIFF
--- a/addons/dialogic/Display/ChoiceButton.gd
+++ b/addons/dialogic/Display/ChoiceButton.gd
@@ -1,6 +1,6 @@
 extends Button
 
-export (int) var choice_index = 1
+export (int) var choice_index = -1
 
 func _ready():
 	add_to_group('dialogic_choice_button')

--- a/addons/dialogic/Editor/Events/BranchEnd.gd
+++ b/addons/dialogic/Editor/Events/BranchEnd.gd
@@ -38,6 +38,7 @@ func parent_node_changed():
 	if parent_node:
 		if parent_node.resource is DialogicChoiceEvent:
 			$Label.text = "End of choice '"+parent_node.resource.Text+"'"
+			$ConditionButtons.hide()
 		elif parent_node.resource is DialogicConditionEvent:
 			if parent_node.resource.ConditionType != DialogicConditionEvent.ConditionTypes.ELSE:
 				$ConditionButtons.show()

--- a/addons/dialogic/Other/DefaultDialogNode.tscn
+++ b/addons/dialogic/Other/DefaultDialogNode.tscn
@@ -87,42 +87,31 @@ margin_bottom = 106.0
 alignment = 1
 
 [node name="Choice" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 36.0
 margin_right = 292.0
 margin_bottom = 56.0
 
 [node name="Choice2" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 60.0
 margin_right = 292.0
 margin_bottom = 80.0
-choice_index = 2
 
 [node name="Choice3" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 84.0
 margin_right = 292.0
 margin_bottom = 104.0
-choice_index = 3
 
 [node name="Choice4" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 108.0
 margin_right = 292.0
 margin_bottom = 128.0
-choice_index = 4
 
 [node name="Choice5" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 132.0
 margin_right = 292.0
 margin_bottom = 152.0
-choice_index = 5
 
 [node name="Choice6" parent="Choices" instance=ExtResource( 4 )]
-margin_left = 0.0
 margin_top = 156.0
 margin_right = 292.0
 margin_bottom = 176.0
-choice_index = 6

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -160,11 +160,13 @@ func show_current_choices() -> void:
 		button_idx += 1
 
 func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -> void:
+	var idx = 1
 	for node in get_tree().get_nodes_in_group('dialogic_choice_button'):
-		if node.choice_index == button_index:
+		if (node.choice_index == button_index) or (idx == button_index and node.choice_index == -1):
 			node.show()
 			node.text = text
 			node.connect('pressed', self, 'choice_selected', [event_index])
+		idx += 1
 
 func choice_selected(event_index:int) -> void:
 	hide_all_choices()
@@ -199,10 +201,10 @@ func get_current_choice_indexes() -> Array:
 	var evt_idx = current_event_idx
 	var ignore = 0
 	while true:
+		
 		evt_idx += 1
 		if evt_idx >= len(current_timeline_events):
 			break
-		
 		if current_timeline_events[evt_idx] is DialogicChoiceEvent:
 			if ignore == 0:
 				choices.append(evt_idx)
@@ -215,7 +217,6 @@ func get_current_choice_indexes() -> Array:
 		
 		if current_timeline_events[evt_idx] is DialogicEndBranchEvent:
 			ignore -= 1
-	
 	return choices
 
 func is_character_joined(character:DialogicCharacter) -> bool:

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -63,22 +63,30 @@ func load(path: String, original_path: String):
 	# Parse the lines as seperate events and recreate them as resources
 	var prev_indent = ""
 	var events = []
+	# this is needed to add a end branch event even to empty conditions/choices
+	var prev_was_opener = false
 	for line in file.get_as_text().split("\n", false):
 		var stripped_line = line.strip_edges(true, false)
 		
 		if stripped_line.empty():
 			continue
-			
+		
 		var indent = line.substr(0,len(line)-len(stripped_line))
 		if len(indent) < len(prev_indent):
 			for i in range(len(prev_indent)-len(indent)):
 				events.append(DialogicEndBranchEvent.new())
-		
+		elif prev_was_opener and len(indent) == len(prev_indent):
+			events.append(DialogicEndBranchEvent.new())
+			
 		prev_indent = indent
+		
 		line = stripped_line
 		var event = DialogicUtil.get_event_by_string(line).new()
 		event.load_from_string_to_store(line)
 		events.append(event)
+		
+		prev_was_opener = (event is DialogicChoiceEvent or event is DialogicConditionEvent)
+
 	
 	if !prev_indent.empty():
 		for i in range(len(prev_indent)):

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -50,8 +50,8 @@ func save(path: String, resource: Resource, flags: int) -> int:
 			if idx < len(resource.events)-1 and resource.events[idx+1] is DialogicChoiceEvent:
 				indent -= 1
 			else:
+				result += "\t".repeat(indent)+"\n"
 				indent -= 1
-				result += "\n"
 			continue
 		if event != null:
 			result += "\t".repeat(indent)+event.get_as_string_to_store() + "\n"


### PR DESCRIPTION
# Auto detect choice button index
The default for the choice button (display node) is now -1 meaning the choices will be distributed to the members of the group in tree order.

# Fixed empty choices issues
If you didn't add events between a choice and it's end event, this resulted in incorrect loading of the timeline (it didn't detect the end branches as there was no change in indentation). This is fixed now and should also be fixed for conditions.

# Other things
- the add elif and add else buttons are now hidden on choices
