### PR TITLE
1.4: Added simple slide_in character entrance animations

### DIFF
--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/slide_in_left.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/slide_in_left.gd
@@ -1,0 +1,19 @@
+func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	var x_frames = [
+		{ percentage = 0, to = -2000 },
+		{ percentage = 80, to = +2000 },
+		{ percentage = 100, to = 0 },
+	]
+	
+
+	var opacity_frames = [
+		{ percentage = 0, from = 0.7 },
+		{ percentage = 80, to = 0.7 },
+		{ percentage = 100, to = 1 },
+	]
+
+	DialogicAnimaPropertiesHelper.set_2D_pivot(data.node, DialogicAnimaPropertiesHelper.PIVOT.CENTER)
+
+	anima_tween.add_relative_frames(data, "x", x_frames)
+	#anima_tween.add_frames(data, "scale", scale_frames)
+	anima_tween.add_frames(data, "opacity", opacity_frames)

--- a/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/slide_in_right.gd
+++ b/addons/dialogic/Nodes/Anima/animations/entrances_and_exits/slide_in_right.gd
@@ -1,0 +1,25 @@
+func generate_animation(anima_tween: Tween, data: Dictionary) -> void:
+	var x_frames = [
+		{ percentage = 0, to = 2000 },
+		{ percentage = 80, to = -2000 },
+		{ percentage = 100, to = 0 },
+	]
+	
+	var scale = DialogicAnimaPropertiesHelper.get_scale(data.node)
+	var scale_frames = [
+		{ percentage = 0, from = scale * Vector2(0.7, 0.7) },
+		{ percentage = 80, to = scale * Vector2(0.7, 0.7) },
+		{ percentage = 100, to = scale * Vector2(1, 1) },
+	]
+
+	var opacity_frames = [
+		{ percentage = 0, from = 0.7 },
+		{ percentage = 80, to = 0.7 },
+		{ percentage = 100, to = 1 },
+	]
+
+	DialogicAnimaPropertiesHelper.set_2D_pivot(data.node, DialogicAnimaPropertiesHelper.PIVOT.CENTER)
+
+	anima_tween.add_relative_frames(data, "x", x_frames)
+	anima_tween.add_frames(data, "scale", scale_frames)
+	anima_tween.add_frames(data, "opacity", opacity_frames)


### PR DESCRIPTION
I wanted a simple character slide-in animation, but there were only back-in animations provided. I simply duplicated and modified back_in_right.gd and back_in_left.gd to remove the scaling so that I had simple slide-in animations.