### PR TITLE
2.0 Add condition to choice

### DIFF
--- a/addons/dialogic/Events/Condition/event.gd
+++ b/addons/dialogic/Events/Condition/event.gd
@@ -13,9 +13,7 @@ func _execute() -> void:
 		finish()
 		return
 	
-	var expr = Expression.new()
-	expr.parse(Condition)
-	var result = expr.execute()
+	var result = dialogic_game_handler.execute_condition(Condition)
 	if not result:
 		var idx = dialogic_game_handler.current_event_idx
 		var ignore = 1

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -171,15 +171,23 @@ func show_current_choices() -> void:
 	var button_idx = 1
 	for choice_index in get_current_choice_indexes():
 		var choice_event = current_timeline_events[choice_index]
-		show_choice(button_idx, choice_event.Text, true, choice_index)
-		button_idx += 1
-
+		# check if condition is false
+		if not choice_event.Condition.empty() and not execute_condition(choice_event.Condition):
+			# check what to do in this case
+			if choice_event.IfFalseAction == DialogicChoiceEvent.IfFalseActions.DISABLE:
+				show_choice(button_idx, choice_event.Text, false, choice_index)
+				button_idx += 1
+		# else just show it
+		else:
+			show_choice(button_idx, choice_event.Text, true, choice_index)
+			button_idx += 1
 func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -> void:
 	var idx = 1
 	for node in get_tree().get_nodes_in_group('dialogic_choice_button'):
 		if (node.choice_index == button_index) or (idx == button_index and node.choice_index == -1):
 			node.show()
 			node.text = parse_variables(text)
+			node.disabled = not enabled
 			node.connect('pressed', self, 'choice_selected', [event_index])
 		if node.choice_index >0:
 			idx = node.choice_index
@@ -364,6 +372,11 @@ func get_current_portrait_info_of_character(character:DialogicCharacter) -> Arra
 
 func interpolate_volume_linearly(value, node):
 	node.volume_db = linear2db(value)
+
+func execute_condition(condition:String) -> bool:
+	var expr = Expression.new()
+	expr.parse(condition)
+	return true if expr.execute() else false
 
 func get_autoloads() -> Array:
 	var autoloads = []


### PR DESCRIPTION
Should fix #958
Adds a condition input to the choice event. UI is very bad but functionality is there. You can also choose, what to do if the condition isn't met (Default/Hide/Disable). Default is currently just the same as Hide, but I want to add a setting for this later.

In the text format you can write the conditions like this:
```
Emilio: Wow, some options are disabled!
- This is disabled [if false] [else disable]
- This might be disabled [if some_cool_condition] [else disabeld]
- This will be hidden [if false] [else hide]
- This is always visible
```

# Other
- moved the condition execution into a function of the dialogic_game_handler, because now multiple events (and the game_handler itself) use it.