### PR TITLE
2.0 Character Editor/Setting improvements 

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://addons/dialogic/Editor/CharacterEditor/PortraitEntry.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd" type="Script" id=2]
 [ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=3]
 [ext_resource path="res://icon.png" type="Texture" id=4]
 [ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=5]
-[ext_resource path="res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn" type="PackedScene" id=6]
 [ext_resource path="res://addons/dialogic/Editor/Images/Event Icons/event-outline.svg" type="Texture" id=7]
 
 [sub_resource type="StyleBoxFlat" id=1]
@@ -30,7 +29,7 @@ size = Vector2( 128, 256 )
 
 [sub_resource type="BitmapFont" id=4]
 textures = [ SubResource( 3 ) ]
-chars = PoolIntArray( 32, 0, 0, 0, 0, 0, 0, 11, 4, 160, 0, 1734439808, 0, 0, 0, 0, 11, 4, 96, 0, 2, 216, 3, 2, 3, 0, 8, 192, 0, 32, 16, 11, 13, -1, -2, 9, 224, 0, 85, 180, 5, 11, 1, 0, 7, 64, 0, 72, 34, 10, 11, 1, 1, 12, 97, 0, 76, 188, 5, 8, 1, 3, 7, 65, 0, 2, 16, 11, 10, -1, 1, 9, 161, 0, 2, 222, 2, 11, 1, 3, 4, 193, 0, 17, 16, 11, 13, -1, -2, 9, 225, 0, 112, 169, 5, 11, 1, 0, 7, 33, 0, 65, 234, 2, 10, 1, 1, 4, 34, 0, 49, 187, 5, 4, 1, 1, 6, 162, 0, 12, 136, 6, 10, 1, 1, 8, 66, 0, 46, 109, 7, 10, 1, 1, 9, 194, 0, 113, 2, 11, 13, -1, -2, 9, 226, 0, 72, 143, 6, 11, 1, 0, 7, 98, 0, 102, 165, 6, 11, 1, 0, 8, 99, 0, 40, 179, 5, 8, 1, 3, 7, 67, 0, 68, 115, 7, 10, 1, 1, 8, 227, 0, 2, 155, 6, 12, 1, -1, 7, 195, 0, 53, 2, 11, 14, -1, -3, 9, 163, 0, 22, 167, 6, 10, 1, 1, 8, 35, 0, 78, 66, 8, 10, 0, 1, 9, 164, 0, 14, 79, 8, 7, 0, 3, 8, 68, 0, 90, 66, 8, 10, 1, 1, 10, 100, 0, 82, 150, 6, 11, 1, 0, 8, 36, 0, 102, 137, 6, 12, 1, 0, 8, 196, 0, 98, 2, 11, 13, -1, -2, 9, 228, 0, 121, 169, 5, 11, 1, 0, 7, 101, 0, 32, 124, 6, 8, 1, 3, 8, 197, 0, 83, 2, 11, 12, -1, -1, 9, 229, 0, 20, 196, 5, 12, 1, -1, 7, 165, 0, 79, 98, 7, 10, 0, 1, 8, 69, 0, 29, 191, 5, 10, 1, 1, 7, 37, 0, 2, 30, 10, 10, 1, 1, 12, 230, 0, 58, 34, 10, 8, 1, 3, 12, 102, 0, 2, 201, 5, 11, 0, 0, 4, 166, 0, 95, 228, 2, 14, 3, 0, 7, 198, 0, 21, 2, 12, 10, -1, 1, 12, 70, 0, 101, 105, 6, 10, 1, 1, 7, 38, 0, 67, 49, 9, 10, 1, 1, 10, 39, 0, 119, 219, 2, 4, 1, 1, 3, 167, 0, 112, 131, 6, 11, 0, 0, 7, 103, 0, 13, 107, 7, 11, 1, 3, 7, 199, 0, 57, 97, 7, 13, 1, 1, 8, 231, 0, 2, 186, 5, 11, 1, 3, 7, 71, 0, 66, 65, 8, 10, 1, 1, 10, 168, 0, 77, 217, 4, 2, 2, 0, 8, 104, 0, 72, 158, 6, 11, 1, 0, 8, 40, 0, 93, 212, 4, 12, 1, 1, 4, 200, 0, 47, 195, 5, 13, 1, -2, 7, 232, 0, 62, 143, 6, 11, 1, 0, 8, 72, 0, 54, 65, 8, 10, 1, 1, 10, 105, 0, 109, 213, 3, 11, 0, 0, 4, 41, 0, 51, 226, 3, 12, 0, 1, 4, 201, 0, 56, 197, 5, 13, 1, -2, 7, 233, 0, 52, 142, 6, 11, 1, 0, 8, 169, 0, 44, 34, 10, 10, 1, 1, 12, 73, 0, 38, 191, 5, 10, 0, 1, 5, 170, 0, 29, 205, 4, 5, 0, 1, 5, 42, 0, 108, 80, 7, 6, 0, 0, 8, 202, 0, 65, 202, 5, 13, 1, -2, 7, 74, 0, 92, 195, 5, 13, -2, 1, 3, 106, 0, 101, 213, 4, 14, -1, 0, 4, 234, 0, 12, 181, 6, 11, 1, 0, 8, 171, 0, 22, 181, 5, 6, 1, 4, 7, 43, 0, 101, 94, 7, 7, 0, 3, 8, 107, 0, 112, 92, 7, 11, 1, 0, 7, 203, 0, 83, 200, 5, 13, 1, -2, 7, 235, 0, 2, 171, 6, 11, 1, 0, 8, 75, 0, 102, 66, 8, 10, 1, 1, 8, 44, 0, 107, 231, 2, 3, 1, 9, 4, 172, 0, 2, 104, 7, 4, 0, 6, 8, 108, 0, 113, 228, 2, 11, 1, 0, 4, 204, 0, 101, 196, 5, 13, 0, -2, 5, 236, 0, 30, 214, 3, 11, 0, 0, 4, 76, 0, 22, 124, 6, 10, 1, 1, 7, 173, 0, 16, 229, 3, 2, 1, 7, 5, 45, 0, 123, 201, 3, 2, 1, 7, 5, 109, 0, 68, 2, 11, 8, 1, 3, 13, 205, 0, 11, 211, 5, 13, 0, -2, 5, 237, 0, 37, 214, 3, 11, 1, 0, 4, 77, 0, 62, 20, 10, 10, 1, 1, 12, 46, 0, 101, 231, 2, 2, 1, 9, 4, 110, 0, 111, 107, 6, 8, 1, 3, 8, 206, 0, 20, 212, 5, 13, 0, -2, 5, 238, 0, 11, 196, 5, 11, -1, 0, 4, 174, 0, 30, 33, 10, 10, 1, 1, 12, 78, 0, 2, 79, 8, 10, 1, 1, 10, 175, 0, 35, 111, 7, 1, 0, -1, 7, 111, 0, 102, 153, 6, 8, 1, 3, 8, 207, 0, 119, 184, 5, 13, 0, -2, 5, 239, 0, 69, 219, 4, 11, 0, 0, 4, 79, 0, 41, 66, 9, 10, 1, 1, 11, 47, 0, 90, 105, 7, 10, -1, 1, 5, 176, 0, 61, 219, 4, 4, 1, 1, 6, 112, 0, 32, 150, 6, 11, 1, 3, 8, 240, 0, 82, 165, 6, 11, 1, 0, 8, 208, 0, 86, 33, 9, 10, 0, 1, 10, 80, 0, 52, 128, 6, 10, 1, 1, 8, 48, 0, 42, 135, 6, 10, 1, 1, 8, 177, 0, 46, 97, 7, 8, 0, 3, 8, 113, 0, 22, 152, 6, 11, 1, 3, 8, 241, 0, 2, 112, 6, 12, 1, -1, 8, 81, 0, 15, 59, 9, 13, 1, 1, 11, 209, 0, 74, 80, 8, 14, 1, -3, 10, 49, 0, 45, 212, 4, 10, 2, 1, 8, 178, 0, 58, 187, 5, 6, 0, 1, 5, 114, 0, 85, 217, 4, 8, 1, 3, 5, 210, 0, 2, 62, 9, 13, 1, -2, 11, 242, 0, 62, 165, 6, 11, 1, 0, 8, 82, 0, 35, 97, 7, 10, 1, 1, 8, 50, 0, 57, 114, 7, 10, 1, 1, 8, 179, 0, 53, 214, 4, 6, 0, 1, 5, 115, 0, 112, 146, 6, 8, 0, 3, 7, 211, 0, 106, 49, 9, 13, 1, -2, 11, 243, 0, 52, 172, 6, 11, 1, 0, 8, 83, 0, 24, 96, 7, 10, 0, 1, 7, 51, 0, 22, 138, 6, 10, 1, 1, 8, 180, 0, 9, 228, 3, 2, 3, 0, 8, 116, 0, 67, 188, 5, 10, 0, 1, 5, 212, 0, 93, 49, 9, 13, 1, -2, 11, 244, 0, 42, 164, 6, 11, 1, 0, 8, 84, 0, 13, 93, 7, 10, 0, 1, 7, 52, 0, 24, 110, 7, 10, 1, 1, 8, 117, 0, 42, 123, 6, 8, 1, 3, 8, 181, 0, 2, 140, 6, 11, 1, 3, 8, 245, 0, 12, 165, 6, 12, 1, -1, 8, 213, 0, 2, 44, 9, 14, 1, -3, 11, 85, 0, 114, 66, 8, 10, 1, 1, 10, 53, 0, 92, 119, 6, 10, 1, 1, 8, 118, 0, 15, 47, 9, 8, -1, 3, 7, 182, 0, 68, 98, 7, 13, 1, 0, 9, 214, 0, 80, 49, 9, 13, 1, -2, 11, 246, 0, 72, 173, 6, 11, 1, 0, 8, 86, 0, 76, 18, 10, 10, -1, 1, 8, 54, 0, 82, 121, 6, 10, 1, 1, 8, 183, 0, 77, 223, 2, 2, 1, 5, 4, 215, 0, 2, 93, 7, 7, 0, 3, 8, 247, 0, 90, 94, 7, 7, 0, 3, 8, 119, 0, 37, 2, 12, 8, -1, 3, 10, 87, 0, 2, 2, 15, 10, -1, 1, 13, 55, 0, 72, 129, 6, 10, 1, 1, 8, 184, 0, 116, 212, 3, 3, 0, 11, 3, 120, 0, 119, 80, 7, 8, 0, 3, 7, 248, 0, 2, 128, 6, 8, 1, 3, 8, 216, 0, 99, 33, 9, 12, 1, 0, 11, 88, 0, 90, 19, 10, 10, -1, 1, 8, 56, 0, 62, 129, 6, 10, 1, 1, 8, 185, 0, 23, 229, 3, 6, 0, 1, 5, 57, 0, 12, 122, 6, 10, 1, 1, 8, 121, 0, 112, 33, 9, 11, -1, 3, 7, 249, 0, 52, 157, 6, 11, 1, 0, 8, 217, 0, 38, 80, 8, 13, 1, -2, 10, 89, 0, 28, 65, 9, 10, -1, 1, 7, 186, 0, 37, 205, 4, 5, 0, 1, 5, 58, 0, 89, 229, 2, 8, 1, 3, 4, 122, 0, 112, 119, 6, 8, 1, 3, 7, 90, 0, 32, 136, 6, 10, 1, 1, 8, 250, 0, 42, 149, 6, 11, 1, 0, 8, 218, 0, 26, 79, 8, 13, 1, -2, 10, 187, 0, 31, 181, 5, 6, 1, 4, 7, 59, 0, 71, 234, 2, 9, 1, 3, 4, 251, 0, 12, 150, 6, 11, 1, 0, 8, 123, 0, 103, 180, 5, 12, 0, 1, 5, 91, 0, 58, 227, 3, 12, 1, 1, 4, 219, 0, 50, 80, 8, 13, 1, -2, 10, 60, 0, 92, 153, 6, 7, 1, 3, 8, 92, 0, 97, 80, 7, 10, -1, 1, 5, 252, 0, 92, 133, 6, 11, 1, 0, 8, 220, 0, 62, 79, 8, 13, 1, -2, 10, 124, 0, 83, 229, 2, 14, 3, 0, 7, 188, 0, 16, 33, 10, 10, 0, 1, 10, 61, 0, 79, 112, 7, 5, 0, 4, 8, 125, 0, 110, 196, 5, 12, 0, 1, 5, 93, 0, 44, 226, 3, 12, 0, 1, 4, 221, 0, 54, 48, 9, 13, -1, -2, 7, 253, 0, 28, 47, 9, 14, -1, 0, 7, 189, 0, 47, 20, 11, 10, 0, 1, 10, 126, 0, 62, 158, 6, 3, 1, 5, 8, 94, 0, 86, 80, 7, 6, 0, 1, 7, 62, 0, 112, 158, 6, 7, 1, 3, 8, 254, 0, 102, 119, 6, 14, 1, 0, 8, 222, 0, 32, 165, 6, 10, 1, 1, 8, 190, 0, 104, 19, 10, 10, 0, 1, 10, 95, 0, 92, 148, 6, 1, 0, 12, 6, 63, 0, 74, 202, 5, 10, 0, 1, 6, 191, 0, 94, 180, 5, 11, 0, 3, 6, 255, 0, 41, 48, 9, 14, -1, 0, 7, 223, 0, 82, 135, 6, 11, 1, 0, 8 )
+chars = PoolIntArray( 64, 0, 72, 34, 10, 11, 1, 1, 12, 224, 0, 85, 180, 5, 11, 1, 0, 7, 192, 0, 32, 16, 11, 13, -1, -2, 9, 96, 0, 2, 216, 3, 2, 3, 0, 8, 160, 0, 1734439808, 0, 0, 0, 0, 11, 4, 32, 0, 0, 0, 0, 0, 0, 11, 4, 33, 0, 65, 234, 2, 10, 1, 1, 4, 225, 0, 112, 169, 5, 11, 1, 0, 7, 193, 0, 17, 16, 11, 13, -1, -2, 9, 161, 0, 2, 222, 2, 11, 1, 3, 4, 65, 0, 2, 16, 11, 10, -1, 1, 9, 97, 0, 76, 188, 5, 8, 1, 3, 7, 98, 0, 102, 165, 6, 11, 1, 0, 8, 226, 0, 72, 143, 6, 11, 1, 0, 7, 194, 0, 113, 2, 11, 13, -1, -2, 9, 66, 0, 46, 109, 7, 10, 1, 1, 9, 162, 0, 12, 136, 6, 10, 1, 1, 8, 34, 0, 49, 187, 5, 4, 1, 1, 6, 35, 0, 78, 66, 8, 10, 0, 1, 9, 163, 0, 22, 167, 6, 10, 1, 1, 8, 195, 0, 53, 2, 11, 14, -1, -3, 9, 227, 0, 2, 155, 6, 12, 1, -1, 7, 67, 0, 68, 115, 7, 10, 1, 1, 8, 99, 0, 40, 179, 5, 8, 1, 3, 7, 228, 0, 121, 169, 5, 11, 1, 0, 7, 196, 0, 98, 2, 11, 13, -1, -2, 9, 36, 0, 102, 137, 6, 12, 1, 0, 8, 100, 0, 82, 150, 6, 11, 1, 0, 8, 68, 0, 90, 66, 8, 10, 1, 1, 10, 164, 0, 14, 79, 8, 7, 0, 3, 8, 37, 0, 2, 30, 10, 10, 1, 1, 12, 69, 0, 29, 191, 5, 10, 1, 1, 7, 165, 0, 79, 98, 7, 10, 0, 1, 8, 229, 0, 20, 196, 5, 12, 1, -1, 7, 197, 0, 83, 2, 11, 12, -1, -1, 9, 101, 0, 32, 124, 6, 8, 1, 3, 8, 38, 0, 67, 49, 9, 10, 1, 1, 10, 70, 0, 101, 105, 6, 10, 1, 1, 7, 198, 0, 21, 2, 12, 10, -1, 1, 12, 166, 0, 95, 228, 2, 14, 3, 0, 7, 102, 0, 2, 201, 5, 11, 0, 0, 4, 230, 0, 58, 34, 10, 8, 1, 3, 12, 71, 0, 66, 65, 8, 10, 1, 1, 10, 231, 0, 2, 186, 5, 11, 1, 3, 7, 199, 0, 57, 97, 7, 13, 1, 1, 8, 103, 0, 13, 107, 7, 11, 1, 3, 7, 167, 0, 112, 131, 6, 11, 0, 0, 7, 39, 0, 119, 219, 2, 4, 1, 1, 3, 72, 0, 54, 65, 8, 10, 1, 1, 10, 232, 0, 62, 143, 6, 11, 1, 0, 8, 200, 0, 47, 195, 5, 13, 1, -2, 7, 40, 0, 93, 212, 4, 12, 1, 1, 4, 104, 0, 72, 158, 6, 11, 1, 0, 8, 168, 0, 77, 217, 4, 2, 2, 0, 8, 73, 0, 38, 191, 5, 10, 0, 1, 5, 169, 0, 44, 34, 10, 10, 1, 1, 12, 233, 0, 52, 142, 6, 11, 1, 0, 8, 201, 0, 56, 197, 5, 13, 1, -2, 7, 41, 0, 51, 226, 3, 12, 0, 1, 4, 105, 0, 109, 213, 3, 11, 0, 0, 4, 106, 0, 101, 213, 4, 14, -1, 0, 4, 74, 0, 92, 195, 5, 13, -2, 1, 3, 202, 0, 65, 202, 5, 13, 1, -2, 7, 42, 0, 108, 80, 7, 6, 0, 0, 8, 170, 0, 29, 205, 4, 5, 0, 1, 5, 234, 0, 12, 181, 6, 11, 1, 0, 8, 171, 0, 22, 181, 5, 6, 1, 4, 7, 43, 0, 101, 94, 7, 7, 0, 3, 8, 107, 0, 112, 92, 7, 11, 1, 0, 7, 203, 0, 83, 200, 5, 13, 1, -2, 7, 235, 0, 2, 171, 6, 11, 1, 0, 8, 75, 0, 102, 66, 8, 10, 1, 1, 8, 44, 0, 107, 231, 2, 3, 1, 9, 4, 172, 0, 2, 104, 7, 4, 0, 6, 8, 108, 0, 113, 228, 2, 11, 1, 0, 4, 204, 0, 101, 196, 5, 13, 0, -2, 5, 236, 0, 30, 214, 3, 11, 0, 0, 4, 76, 0, 22, 124, 6, 10, 1, 1, 7, 173, 0, 16, 229, 3, 2, 1, 7, 5, 45, 0, 123, 201, 3, 2, 1, 7, 5, 109, 0, 68, 2, 11, 8, 1, 3, 13, 205, 0, 11, 211, 5, 13, 0, -2, 5, 237, 0, 37, 214, 3, 11, 1, 0, 4, 77, 0, 62, 20, 10, 10, 1, 1, 12, 46, 0, 101, 231, 2, 2, 1, 9, 4, 110, 0, 111, 107, 6, 8, 1, 3, 8, 206, 0, 20, 212, 5, 13, 0, -2, 5, 238, 0, 11, 196, 5, 11, -1, 0, 4, 174, 0, 30, 33, 10, 10, 1, 1, 12, 78, 0, 2, 79, 8, 10, 1, 1, 10, 175, 0, 35, 111, 7, 1, 0, -1, 7, 111, 0, 102, 153, 6, 8, 1, 3, 8, 207, 0, 119, 184, 5, 13, 0, -2, 5, 239, 0, 69, 219, 4, 11, 0, 0, 4, 79, 0, 41, 66, 9, 10, 1, 1, 11, 47, 0, 90, 105, 7, 10, -1, 1, 5, 176, 0, 61, 219, 4, 4, 1, 1, 6, 112, 0, 32, 150, 6, 11, 1, 3, 8, 240, 0, 82, 165, 6, 11, 1, 0, 8, 208, 0, 86, 33, 9, 10, 0, 1, 10, 80, 0, 52, 128, 6, 10, 1, 1, 8, 48, 0, 42, 135, 6, 10, 1, 1, 8, 177, 0, 46, 97, 7, 8, 0, 3, 8, 113, 0, 22, 152, 6, 11, 1, 3, 8, 241, 0, 2, 112, 6, 12, 1, -1, 8, 81, 0, 15, 59, 9, 13, 1, 1, 11, 209, 0, 74, 80, 8, 14, 1, -3, 10, 49, 0, 45, 212, 4, 10, 2, 1, 8, 178, 0, 58, 187, 5, 6, 0, 1, 5, 114, 0, 85, 217, 4, 8, 1, 3, 5, 210, 0, 2, 62, 9, 13, 1, -2, 11, 242, 0, 62, 165, 6, 11, 1, 0, 8, 82, 0, 35, 97, 7, 10, 1, 1, 8, 50, 0, 57, 114, 7, 10, 1, 1, 8, 179, 0, 53, 214, 4, 6, 0, 1, 5, 115, 0, 112, 146, 6, 8, 0, 3, 7, 211, 0, 106, 49, 9, 13, 1, -2, 11, 243, 0, 52, 172, 6, 11, 1, 0, 8, 83, 0, 24, 96, 7, 10, 0, 1, 7, 51, 0, 22, 138, 6, 10, 1, 1, 8, 180, 0, 9, 228, 3, 2, 3, 0, 8, 116, 0, 67, 188, 5, 10, 0, 1, 5, 212, 0, 93, 49, 9, 13, 1, -2, 11, 244, 0, 42, 164, 6, 11, 1, 0, 8, 84, 0, 13, 93, 7, 10, 0, 1, 7, 52, 0, 24, 110, 7, 10, 1, 1, 8, 53, 0, 92, 119, 6, 10, 1, 1, 8, 85, 0, 114, 66, 8, 10, 1, 1, 10, 213, 0, 2, 44, 9, 14, 1, -3, 11, 117, 0, 42, 123, 6, 8, 1, 3, 8, 181, 0, 2, 140, 6, 11, 1, 3, 8, 245, 0, 12, 165, 6, 12, 1, -1, 8, 54, 0, 82, 121, 6, 10, 1, 1, 8, 86, 0, 76, 18, 10, 10, -1, 1, 8, 246, 0, 72, 173, 6, 11, 1, 0, 8, 214, 0, 80, 49, 9, 13, 1, -2, 11, 182, 0, 68, 98, 7, 13, 1, 0, 9, 118, 0, 15, 47, 9, 8, -1, 3, 7, 55, 0, 72, 129, 6, 10, 1, 1, 8, 87, 0, 2, 2, 15, 10, -1, 1, 13, 119, 0, 37, 2, 12, 8, -1, 3, 10, 247, 0, 90, 94, 7, 7, 0, 3, 8, 215, 0, 2, 93, 7, 7, 0, 3, 8, 183, 0, 77, 223, 2, 2, 1, 5, 4, 56, 0, 62, 129, 6, 10, 1, 1, 8, 88, 0, 90, 19, 10, 10, -1, 1, 8, 216, 0, 99, 33, 9, 12, 1, 0, 11, 248, 0, 2, 128, 6, 8, 1, 3, 8, 120, 0, 119, 80, 7, 8, 0, 3, 7, 184, 0, 116, 212, 3, 3, 0, 11, 3, 89, 0, 28, 65, 9, 10, -1, 1, 7, 217, 0, 38, 80, 8, 13, 1, -2, 10, 249, 0, 52, 157, 6, 11, 1, 0, 8, 121, 0, 112, 33, 9, 11, -1, 3, 7, 57, 0, 12, 122, 6, 10, 1, 1, 8, 185, 0, 23, 229, 3, 6, 0, 1, 5, 218, 0, 26, 79, 8, 13, 1, -2, 10, 250, 0, 42, 149, 6, 11, 1, 0, 8, 90, 0, 32, 136, 6, 10, 1, 1, 8, 122, 0, 112, 119, 6, 8, 1, 3, 7, 58, 0, 89, 229, 2, 8, 1, 3, 4, 186, 0, 37, 205, 4, 5, 0, 1, 5, 219, 0, 50, 80, 8, 13, 1, -2, 10, 91, 0, 58, 227, 3, 12, 1, 1, 4, 123, 0, 103, 180, 5, 12, 0, 1, 5, 251, 0, 12, 150, 6, 11, 1, 0, 8, 59, 0, 71, 234, 2, 9, 1, 3, 4, 187, 0, 31, 181, 5, 6, 1, 4, 7, 188, 0, 16, 33, 10, 10, 0, 1, 10, 124, 0, 83, 229, 2, 14, 3, 0, 7, 220, 0, 62, 79, 8, 13, 1, -2, 10, 252, 0, 92, 133, 6, 11, 1, 0, 8, 92, 0, 97, 80, 7, 10, -1, 1, 5, 60, 0, 92, 153, 6, 7, 1, 3, 8, 189, 0, 47, 20, 11, 10, 0, 1, 10, 253, 0, 28, 47, 9, 14, -1, 0, 7, 221, 0, 54, 48, 9, 13, -1, -2, 7, 93, 0, 44, 226, 3, 12, 0, 1, 4, 125, 0, 110, 196, 5, 12, 0, 1, 5, 61, 0, 79, 112, 7, 5, 0, 4, 8, 190, 0, 104, 19, 10, 10, 0, 1, 10, 222, 0, 32, 165, 6, 10, 1, 1, 8, 254, 0, 102, 119, 6, 14, 1, 0, 8, 62, 0, 112, 158, 6, 7, 1, 3, 8, 94, 0, 86, 80, 7, 6, 0, 1, 7, 126, 0, 62, 158, 6, 3, 1, 5, 8, 223, 0, 82, 135, 6, 11, 1, 0, 8, 255, 0, 41, 48, 9, 14, -1, 0, 7, 191, 0, 94, 180, 5, 11, 0, 3, 6, 63, 0, 74, 202, 5, 10, 0, 1, 6, 95, 0, 92, 148, 6, 1, 0, 12, 6 )
 height = 14.0
 ascent = 11.0
 
@@ -256,10 +255,9 @@ size_flags_horizontal = 3
 wrap_enabled = true
 
 [node name="Theme" type="HBoxContainer" parent="Split/EditorScroll/Editor"]
-visible = false
-margin_top = 134.0
-margin_right = 581.0
-margin_bottom = 158.0
+margin_top = 110.0
+margin_right = 571.0
+margin_bottom = 134.0
 
 [node name="TLabel5" parent="Split/EditorScroll/Editor/Theme" instance=ExtResource( 3 )]
 anchor_right = 0.0
@@ -271,59 +269,37 @@ size_flags_vertical = 0
 text = "Theme: "
 text_key = "Theme: "
 
-[node name="ThemeButton" parent="Split/EditorScroll/Editor/Theme" instance=ExtResource( 6 )]
+[node name="ThemeName" type="LineEdit" parent="Split/EditorScroll/Editor/Theme"]
 unique_name_in_owner = true
-anchor_right = 0.0
-anchor_bottom = 0.0
 margin_left = 134.0
-margin_right = 282.0
+margin_right = 284.0
 margin_bottom = 24.0
+rect_min_size = Vector2( 150, 0 )
 
 [node name="Separator" type="HSeparator" parent="Split/EditorScroll/Editor"]
-margin_top = 110.0
+margin_top = 138.0
 margin_right = 571.0
-margin_bottom = 128.0
+margin_bottom = 156.0
 rect_min_size = Vector2( 0, 10 )
 custom_constants/separation = 18
 
 [node name="Portraits" type="HBoxContainer" parent="Split/EditorScroll/Editor"]
-margin_top = 132.0
+margin_top = 160.0
 margin_right = 571.0
-margin_bottom = 156.0
+margin_bottom = 184.0
 
 [node name="PortraitsTitle" parent="Split/EditorScroll/Editor/Portraits" instance=ExtResource( 3 )]
 unique_name_in_owner = true
 anchor_right = 0.0
 anchor_bottom = 0.0
 margin_top = 5.0
-margin_right = 295.0
+margin_right = 447.0
 margin_bottom = 19.0
 size_flags_horizontal = 3
 custom_fonts/font = SubResource( 4 )
 text = "Portraits"
 valign = 1
 text_key = "Portraits"
-
-[node name="TLabel13" parent="Split/EditorScroll/Editor/Portraits" instance=ExtResource( 3 )]
-anchor_right = 0.0
-anchor_bottom = 0.0
-margin_left = 299.0
-margin_top = 5.0
-margin_right = 367.0
-margin_bottom = 19.0
-text = "Main scale"
-text_key = "Main scale"
-
-[node name="CharacterScale" type="SpinBox" parent="Split/EditorScroll/Editor/Portraits"]
-unique_name_in_owner = true
-margin_left = 371.0
-margin_right = 447.0
-margin_bottom = 24.0
-size_flags_vertical = 4
-value = 100.0
-allow_greater = true
-align = 2
-suffix = "%"
 
 [node name="PortraitSearch" type="LineEdit" parent="Split/EditorScroll/Editor/Portraits"]
 unique_name_in_owner = true
@@ -336,8 +312,82 @@ expand_to_text_length = true
 clear_button_enabled = true
 placeholder_text = "Search"
 
+[node name="PortraitMainSettings" type="HBoxContainer" parent="Split/EditorScroll/Editor"]
+margin_top = 188.0
+margin_right = 571.0
+margin_bottom = 212.0
+alignment = 2
+
+[node name="TLabel11" parent="Split/EditorScroll/Editor/PortraitMainSettings" instance=ExtResource( 3 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 184.0
+margin_top = 5.0
+margin_right = 217.0
+margin_bottom = 19.0
+text = "Scale"
+text_key = "Scale"
+
+[node name="MainScale" type="SpinBox" parent="Split/EditorScroll/Editor/PortraitMainSettings"]
+unique_name_in_owner = true
+margin_left = 221.0
+margin_right = 297.0
+margin_bottom = 24.0
+value = 100.0
+allow_greater = true
+align = 2
+suffix = "%"
+
+[node name="TLabel12" parent="Split/EditorScroll/Editor/PortraitMainSettings" instance=ExtResource( 3 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 301.0
+margin_top = 5.0
+margin_right = 340.0
+margin_bottom = 19.0
+text = "Offset"
+text_key = "Offset"
+
+[node name="MainOffsetX" type="SpinBox" parent="Split/EditorScroll/Editor/PortraitMainSettings"]
+unique_name_in_owner = true
+margin_left = 344.0
+margin_right = 420.0
+margin_bottom = 24.0
+allow_greater = true
+allow_lesser = true
+suffix = "X"
+
+[node name="MainOffsetY" type="SpinBox" parent="Split/EditorScroll/Editor/PortraitMainSettings"]
+unique_name_in_owner = true
+margin_left = 424.0
+margin_right = 500.0
+margin_bottom = 24.0
+allow_greater = true
+allow_lesser = true
+suffix = "Y"
+
+[node name="MirrorOption" type="HBoxContainer" parent="Split/EditorScroll/Editor/PortraitMainSettings"]
+margin_left = 504.0
+margin_right = 571.0
+margin_bottom = 24.0
+
+[node name="TLabel11" parent="Split/EditorScroll/Editor/PortraitMainSettings/MirrorOption" instance=ExtResource( 3 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 39.0
+margin_bottom = 19.0
+text = "Mirror"
+text_key = "Mirror"
+
+[node name="MainMirror" type="CheckBox" parent="Split/EditorScroll/Editor/PortraitMainSettings/MirrorOption"]
+unique_name_in_owner = true
+margin_left = 43.0
+margin_right = 67.0
+margin_bottom = 24.0
+
 [node name="PortraitPanel" type="PanelContainer" parent="Split/EditorScroll/Editor"]
-margin_top = 160.0
+margin_top = 216.0
 margin_right = 571.0
 margin_bottom = 590.0
 size_flags_vertical = 3
@@ -347,7 +397,7 @@ custom_styles/panel = SubResource( 7 )
 margin_left = 2.0
 margin_top = 2.0
 margin_right = 569.0
-margin_bottom = 428.0
+margin_bottom = 372.0
 
 [node name="Labels" type="HBoxContainer" parent="Split/EditorScroll/Editor/PortraitPanel/VBoxContainer"]
 margin_right = 567.0
@@ -397,13 +447,13 @@ icon = SubResource( 9 )
 [node name="ScrollContainer" type="ScrollContainer" parent="Split/EditorScroll/Editor/PortraitPanel/VBoxContainer"]
 margin_top = 26.0
 margin_right = 567.0
-margin_bottom = 426.0
+margin_bottom = 370.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Split/EditorScroll/Editor/PortraitPanel/VBoxContainer/ScrollContainer"]
 margin_right = 567.0
-margin_bottom = 400.0
+margin_bottom = 344.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
@@ -586,6 +636,7 @@ margin_left = 43.0
 margin_right = 67.0
 margin_bottom = 24.0
 
-[connection signal="value_changed" from="Split/EditorScroll/Editor/Portraits/CharacterScale" to="." method="_on_Scale_value_changed"]
+[connection signal="value_changed" from="Split/EditorScroll/Editor/PortraitMainSettings/MainScale" to="." method="_on_Scale_value_changed"]
+[connection signal="toggled" from="Split/EditorScroll/Editor/PortraitMainSettings/MirrorOption/MainMirror" to="." method="_on_MirrorPortraitsCheckBox_toggled"]
 [connection signal="value_changed" from="Split/Preview/PortraitSettings/PortraitScale" to="." method="_on_Scale_value_changed"]
 [connection signal="toggled" from="Split/Preview/PortraitSettings/MirrorOption/PortraitMirror" to="." method="_on_MirrorPortraitsCheckBox_toggled"]

--- a/addons/dialogic/Events/Change theme/event.gd
+++ b/addons/dialogic/Events/Change theme/event.gd
@@ -7,6 +7,9 @@ var ThemeName: String = ""
 
 func _execute() -> void:
 	dialogic_game_handler.change_theme(ThemeName)
+	# base theme isn't overridden by character themes
+	# these means after a charcter theme, we can change back to the base theme
+	dialogic_game_handler.set_current_state_info('base_theme', ThemeName)
 	finish()
 
 

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -22,21 +22,34 @@ func _init() -> void:
 
 
 func _execute() -> void:
-	dialogic_game_handler.update_dialog_text(dialogic_game_handler.parse_variables(Text))
+	
 	if Character:
 		dialogic_game_handler.update_name_label(Character.name, Character.color)
 		if Portrait:
 			dialogic_game_handler.update_portrait(Character, Portrait)
+		if Character.theme:
+			dialogic_game_handler.change_theme(Character.theme)
 	else:
 		dialogic_game_handler.update_name_label("")
+	
+	if not Character or not Character.theme:
+		# if previous characters had a custom theme change back to base theme 
+		if dialogic_game_handler.get_current_state_info('base_theme') != dialogic_game_handler.get_current_state_info('theme'):
+			dialogic_game_handler.change_theme(dialogic_game_handler.get_current_state_info('base_theme', 'Default'))
+	
+	dialogic_game_handler.update_dialog_text(dialogic_game_handler.parse_variables(Text))
+	
+	# Wait for text to finish revealing
 	while true:
 		yield(dialogic_game_handler, "state_changed")
 		if dialogic_game_handler.current_state == dialogic_game_handler.states.IDLE:
 			break
+	
 	if dialogic_game_handler.is_question(dialogic_game_handler.current_event_idx):
 		#print("QUESTION!")
 		dialogic_game_handler.show_current_choices()
 		dialogic_game_handler.current_state = dialogic_game_handler.states.AWAITING_CHOICE
+	
 	finish()
 
 

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -9,10 +9,8 @@ var current_timeline_events = []
 var current_state = null setget set_current_state
 var current_event_idx = 0
 var current_portraits = []
-var current_bg_music
-var current_bg_image
-var current_name
-var current_text
+
+var current_state_info :Dictionary = {}
 
 var variable # This is used by the user to store variables
 
@@ -247,6 +245,7 @@ func play_sound(path:String, volume:float = 0, audio_bus:String = "Master", loop
 
 
 func change_theme(theme_name):
+	set_current_state_info('theme', theme_name)
 	for theme_node in get_tree().get_nodes_in_group('dialogic_themes'):
 		if theme_node.theme_name == theme_name:
 			theme_node.show()
@@ -370,3 +369,9 @@ func get_autoloads() -> Array:
 	for c in get_tree().root.get_children():
 		autoloads.append(c)
 	return autoloads
+
+func get_current_state_info(property:String, default = null):
+	return current_state_info.get(property, default)
+
+func set_current_state_info(property:String, value) -> void:
+	current_state_info[property] = value

--- a/addons/dialogic/Resources/character.gd
+++ b/addons/dialogic/Resources/character.gd
@@ -3,17 +3,19 @@ extends Resource
 class_name DialogicCharacter
 
 
-export (String) var name = ""
-export (String) var display_name = ""
-export (PoolStringArray) var nicknames = []
+export (String) var name:String = ""
+export (String) var display_name:String = ""
+export (PoolStringArray) var nicknames:Array = []
 
-export (Color) var color = Color()
-export (String, MULTILINE) var description = ""
-export (String) var theme = ""
+export (Color) var color:Color = Color()
+export (String, MULTILINE) var description:String = ""
+export (String) var theme:String = ""
 
 export (float) var scale:float = 1.0 
+export (Vector2) var offset:Vector2 = Vector2()
+export (bool) var mirror:bool = false
 
-export (Dictionary) var portraits = {}
+export (Dictionary) var portraits:Dictionary = {}
 
 
 

--- a/characters/Jowan.dch
+++ b/characters/Jowan.dch
@@ -4,70 +4,72 @@
 "color": Color( 0.596078, 0.690196, 0.356863, 1 ),
 "description": "A dialogic developer.",
 "display_name": "Jowan",
+"mirror": false,
 "name": "Jowan",
 "nicknames": [ "Spooner", "Jo" ],
+"offset": Vector2( 0, 40 ),
 "portraits": {
 "avoid": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 avoid.png",
 "scale": 1
 },
 "blink": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 blink.png",
 "scale": 1
 },
 "concept": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 concept.png",
 "scale": 1
 },
 "confusion": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 confusion.png",
 "scale": 1
 },
 "doubt": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 doubt.png",
 "scale": 1
 },
 "happy": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 happy.png",
 "scale": 1
 },
 "plot": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 plot.png",
 "scale": 1
 },
 "sad": {
-"mirror": false,
-"offset": Vector2( 0, 40 ),
+"mirror": true,
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 sad.png",
 "scale": 1
 },
 "shy": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 shy.png",
 "scale": 1
 },
 "surprise": {
 "mirror": false,
-"offset": Vector2( 0, 40 ),
+"offset": Vector2( 0, 0 ),
 "path": "res://addons/dialogic/Example Assets/portraits/Jane/pl3 surprise.png",
 "scale": 1
 }
 },
 "scale": 0.8,
-"theme": ""
+"theme": "Special"
 }


### PR DESCRIPTION
Should fix
- #937 
 
Adds 
- global portrait offset
- global portrait mirror

Implements
- character themes
- portrait search

# Notes
- moved the "global" settings scale, offset and mirror one row below, so the editor is less cluttered
- added a current_state_info dictionary to the DialogicGameHandler. It's supposed to hold all info about the current state and make communication between events easier. For example it saves the current theme name and the current base_theme name (base_theme isn't affected by character themes and allows to go back after a character with a custom theme talked).  