### PR TITLE
2.0 Text commands/modifiers

### DIFF
--- a/addons/dialogic/Display/DialogText.gd
+++ b/addons/dialogic/Display/DialogText.gd
@@ -1,32 +1,99 @@
 extends RichTextLabel
 
-export(String, 'Left', 'Center', 'Right') var Align = 'Left'
-var timer
+export(String, 'Left', 'Center', 'Right') var Align :String = 'Left'
+onready var timer = $Timer
 
-func _ready():
+var effect_regex = RegEx.new()
+var modifier_words_select_regex = RegEx.new()
+var effects:Array = []
+
+var speed:float = 0.01
+
+func _ready() -> void:
+	# add to necessary
 	add_to_group('dialogic_dialog_text')
-	bbcode_text = ""
-	timer = Timer.new()
-	add_child(timer)
+	
+	# setup my timer
 	timer.wait_time = 0.01
 	timer.connect("timeout", self, 'continue_reveal')
-
-func reveal_text():
+	
+	# compile effects regex
+	effect_regex.compile("\\[(?<command>[^\\[=,]*)(=(?<value>[^\\[]*))?\\]")
+	
+	# compule modifier regexs
+	modifier_words_select_regex.compile("\\[[^\\[]+(,[^\\]]*)\\]")
+	
+# this is called by the DialogicGameHandler to set text
+func reveal_text(_text:String) -> void:
+	bbcode_text = parse_effects(parse_modifiers(_text))
 	if Align == 'Center':
 		bbcode_text = '[center]'+bbcode_text
 	elif Align == 'Right':
 		bbcode_text = '[right]'+bbcode_text
 	visible_characters = 0
-	timer.start()
+	timer.start(speed)
 
-func continue_reveal():
+# called by the timer -> reveals more text
+func continue_reveal() -> void:
 	if visible_characters < len(bbcode_text):
 		visible_characters += 1
-		timer.start()
+		execute_effects()
+		if timer.is_stopped():
+			if speed == 0:
+				continue_reveal()
+			else:
+				timer.start(speed)
 	else:
 		finish_text()
 
+# shows all the text imidiatly
+# called by this thing itself or the DialogicGameHandler
 func finish_text():
 	percent_visible = 1
+	execute_effects(true)
 	timer.stop()
 	DialogicGameHandler.current_state = DialogicGameHandler.states.IDLE
+
+
+func parse_effects(_text:String) -> String:
+	effects.clear()
+	var position_correction = 0
+	for effect_match in effect_regex.search_all(_text):
+		# append [index, command, value] to effects array
+		effects.append([effect_match.get_start()-position_correction, effect_match.get_string('command'), effect_match.get_string('value').strip_edges()])
+		
+		_text.erase(effect_match.get_start()-position_correction, len(effect_match.get_string()))
+		position_correction += len(effect_match.get_string())
+	
+	return _text
+
+func execute_effects(skip :bool= false) -> void:
+	# might have to execute multiple effects
+	while effects and (visible_characters >= effects.front()[0] or visible_characters== -1):
+		var effect = effects.pop_front()
+		match effect[1]:
+			'pause':
+				if skip:
+					continue
+				if effect[2].is_valid_float():
+					timer.start(float(effect[2]))
+				else:
+					timer.start(1)
+			'speed':
+				if skip:
+					continue
+				if effect[2].is_valid_float():
+					speed = float(effect[2])
+			'signal':
+				DialogicGameHandler.emit_signal("text_signal", effect[2])
+			'portrait':
+				if effect[2]:
+					if DialogicGameHandler.get_current_state_info('character', null):
+						DialogicGameHandler.update_portrait(DialogicGameHandler.get_current_state_info('character'), effect[2])
+
+func parse_modifiers(_text:String) -> String:
+	for replace_mod_match in modifier_words_select_regex.search_all(_text):
+		var list = replace_mod_match.get_string().trim_prefix("[").trim_suffix("]").split(',')
+		var item = list[randi()%len(list)]
+		_text = _text.replace(replace_mod_match.get_string(), item.strip_edges())
+	return _text

--- a/addons/dialogic/Display/DialogText.tscn
+++ b/addons/dialogic/Display/DialogText.tscn
@@ -8,3 +8,7 @@ margin_bottom = 81.0
 bbcode_enabled = true
 text = "This is some preview dialog text!"
 script = ExtResource( 1 )
+Align = null
+
+[node name="Timer" type="Timer" parent="."]
+one_shot = true

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -24,13 +24,16 @@ func _init() -> void:
 func _execute() -> void:
 	
 	if Character:
+		dialogic_game_handler.set_current_state_info('character', Character)
 		dialogic_game_handler.update_name_label(Character.name, Character.color)
 		if Portrait:
 			dialogic_game_handler.update_portrait(Character, Portrait)
 		if Character.theme:
 			dialogic_game_handler.change_theme(Character.theme)
 	else:
+		dialogic_game_handler.set_current_state_info('character', null)
 		dialogic_game_handler.update_name_label("")
+		
 	
 	if not Character or not Character.theme:
 		# if previous characters had a custom theme change back to base theme 

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -17,6 +17,7 @@ var variable # This is used by the user to store variables
 signal state_changed(new_state)
 signal timeline_ended()
 signal signal_event(argument)
+signal text_signal(argument)
 
 ################################################################################
 ## 						INPUT (WIP)
@@ -102,22 +103,26 @@ func reset_all_display_nodes() -> void:
 func update_dialog_text(text:String) -> void:
 	current_state = states.SHOWING_TEXT
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
-		text_node.bbcode_text = text
-		text_node.reveal_text()
+		if text_node.is_visible_in_tree():
+			text_node.reveal_text(text)
 
 func skip_text_animation():
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
-		text_node.finish_text()
+		if text_node.is_visible_in_tree():
+			text_node.finish_text()
 
 func update_name_label(name:String, color:Color = Color()) -> void:
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
-		name_label.text = name
-		name_label.self_modulate = color
+		if name_label.is_visible_in_tree():
+			name_label.text = name
+			name_label.self_modulate = color
 
 func update_portrait(character: DialogicCharacter, portrait:String = "", position_idx:int = -1, z_index:int = 0, move:bool = false, animation:String = "") -> void:
 	
 	if not character:
 		return
+	if not portrait in character.portraits:
+		printerr("[Dialogic] Character ", character.display_name, " has no portrait '",portrait,"'.")
 	if len(get_tree().get_nodes_in_group('dialogic_portrait_holder')) == 0:
 		assert('[Dialogic] If you want to display portraits, you need a PortraitHolder scene!')
 		
@@ -179,9 +184,12 @@ func show_current_choices() -> void:
 		else:
 			show_choice(button_idx, choice_event.Text, true, choice_index)
 			button_idx += 1
+
 func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -> void:
 	var idx = 1
 	for node in get_tree().get_nodes_in_group('dialogic_choice_button'):
+		if !node.get_parent().is_visible_in_tree():
+			continue
 		if (node.choice_index == button_index) or (idx == button_index and node.choice_index == -1):
 			node.show()
 			node.text = parse_variables(text)
@@ -198,10 +206,11 @@ func choice_selected(event_index:int) -> void:
 
 func update_background(path:String) -> void:
 	for node in get_tree().get_nodes_in_group('dialogic_bg_image'):
-		if path.ends_with('.tscn'):
-			node.add_child(load(path).instance())
-		else:
-			node.texture = load(path)
+		if node.is_visible_in_tree():
+			if path.ends_with('.tscn'):
+				node.add_child(load(path).instance())
+			else:
+				node.texture = load(path)
 
 func update_music(path, volume:float = 0, audio_bus:String = "Master", fade_time:float = 0, loop:bool = true) -> void:
 	var fader = create_tween()

--- a/addons/dialogic/Other/TestTimelineScene.gd
+++ b/addons/dialogic/Other/TestTimelineScene.gd
@@ -2,7 +2,17 @@ extends Control
 
 
 func _ready():
+	randomize()
 	var current_timeline = ProjectSettings.get_setting('dialogic/current_timeline_path')
 	print('ProjectSettings - dialogic/current_timeline_path: ', current_timeline)
 	DialogicGameHandler.start_timeline(current_timeline)
 	DialogicGameHandler.connect("timeline_ended", get_tree(), 'quit')
+	DialogicGameHandler.connect("signal_event", self, 'recieve_event_signal')
+	DialogicGameHandler.connect("text_signal", self, 'recieve_text_signal')
+
+func recieve_event_signal(argument):
+	print("[Dialogic] Encountered a signal event: ", argument)
+
+func recieve_text_signal(argument):
+	print("[Dialogic] Encountered a signal in text: ", argument)
+	


### PR DESCRIPTION
- fixes multiple items of (#966)

# Text effects (executed when reached)
Added support for
- [pause=time] 
- [signal=arg]
- [speed=float]
- [portait=name]

# Modifiers (executed before text is shown)
Added support for
- [pick, a, word, or sentence]

# Other
- Modified testing scene (Play Timeline button)
    -> will print on text signal command or signal event
    -> will randomize() before starting timeline
- Made sure visual display elements only get updated if visible in tree. This is necessary because otherwise the hidden textboxes of other themes will cause text commands to be seemingly executed multiple times.
- Added text_signal signal to DialogicGameHandler, because I thought it would be nicer to have two different signals. 
- made sure the text event updates the current character in the current_state_info dictionary