### PR TITLE
2.0 Make sure text effect parser ignores`\[` 

### DIFF
--- a/addons/dialogic/Display/DialogText.gd
+++ b/addons/dialogic/Display/DialogText.gd
@@ -18,10 +18,10 @@ func _ready() -> void:
 	timer.connect("timeout", self, 'continue_reveal')
 	
 	# compile effects regex
-	effect_regex.compile("\\[(?<command>[^\\[=,]*)(=(?<value>[^\\[]*))?\\]")
+	effect_regex.compile("(?<!\\\\)\\[(?<command>[^\\[=,]*)(=(?<value>[^\\[]*))?\\]")
 	
 	# compule modifier regexs
-	modifier_words_select_regex.compile("\\[[^\\[]+(,[^\\]]*)\\]")
+	modifier_words_select_regex.compile("(?<!\\\\)\\[[^\\[]+(,[^\\]]*)\\]")
 	
 # this is called by the DialogicGameHandler to set text
 func reveal_text(_text:String) -> void:
@@ -64,7 +64,7 @@ func parse_effects(_text:String) -> String:
 		
 		_text.erase(effect_match.get_start()-position_correction, len(effect_match.get_string()))
 		position_correction += len(effect_match.get_string())
-	
+	_text = _text.replace('\\[', '[')
 	return _text
 
 func execute_effects(skip :bool= false) -> void:

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -73,7 +73,7 @@ func handle_event(event_index:int) -> void:
 	#print("\n[D] Handle Event ", event_index, ": ", event)
 	if event.continue_at_end:
 		#print("    -> WILL AUTO CONTINUE!")
-		event.connect("event_finished", self, 'handle_next_event')
+		event.connect("event_finished", self, 'handle_next_event', [], CONNECT_ONESHOT)
 	event.execute(self)
 
 


### PR DESCRIPTION
- still related to #971

You can now igore square opening brackets by having a backslash befor them. This will in turn ignore the content and closing bracket and leave it in.

#### Other
- made sure the DIalogicGameHandler connects to the events using a OneShot flag, otherwise it would always complain when you reached an  event a second time (e.g. with a jump loop.