### PR TITLE
2.0 Allow dynamic input fields on dialog node

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd
@@ -50,15 +50,6 @@ func set_value(value):
 		$Search/OpenButton.hide()
 	current_value = value
 
-func react_to_change():
-	if resource_type == resource_types.Portraits:
-		if event_resource.Character:
-			if current_value and (not (current_value in event_resource.Character.portraits.keys())):
-				set_value("")
-				emit_signal("value_changed", property_name, "")
-			show()
-		else:
-			hide()
 
 ################################################################################
 ## 						BASIC

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -104,5 +104,5 @@ func build_event_editor():
 	add_header_edit('ActionType', ValueType.FixedOptionSelector, 'Action:', '',
 		 {'selector_options':{"Join":ActionTypes.Join, "Leave":ActionTypes.Leave, "Update":ActionTypes.Update}})
 	add_header_edit('Character', ValueType.Character, 'Character:')
-	add_header_edit('Portrait', ValueType.Portrait, 'Portrait:')
-	add_header_edit('Position', ValueType.Integer, 'Position:')
+	add_header_edit('Portrait', ValueType.Portrait, 'Portrait:', '', {}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
+	add_header_edit('Position', ValueType.Integer, 'Position:', '', {}, 'Character != null and ActionType != %s' %ActionTypes.Leave)

--- a/addons/dialogic/Events/Choice/event.gd
+++ b/addons/dialogic/Events/Choice/event.gd
@@ -83,4 +83,4 @@ func get_original_translation_text():
 func build_event_editor():
 	add_header_edit("Text", ValueType.SinglelineText)
 	add_body_edit("Condition", ValueType.SinglelineText, 'if ')
-	add_body_edit("IfFalseAction", ValueType.FixedOptionSelector, 'else ', '', {'selector_options':{"Default":IfFalseActions.DEFAULT, "Hide":IfFalseActions.HIDE, "Disable":IfFalseActions.DISABLE}})
+	add_body_edit("IfFalseAction", ValueType.FixedOptionSelector, 'else ', '', {'selector_options':{"Default":IfFalseActions.DEFAULT, "Hide":IfFalseActions.HIDE, "Disable":IfFalseActions.DISABLE}}, '!Condition.empty()')

--- a/addons/dialogic/Events/Music/event.gd
+++ b/addons/dialogic/Events/Music/event.gd
@@ -51,6 +51,6 @@ func get_shortcode_parameters() -> Dictionary:
 func build_event_editor():
 	add_header_edit('FilePath', ValueType.SinglelineText, 'Path:')
 	add_header_edit('FadeLength', ValueType.Float, 'Fade:')
-	add_body_edit('Volume', ValueType.Decibel, 'Volume:')
-	add_body_edit('AudioBus', ValueType.SinglelineText, 'AudioBus:')
-	add_body_edit('Loop', ValueType.Bool, 'Loop:')
+	add_body_edit('Volume', ValueType.Decibel, 'Volume:', '', {}, '!FilePath.empty()')
+	add_body_edit('AudioBus', ValueType.SinglelineText, 'AudioBus:', '', {}, '!FilePath.empty()')
+	add_body_edit('Loop', ValueType.Bool, 'Loop:', '', {}, '!FilePath.empty()')

--- a/addons/dialogic/Events/Sound/event.gd
+++ b/addons/dialogic/Events/Sound/event.gd
@@ -48,6 +48,6 @@ func get_shortcode_parameters() -> Dictionary:
 
 func build_event_editor():
 	add_header_edit('FilePath', ValueType.SinglelineText, 'Path:')
-	add_body_edit('Volume', ValueType.Decibel, 'Volume:')
-	add_body_edit('AudioBus', ValueType.SinglelineText, 'AudioBus:')
+	add_body_edit('Volume', ValueType.Decibel, 'Volume:', '', {}, '!FilePath.empty()')
+	add_body_edit('AudioBus', ValueType.SinglelineText, 'AudioBus:', '', {}, '!FilePath.empty()')
 	#add_body_edit('Loop', ValueType.Bool, 'Loop:')

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -92,5 +92,5 @@ func get_original_translation_text():
 
 func build_event_editor():
 	add_header_edit('Character', ValueType.Character, 'Character:')
-	add_header_edit('Portrait', ValueType.Portrait, '')
+	add_header_edit('Portrait', ValueType.Portrait, '', '', {}, 'Character != null')
 	add_body_edit('Text', ValueType.MultilineText)

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -269,7 +269,7 @@ func add_header_label(text:String) -> void:
 		})
 
 
-func add_header_edit(variable:String, editor_type = ValueType.Label, left_text:String = "", right_text:String = "", extra_info:Dictionary = {}) -> void:
+func add_header_edit(variable:String, editor_type = ValueType.Label, left_text:String = "", right_text:String = "", extra_info:Dictionary = {}, condition:String = "") -> void:
 	editor_list.append({
 		"name":variable, 				# Must be the same as the corresponding property that it edits!
 		"type":typeof(get(variable)),
@@ -279,10 +279,11 @@ func add_header_edit(variable:String, editor_type = ValueType.Label, left_text:S
 		"display_info":extra_info,
 		"left_text":left_text,			# Text that will be displayed left of the field
 		"right_text":right_text,		# Text that will be displayed right of the field
+		"condition":condition,			# If true (or empty), the edit is shown
 		})
 
 
-func add_body_edit(variable:String, editor_type = ValueType.Label, left_text:String= "", right_text:String="", extra_info:Dictionary = {}) -> void:
+func add_body_edit(variable:String, editor_type = ValueType.Label, left_text:String= "", right_text:String="", extra_info:Dictionary = {}, condition:String = "") -> void:
 	editor_list.append({
 		"name":variable, 				# Must be the same as the corresponding property that it edits!
 		"type":typeof(get(variable)),
@@ -292,6 +293,7 @@ func add_body_edit(variable:String, editor_type = ValueType.Label, left_text:Str
 		"display_info":extra_info,
 		"left_text":left_text,			# Text that will be displayed left of the field
 		"right_text":right_text,		# Text that will be displayed right of the field
+		"condition":condition,			# If true (or empty), the edit is shown
 		})
 
 


### PR DESCRIPTION
- implementation of a fix for #955

Allows to add a condition (string) to header and body input fields of the dialog node. 

If the condition is true, they are shown, otherwise hidden.
They update on changes.

*Example Implementation*
![grafik](https://user-images.githubusercontent.com/42868150/177049111-2db0ca64-8910-4bc4-8ccf-305ab5ced9bb.png)


Implemented on:
- Text event (portrait hidden if no character)
- Character event (Portrait & hidden if no character or mode == Leave)
- Sound & Music (Volume, Bus, Loop hidden if no path)
- Choice (ElseAction hidden if no condition)