### PR TITLE
1.4.3 - Fix for export error due to settings theme failure

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -145,9 +145,8 @@ func load_config_files():
 	settings = DialogicResources.get_settings_config()
 	# theme
 	var theme_file = 'res://addons/dialogic/Editor/ThemeEditor/default-theme.cfg'
-	if settings.has_section('theme'):
-		theme_file = settings.get_value('theme', 'default')
-		current_default_theme = theme_file
+	theme_file = settings.get_value('theme', 'default', 'default-theme.cfg')
+	current_default_theme = theme_file
 	current_theme = load_theme(theme_file)
 	
 	# history

--- a/addons/dialogic/Nodes/DialogNode.tscn
+++ b/addons/dialogic/Nodes/DialogNode.tscn
@@ -29,13 +29,19 @@ anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
+margin_left = 640.0
+margin_top = 720.0
+margin_right = 640.0
+margin_bottom = 720.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="TextBubble" parent="." instance=ExtResource( 1 )]
-margin_top = -207.0
-margin_bottom = -40.0
+margin_left = 185.0
+margin_top = 513.0
+margin_right = 1095.0
+margin_bottom = 680.0
 
 [node name="Options" type="VBoxContainer" parent="."]
 visible = false


### PR DESCRIPTION
This fix changes the logic for loading a theme file to give and use a fallback even if nothing exists in the settings file. Previously this value COULD be a null given certain circumstances during an export.

