### PR TITLE
1.4.x - Added NoSkip Event and Auto Advance Mode

### DIFF
--- a/addons/dialogic/Editor/Events/NoSkipEvent.tscn
+++ b/addons/dialogic/Editor/Events/NoSkipEvent.tscn
@@ -1,0 +1,82 @@
+[gd_scene load_steps=7 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/NoSkip/NoSkipPart.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/dialogic/Images/Event Icons/Main Icons/close-dialog.svg" type="Texture" id=3]
+[ext_resource path="res://addons/dialogic/Editor/Events/Templates/EventTemplate.tscn" type="PackedScene" id=4]
+
+[sub_resource type="Image" id=4]
+data = {
+"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+"format": "LumAlpha8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id=2]
+flags = 4
+flags = 4
+image = SubResource( 4 )
+size = Vector2( 16, 16 )
+
+[sub_resource type="StyleBoxEmpty" id=3]
+
+[node name="NoSkipEvent" instance=ExtResource( 4 )]
+event_name = "No Skip"
+event_data = {
+"block_input": true,
+"event_id": "dialogic_050"
+}
+event_color = Color( 0.92549, 0.0941176, 0.756863, 1 )
+event_icon = ExtResource( 3 )
+body_scene = ExtResource( 2 )
+expand_on_default = false
+event_category = 2
+
+[node name="PanelContainer" parent="." index="1"]
+margin_right = 358.0
+
+[node name="MarginContainer" parent="PanelContainer" index="1"]
+margin_right = 358.0
+
+[node name="VBoxContainer" parent="PanelContainer/MarginContainer" index="0"]
+margin_right = 352.0
+
+[node name="Header" parent="PanelContainer/MarginContainer/VBoxContainer" index="0"]
+margin_right = 342.0
+
+[node name="IconPanel" parent="PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer" index="0"]
+self_modulate = Color( 0.92549, 0.0941176, 0.756863, 1 )
+
+[node name="IconTexture" parent="PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer/IconPanel" index="0"]
+self_modulate = Color( 0, 0, 0, 1 )
+texture = ExtResource( 3 )
+
+[node name="Warning" parent="PanelContainer/MarginContainer/VBoxContainer/Header/CenterContainer/IconPanel" index="1"]
+texture = SubResource( 2 )
+
+[node name="TitleLabel" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="1"]
+margin_right = 48.0
+text = "No Skip"
+
+[node name="Content" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="2"]
+margin_left = 48.0
+margin_right = 58.0
+
+[node name="ExpandControl" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="3"]
+visible = true
+margin_left = 58.0
+margin_top = 17.0
+margin_right = 102.0
+margin_bottom = 47.0
+
+[node name="Spacer" parent="PanelContainer/MarginContainer/VBoxContainer/Header" index="4"]
+margin_left = 102.0
+margin_right = 342.0
+
+[node name="Content" parent="PanelContainer/MarginContainer/VBoxContainer/Body" index="0"]
+custom_constants/margin_left = 0
+
+[node name="PopupMenu" parent="." index="2"]
+custom_styles/hover = SubResource( 3 )
+items = [ "Documentation", SubResource( 2 ), 0, false, false, 0, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Move up", SubResource( 2 ), 0, false, false, 2, 0, null, "", false, "Move down", SubResource( 2 ), 0, false, false, 3, 0, null, "", false, "", null, 0, false, false, -1, 0, null, "", true, "Delete", SubResource( 2 ), 0, false, false, 5, 0, null, "", false ]

--- a/addons/dialogic/Editor/Events/NoSkipEvent.tscn
+++ b/addons/dialogic/Editor/Events/NoSkipEvent.tscn
@@ -25,7 +25,8 @@ size = Vector2( 16, 16 )
 event_name = "No Skip"
 event_data = {
 "block_input": true,
-"event_id": "dialogic_050"
+"event_id": "dialogic_050",
+"wait_time": 0.0
 }
 event_color = Color( 0.92549, 0.0941176, 0.756863, 1 )
 event_icon = ExtResource( 3 )

--- a/addons/dialogic/Editor/Events/Parts/NoSkip/EventPart_NoSkip.gd
+++ b/addons/dialogic/Editor/Events/Parts/NoSkip/EventPart_NoSkip.gd
@@ -5,9 +5,11 @@ extends "res://addons/dialogic/Editor/Events/Parts/EventPart.gd"
 
 ## node references
 onready var noskip_selector = $HBoxContainer/NoSkipCheckbox
+onready var autoadvance_time = $HBoxContainer2/AutoAdvanceTime
 
 # used to connect the signals
 func _ready():
+	autoadvance_time.connect("value_changed", self, "_on_SecondsSelector_value_changed")
 	noskip_selector.connect("toggled", self, "_on_HideDialogBox_toggled")
 
 # called by the event block
@@ -15,8 +17,13 @@ func load_data(data:Dictionary):
 	# First set the event_data
 	.load_data(data)
 	
-	# Now update the ui nodes to display the data. 
+	autoadvance_time.value = event_data['wait_time']
 	noskip_selector.pressed = event_data.get('block_input', true)
+
+
+func _on_SecondsSelector_value_changed(value):
+	event_data['wait_time'] = value
+	data_changed()
 
 
 func _on_HideDialogBox_toggled(checkbox_value):

--- a/addons/dialogic/Editor/Events/Parts/NoSkip/EventPart_NoSkip.gd
+++ b/addons/dialogic/Editor/Events/Parts/NoSkip/EventPart_NoSkip.gd
@@ -1,0 +1,28 @@
+tool
+extends "res://addons/dialogic/Editor/Events/Parts/EventPart.gd"
+
+# has an event_data variable that stores the current data!!!
+
+## node references
+onready var noskip_selector = $HBoxContainer/NoSkipCheckbox
+
+# used to connect the signals
+func _ready():
+	noskip_selector.connect("toggled", self, "_on_HideDialogBox_toggled")
+
+# called by the event block
+func load_data(data:Dictionary):
+	# First set the event_data
+	.load_data(data)
+	
+	# Now update the ui nodes to display the data. 
+	noskip_selector.pressed = event_data.get('block_input', true)
+
+
+func _on_HideDialogBox_toggled(checkbox_value):
+	event_data['block_input'] = checkbox_value
+	data_changed()
+
+# has to return the wanted preview, only useful for body parts
+func get_preview():
+	return ''

--- a/addons/dialogic/Editor/Events/Parts/NoSkip/NoSkipPart.tscn
+++ b/addons/dialogic/Editor/Events/Parts/NoSkip/NoSkipPart.tscn
@@ -10,21 +10,47 @@ theme = ExtResource( 3 )
 script = ExtResource( 1 )
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-margin_right = 532.0
-margin_bottom = 24.0
+margin_right = 392.0
+margin_bottom = 31.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Label" parent="HBoxContainer" instance=ExtResource( 2 )]
-margin_top = 5.0
-margin_right = 504.0
-margin_bottom = 19.0
+margin_top = 0.0
+margin_right = 243.0
+margin_bottom = 31.0
 custom_colors/font_color = Color( 0, 0, 0, 1 )
-text = "When checked, default action key input is ignored
+text = "Ignore input and auto advance dialog?
 until an unchecked No Skip is reached"
 
 [node name="NoSkipCheckbox" type="CheckBox" parent="HBoxContainer"]
-margin_left = 508.0
-margin_right = 532.0
+margin_left = 368.0
+margin_right = 392.0
+margin_bottom = 31.0
+size_flags_horizontal = 10
+
+[node name="HSeparator" type="HSeparator" parent="."]
+margin_top = 35.0
+margin_right = 392.0
+margin_bottom = 39.0
+
+[node name="HBoxContainer2" type="HBoxContainer" parent="."]
+margin_top = 43.0
+margin_right = 392.0
+margin_bottom = 67.0
+
+[node name="Label2" parent="HBoxContainer2" instance=ExtResource( 2 )]
+margin_top = 5.0
+margin_right = 312.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+text = "Default wait time after dialog finishes in seconds"
+
+[node name="AutoAdvanceTime" type="SpinBox" parent="HBoxContainer2"]
+margin_left = 316.0
+margin_right = 392.0
 margin_bottom = 24.0
+min_value = 2.0
+max_value = 50.0
+value = 2.0

--- a/addons/dialogic/Editor/Events/Parts/NoSkip/NoSkipPart.tscn
+++ b/addons/dialogic/Editor/Events/Parts/NoSkip/NoSkipPart.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/NoSkip/EventPart_NoSkip.gd" type="Script" id=1]
+[ext_resource path="res://addons/dialogic/Editor/Events/Parts/Text/GreyLabel.tscn" type="PackedScene" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=3]
+
+[node name="VBoxContainer" type="VBoxContainer"]
+size_flags_vertical = 4
+theme = ExtResource( 3 )
+script = ExtResource( 1 )
+
+[node name="HBoxContainer" type="HBoxContainer" parent="."]
+margin_right = 532.0
+margin_bottom = 24.0
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Label" parent="HBoxContainer" instance=ExtResource( 2 )]
+margin_top = 5.0
+margin_right = 504.0
+margin_bottom = 19.0
+custom_colors/font_color = Color( 0, 0, 0, 1 )
+text = "When checked, default action key input is ignored
+until an unchecked No Skip is reached"
+
+[node name="NoSkipCheckbox" type="CheckBox" parent="HBoxContainer"]
+margin_left = 508.0
+margin_right = 532.0
+margin_bottom = 24.0

--- a/addons/dialogic/Editor/Events/Parts/WaitSeconds/WaitSeconds.tscn
+++ b/addons/dialogic/Editor/Events/Parts/WaitSeconds/WaitSeconds.tscn
@@ -9,9 +9,6 @@
 size_flags_vertical = 4
 theme = ExtResource( 3 )
 script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
 margin_right = 377.0

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -53,6 +53,8 @@ var id_to_scene_name = {
 	'dialogic_040':'EmitSignal',
 	'dialogic_041':'ChangeScene',
 	'dialogic_042':'CallNode',
+	#Afterlife
+	'dialogic_050':'NoSkipEvent',
 	}
 
 var event_data

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -10,6 +10,7 @@ var timeline_name: String
 
 ### MODE
 var preview: bool = false
+var noSkipMode: bool = false
 
 enum state {
 	IDLE, # When nothing is happening
@@ -441,7 +442,7 @@ func _process(delta):
 
 # checks for the "input_next" action
 func _input(event: InputEvent) -> void:
-	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()):
+	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and !noSkipMode:
 		if HistoryTimeline.block_dialog_advance:
 			return
 		if is_state(state.WAITING):
@@ -998,6 +999,9 @@ func event_handler(event: Dictionary):
 
 			set_state(state.IDLE)
 			$TextBubble.visible = true
+			_load_next_event()
+		'dialogic_050':
+			noSkipMode = event['block_input']
 			_load_next_event()
 		_:
 			if event['event_id'] in $CustomEvents.handlers.keys():

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -447,7 +447,11 @@ func _process(delta):
 
 # checks for the "input_next" action
 func _input(event: InputEvent) -> void:
-	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and (!noSkipMode or !autoPlayMode):
+	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and autoPlayMode:
+		autoPlayMode = false
+		return
+	
+	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and (!noSkipMode and !autoPlayMode):
 		if HistoryTimeline.block_dialog_advance:
 			return
 		if is_state(state.WAITING):

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -10,7 +10,10 @@ var timeline_name: String
 
 ### MODE
 var preview: bool = false
+
 var noSkipMode: bool = false
+var autoPlayMode: bool = false
+var autoWaitTime : float = 2.0
 
 enum state {
 	IDLE, # When nothing is happening
@@ -430,7 +433,7 @@ func _process(delta):
 	
 	# Hide if no input is required
 	if current_event.has('text'):
-		if '[nw]' in current_event['text'] or '[nw=' in current_event['text']:
+		if '[nw]' in current_event['text'] or '[nw=' in current_event['text'] or noSkipMode or autoPlayMode:
 			$TextBubble/NextIndicatorContainer/NextIndicator.visible = false
 		
 	# Hide if "Don't Close After Last Event" is checked and event is last text
@@ -444,7 +447,7 @@ func _process(delta):
 
 # checks for the "input_next" action
 func _input(event: InputEvent) -> void:
-	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and !noSkipMode:
+	if not Engine.is_editor_hint() and event.is_action_pressed(Dialogic.get_action_button()) and (!noSkipMode or !autoPlayMode):
 		if HistoryTimeline.block_dialog_advance:
 			return
 		if is_state(state.WAITING):
@@ -512,7 +515,7 @@ func _on_text_completed():
 		
 		# [p] needs more work
 		# Setting the timer for how long to wait in the [nw] events
-		if '[nw]' in current_event['text'] or '[nw=' in current_event['text']:
+		if '[nw]' in current_event['text'] or '[nw=' in current_event['text'] or noSkipMode or autoPlayMode:
 			var waiting_time = 2
 			var current_index = dialog_index
 			if '[nw=' in current_event['text']: # Regex stuff
@@ -532,7 +535,12 @@ func _on_text_completed():
 				# - KvaGram
 				#original line
 				#waiting_time = float(wait_settings.split('=')[1])
-			
+			elif noSkipMode or autoPlayMode:
+				waiting_time = autoWaitTime
+				if current_event.has('voice_data'):
+					waiting_time = $"FX/CharacterVoice".remaining_time()
+				else:
+					waiting_time = float(waiting_time)
 			$DialogicTimer.start(waiting_time); yield($DialogicTimer, "timeout")
 			if dialog_index == current_index:
 				_load_next_event()
@@ -1004,6 +1012,7 @@ func event_handler(event: Dictionary):
 			_load_next_event()
 		'dialogic_050':
 			noSkipMode = event['block_input']
+			autoWaitTime = event['wait_time']
 			_load_next_event()
 		_:
 			if event['event_id'] in $CustomEvents.handlers.keys():

--- a/addons/dialogic/Other/DialogicClass.gd
+++ b/addons/dialogic/Other/DialogicClass.gd
@@ -331,6 +331,16 @@ static func toggle_history():
 	else:
 		print('[D] Tried to toggle history, but no dialog node exists.')
 
+################################################################################
+## 					AUTO-ADVANCE
+################################################################################
+static func auto_advance_on(toggle: bool, delay : float=2):
+	if has_current_dialog_node():
+		var dialog_node = Engine.get_main_loop().get_meta('latest_dialogic_node')
+		dialog_node.autoPlayMode = toggle
+		dialog_node.autoWaitTime = float(delay)
+	else:
+		print('[D] Tried to toggle auto advance mode, but no dialog node exists.')
 
 ################################################################################
 ## 					COULD BE USED

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -498,6 +498,9 @@ static func resource_fixer():
 						# Call Node event
 						{'call_node'}:
 							i['event_id'] = 'dialogic_042'
+						# No Skip event
+						{'block_input'}:
+							i['event_id'] = 'dialogic_050'
 			timeline['events'] = events
 			DialogicResources.set_timeline(timeline)
 	if update_index < 2:


### PR DESCRIPTION
Added a no Skip event. This blocks default action input from working until an unchecked no skip event is reached. This is most useful for combining Dialogic with cut scenes and the [nw] command in order to avoid messed up timings.

Only advancement of dialog is skipped. Choices must still be made and will still accept mouse clicks/taps

![image](https://user-images.githubusercontent.com/7741797/177898579-f0fcbffa-d7ba-429b-b5aa-af093d4555ae.png)
