### PR TITLE
1.4.x - Exposed Letter Written signal

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -81,6 +81,8 @@ signal timeline_start(timeline_name)
 signal timeline_end(timeline_name)
 # Custom user signal
 signal dialogic_signal(value)
+# Utility
+signal letter_displayed(lastLetter)
 
 
 ## -----------------------------------------------------------------------------
@@ -1039,8 +1041,10 @@ func update_text(text: String) -> String:
 	return final_text
 
 # plays a sound
-func _on_letter_written():
-	play_audio('typing')
+func _on_letter_written(lastLetter):
+	if lastLetter != ' ':
+		play_audio('typing')
+	emit_signal('letter_displayed', lastLetter)
 
 
 ## -----------------------------------------------------------------------------

--- a/addons/dialogic/Nodes/DialogProxy.gd
+++ b/addons/dialogic/Nodes/DialogProxy.gd
@@ -33,7 +33,8 @@ var _signals_to_copy = [
 	'text_complete',
 	'timeline_start',
 	'timeline_end',
-	'dialogic_signal'
+	'dialogic_signal',
+	'letter_displayed',
 ]
 ## -----------------------------------------------------------------------------
 ## 						SIGNALS (proxy copy of DialogNode signals)
@@ -48,3 +49,4 @@ signal timeline_start(timeline_name)
 signal timeline_end(timeline_name)
 # Custom user signal
 signal dialogic_signal(value)
+signal letter_displayed(lastLetter)

--- a/addons/dialogic/Nodes/TextBubble.gd
+++ b/addons/dialogic/Nodes/TextBubble.gd
@@ -20,7 +20,7 @@ var _finished := false
 var _theme
 
 signal text_completed()
-signal letter_written()
+signal letter_written(lastLetter)
 signal signal_request(arg)
 
 ## *****************************************************************************
@@ -283,11 +283,11 @@ func _on_writing_timer_timeout():
 		if text_label.visible_characters > text_label.get_total_character_count():
 			_handle_text_completed()
 		elif (
-			text_label.visible_characters > 0 and 
+			text_label.visible_characters > 0 #and 
 			#text_label.text.length() > text_label.visible_characters-1 and 
-			text_label.text[text_label.visible_characters-1] != " "
+			#text_label.text[text_label.visible_characters-1] != " "
 		):
-			emit_signal('letter_written')
+			emit_signal('letter_written', text_label.text[text_label.visible_characters-1] )
 	else:
 		$WritingTimer.stop()
 

--- a/addons/dialogic/Nodes/canvas_dialog_node.gd
+++ b/addons/dialogic/Nodes/canvas_dialog_node.gd
@@ -13,7 +13,7 @@ signal timeline_end(timeline_name)
 signal text_complete(text_event)
 # Custom user signal
 signal dialogic_signal(value)
-
+signal letter_displayed(lastLetter)
 
 var _dialog_node_scene = load("res://addons/dialogic/Nodes/DialogNode.tscn")
 var dialog_node = null
@@ -35,6 +35,8 @@ func set_dialog_node_scene(scene) -> void:
 		_err = dialog_node.connect("text_complete", self, "_on_text_complete")
 		assert(_err == OK)
 		_err = dialog_node.connect("dialogic_signal", self, "_on_dialogic_signal")
+		assert(_err == OK)
+		_err = dialog_node.connect("letter_displayed", self, "_on_letter_displayed")
 		assert(_err == OK)
 
 func _enter_tree() -> void:  
@@ -76,3 +78,7 @@ func _on_text_complete(text_event) -> void:
 
 func _on_dialogic_signal(value) -> void:
 	emit_signal("dialogic_signal", value)
+
+
+func _on_letter_displayed(last_letter):
+	emit_signal("letter_displayed", last_letter)


### PR DESCRIPTION
Added new signal 'letter_displayed', which is emitted whenever a letter is written on the text bubble. This hooks into the existing 'letter_written' signal that plays the typing audio, and bubbles up further with the char that is written (including spaces).

This can be used to build a buffer and react to text as it displays on the screen, or time lip flaps, etc.