### PR TITLE
2.0 Add Character Animation support

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
@@ -46,6 +46,7 @@ mouse_filter = 1
 size_flags_horizontal = 3
 size_flags_vertical = 4
 theme = ExtResource( 2 )
+expand_to_text_length = true
 placeholder_text = "Select Resource"
 caret_blink = true
 caret_blink_speed = 0.5
@@ -57,6 +58,7 @@ margin_right = 440.0
 margin_bottom = 139.0
 
 [node name="OpenButton" type="ToolButton" parent="Search"]
+visible = false
 anchor_left = 1.0
 anchor_top = 0.5
 anchor_right = 1.0

--- a/addons/dialogic/Editor/Events/Templates/EventNode.gd
+++ b/addons/dialogic/Editor/Events/Templates/EventNode.gd
@@ -198,15 +198,12 @@ func build_editor():
 			editor_node = load("res://addons/dialogic/Editor/Events/Fields/Bool.tscn").instance()
 		
 		## RESOURCES
-		elif p.dialogic_type in [resource.ValueType.Character, resource.ValueType.Portrait, resource.ValueType.Timeline]:
+		elif p.dialogic_type == resource.ValueType.Resource:
 			editor_node = load("res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn").instance()
-			if p.dialogic_type == resource.ValueType.Character:
-				editor_node.resource_type = editor_node.resource_types.Characters
-			elif p.dialogic_type == resource.ValueType.Portrait:
-				editor_node.resource_type = editor_node.resource_types.Portraits
-			elif p.dialogic_type == resource.ValueType.Timeline:
-				editor_node.resource_type = editor_node.resource_types.Timelines
-		
+			
+			editor_node.file_extension = p.display_info.get('file_extension', '')
+			editor_node.get_suggestions_func = p.display_info.get('suggestions_func', editor_node.get_suggestions_func)
+			editor_node.empty_text = p.display_info.get('empty_text', '')
 		## INTEGERS
 		elif p.dialogic_type == resource.ValueType.Integer:
 			editor_node = load("res://addons/dialogic/Editor/Events/Fields/Number.tscn").instance()
@@ -241,6 +238,8 @@ func build_editor():
 		
 		### --------------------------------------------------------------------
 		### 2. FILL THE NEW NODE WITH INFORMATION AND LISTEN TO CHANGES
+		if "event_resource" in editor_node:
+			editor_node.event_resource = resource
 		if 'property_name' in editor_node:
 			editor_node.property_name = p.name
 		if editor_node.has_method('set_value'):
@@ -253,8 +252,7 @@ func build_editor():
 			editor_node.set_right_text(p.right_text)
 		if p.has('condition'):
 			edit_conditions_list.append([editor_node, p.condition])
-		if "event_resource" in editor_node:
-			editor_node.event_resource = resource
+		
 		
 		### --------------------------------------------------------------------
 		### 3. ADD IT TO THE RIGHT PLACE (HEADER/BODY)

--- a/addons/dialogic/Events/Character/AnimationsSettings.gd
+++ b/addons/dialogic/Events/Character/AnimationsSettings.gd
@@ -1,0 +1,74 @@
+tool
+extends HSplitContainer
+
+var current_animation_path = ""
+
+func _ready():
+	$'%JoinDefault'.get_suggestions_func = [self, 'get_join_animation_suggestions']
+	$'%LeaveDefault'.get_suggestions_func = [self, 'get_leave_animation_suggestions']
+
+func refresh():
+	$'%CustomAnimationsFolderOpener'.icon = get_icon("Folder", "EditorIcons")
+	get_node('%CustomAnimationsFolder').text = DialogicUtil.get_project_setting('dialogic/animations_custom_folder', 'res://addons/dialogic_additions/Animations')
+	
+	$'%JoinDefault'.set_value(DialogicUtil.get_project_setting('dialogic/animations_join_default', 
+	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_in_up.gd')))
+	$'%LeaveDefault'.set_value(DialogicUtil.get_project_setting('dialogic/animations_leave_default', 
+	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_out_down.gd')))
+	$'%JoinDefaultLength'.set_value(DialogicUtil.get_project_setting('dialogic/animations_join_default_length', 0.5))
+	$'%LeaveDefaultLength'.set_value(DialogicUtil.get_project_setting('dialogic/animations_leave_default_length', 0.5))
+	$'%LeaveDefaultWait'.pressed = DialogicUtil.get_project_setting('dialogic/animations_leave_default_wait', true)
+	$'%JoinDefaultWait'.pressed = DialogicUtil.get_project_setting('dialogic/animations_join_default_wait', true)
+
+
+func _on_LeaveDefault_value_changed(property_name, value):
+	ProjectSettings.set_setting('dialogic/animations_leave_default', value)
+
+
+func _on_JoinDefault_value_changed(property_name, value):
+	ProjectSettings.set_setting('dialogic/animations_join_default', value)
+
+
+func _on_JoinDefaultLength_value_changed(value):
+	ProjectSettings.set_setting('dialogic/animations_join_default_length', value)
+
+
+func _on_LeaveDefaultLength_value_changed(value):
+	ProjectSettings.set_setting('dialogic/animations_leave_default_length', value)
+
+func _on_JoinDefaultWait_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/animations_join_default_wait', button_pressed)
+
+func _on_LeaveDefaultWait_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/animations_leave_default_wait', button_pressed)
+
+
+func get_join_animation_suggestions(search_text):
+	var suggestions = {}
+	for anim in list_animations():
+		if search_text.to_lower() in anim.get_file().to_lower():
+			if '_in' in anim.get_file():
+				suggestions[DialogicUtil.pretty_name(anim)] = anim
+	return suggestions
+
+func get_leave_animation_suggestions(search_text):
+	var suggestions = {}
+	for anim in list_animations():
+		if search_text.to_lower() in anim.get_file().to_lower():
+			if '_out' in anim.get_file():
+				suggestions[DialogicUtil.pretty_name(anim)] = anim
+	return suggestions
+
+func list_animations() -> Array:
+	var list = DialogicUtil.listdir(get_script().resource_path.get_base_dir().plus_file('DefaultAnimations'), true, false, true)
+	list.append_array(DialogicUtil.listdir(DialogicUtil.get_project_setting('dialogic/animations_custom_folder', 'res://addons/dialogic_additions/Animations'), true, false, true))
+	return list
+
+
+func _on_CustomAnimationsFolderOpener_pressed():
+	find_parent('EditorView').godot_file_dialog(self, 'custom_anims_folder_selected', '', EditorFileDialog.MODE_OPEN_DIR, 'Select custom animation folder')
+
+func custom_anims_folder_selected(path):
+	get_node('%CustomAnimationsFolder').text = path
+	ProjectSettings.set_setting('dialogic/animations_custom_folder', path)
+

--- a/addons/dialogic/Events/Character/AnimationsSettings.tscn
+++ b/addons/dialogic/Events/Character/AnimationsSettings.tscn
@@ -1,0 +1,174 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Events/Character/AnimationsSettings.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn" type="PackedScene" id=3]
+
+[sub_resource type="Image" id=3]
+data = {
+"data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+"format": "LumAlpha8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id=2]
+flags = 4
+flags = 4
+image = SubResource( 3 )
+size = Vector2( 16, 16 )
+
+[node name="Animations" type="HSplitContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+margin_right = 1024.0
+margin_bottom = 600.0
+size_flags_horizontal = 3
+size_flags_stretch_ratio = 0.5
+
+[node name="TLabel" parent="VBoxContainer" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 1024.0
+margin_bottom = 14.0
+text = "Animations"
+title = true
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 18.0
+margin_right = 1024.0
+margin_bottom = 42.0
+
+[node name="TLabel2" parent="VBoxContainer/HBoxContainer" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 494.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Custom anims folder"
+
+[node name="CustomAnimationsFolder" type="LineEdit" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 498.0
+margin_right = 992.0
+margin_bottom = 24.0
+size_flags_horizontal = 3
+
+[node name="CustomAnimationsFolderOpener" type="Button" parent="VBoxContainer/HBoxContainer"]
+unique_name_in_owner = true
+margin_left = 996.0
+margin_right = 1024.0
+margin_bottom = 24.0
+icon = SubResource( 2 )
+
+[node name="TLabel2" parent="VBoxContainer" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 46.0
+margin_right = 1024.0
+margin_bottom = 60.0
+text = "Defaults"
+title = true
+
+[node name="DefaultIn" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 64.0
+margin_right = 1024.0
+margin_bottom = 104.0
+
+[node name="TLabel2" parent="VBoxContainer/DefaultIn" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 13.0
+margin_right = 673.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+text = "Default Join animation"
+
+[node name="JoinDefault" parent="VBoxContainer/DefaultIn" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 677.0
+margin_top = 8.0
+margin_right = 829.0
+margin_bottom = 32.0
+
+[node name="JoinDefaultLength" type="SpinBox" parent="VBoxContainer/DefaultIn"]
+unique_name_in_owner = true
+margin_left = 833.0
+margin_right = 907.0
+margin_bottom = 40.0
+step = 0.1
+
+[node name="TLabel3" parent="VBoxContainer/DefaultIn" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 911.0
+margin_top = 13.0
+margin_right = 944.0
+margin_bottom = 27.0
+text = "Wait:"
+
+[node name="JoinDefaultWait" type="CheckButton" parent="VBoxContainer/DefaultIn"]
+unique_name_in_owner = true
+margin_left = 948.0
+margin_right = 1024.0
+margin_bottom = 40.0
+
+[node name="DefaultOut" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 108.0
+margin_right = 1024.0
+margin_bottom = 148.0
+
+[node name="TLabel2" parent="VBoxContainer/DefaultOut" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 13.0
+margin_right = 673.0
+margin_bottom = 27.0
+size_flags_horizontal = 3
+text = "Default Leave animation"
+
+[node name="LeaveDefault" parent="VBoxContainer/DefaultOut" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 677.0
+margin_top = 8.0
+margin_right = 829.0
+margin_bottom = 32.0
+
+[node name="LeaveDefaultLength" type="SpinBox" parent="VBoxContainer/DefaultOut"]
+unique_name_in_owner = true
+margin_left = 833.0
+margin_right = 907.0
+margin_bottom = 40.0
+step = 0.1
+
+[node name="TLabel4" parent="VBoxContainer/DefaultOut" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 911.0
+margin_top = 13.0
+margin_right = 944.0
+margin_bottom = 27.0
+text = "Wait:"
+
+[node name="LeaveDefaultWait" type="CheckButton" parent="VBoxContainer/DefaultOut"]
+unique_name_in_owner = true
+margin_left = 948.0
+margin_right = 1024.0
+margin_bottom = 40.0
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/CustomAnimationsFolderOpener" to="." method="_on_CustomAnimationsFolderOpener_pressed"]
+[connection signal="value_changed" from="VBoxContainer/DefaultIn/JoinDefault" to="." method="_on_JoinDefault_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/DefaultIn/JoinDefaultLength" to="." method="_on_JoinDefaultLength_value_changed"]
+[connection signal="toggled" from="VBoxContainer/DefaultIn/JoinDefaultWait" to="." method="_on_JoinDefaultWait_toggled"]
+[connection signal="value_changed" from="VBoxContainer/DefaultOut/LeaveDefault" to="." method="_on_LeaveDefault_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/DefaultOut/LeaveDefaultLength" to="." method="_on_LeaveDefaultLength_value_changed"]
+[connection signal="toggled" from="VBoxContainer/DefaultOut/LeaveDefaultWait" to="." method="_on_LeaveDefaultWait_toggled"]

--- a/addons/dialogic/Events/Character/DefaultAnimations/bounce_in.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/bounce_in.gd
@@ -1,0 +1,16 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	node.scale = Vector2()
+	node.modulate.a = 0
+	
+	tween.set_ease(Tween.EASE_IN_OUT)
+	tween.set_trans(Tween.TRANS_LINEAR)
+	tween.set_parallel()
+	
+	tween.tween_property(node, 'scale', Vector2(1,1), time).set_trans(Tween.TRANS_ELASTIC).set_ease(Tween.EASE_OUT)
+	tween.tween_property(node, 'modulate:a', 1.0, time)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DefaultAnimations/bounce_out.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/bounce_out.gd
@@ -1,0 +1,16 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	node.scale = Vector2(1,1)
+	node.modulate.a = 1
+	
+	tween.set_ease(Tween.EASE_IN_OUT)
+	tween.set_trans(Tween.TRANS_LINEAR)
+	tween.set_parallel()
+	
+	tween.tween_property(node, 'scale', Vector2(), time).set_trans(Tween.TRANS_ELASTIC).set_ease(Tween.EASE_IN)
+	tween.tween_property(node, 'modulate:a', 0.0, time)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DefaultAnimations/fade_in_up.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/fade_in_up.gd
@@ -1,0 +1,15 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	node.position.y = orig_pos.y + node.get_viewport().size.y/5
+	node.modulate.a = 0
+	tween.set_ease(Tween.EASE_IN_OUT)
+	tween.set_trans(Tween.TRANS_SINE)
+	tween.set_parallel()
+	
+	tween.tween_property(node, 'position', orig_pos, time)
+	tween.tween_property(node, 'modulate:a', 1.0, time)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DefaultAnimations/fade_out_down.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/fade_out_down.gd
@@ -1,0 +1,13 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	tween.set_ease(Tween.EASE_IN_OUT)
+	tween.set_trans(Tween.TRANS_SINE)
+	tween.set_parallel()
+	
+	tween.tween_property(node, 'position:y', orig_pos.y + node.get_viewport().size.y/5, time)
+	tween.tween_property(node, 'modulate:a', 0.0, time)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DefaultAnimations/heartbeat.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/heartbeat.gd
@@ -1,0 +1,12 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	#tween.set_parallel(true)
+	#node.scale = Vector2(1,1)*1.2
+	tween.tween_property(node, 'scale', Vector2(1,1)*1.2, time*0.5).set_trans(Tween.TRANS_ELASTIC).set_ease(Tween.EASE_OUT)
+	#tween.tween_property(node, 'scale', Vector2(1,1)*1.1, time*0.5).set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	tween.tween_property(node, 'scale', Vector2(1,1), time*0.5).set_trans(Tween.TRANS_BOUNCE).set_ease(Tween.EASE_OUT)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DefaultAnimations/instant_in_or_out.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/instant_in_or_out.gd
@@ -1,0 +1,5 @@
+extends DialogicAnimation
+
+func animate():
+	yield(node.get_tree(), "idle_frame")
+	emit_signal('finished')

--- a/addons/dialogic/Events/Character/DefaultAnimations/tada.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/tada.gd
@@ -1,0 +1,19 @@
+extends DialogicAnimation
+
+func animate():
+	var tween = (node.get_tree().create_tween() as SceneTreeTween)
+	tween.bind_node(self)
+	tween.set_parallel(true)
+	tween.set_trans(Tween.TRANS_SINE)
+	tween.set_ease(Tween.EASE_OUT)
+	
+	tween.tween_property(node, 'scale', Vector2(1,1)*1.1, time*0.3)
+	tween.tween_property(node, 'rotation_degrees', -5.0, time*0.1).set_delay(time*0.2)
+	tween.tween_property(node, 'rotation_degrees', 5.0, time*0.1).set_delay(time*0.3)
+	tween.tween_property(node, 'rotation_degrees', -5.0, time*0.1).set_delay(time*0.4)
+	tween.tween_property(node, 'rotation_degrees', 5.0, time*0.1).set_delay(time*0.5)
+	tween.tween_property(node, 'rotation_degrees', -5.0, time*0.1).set_delay(time*0.6)
+	tween.chain().tween_property(node, 'scale', Vector2(1,1), time*0.3)
+	tween.parallel().tween_property(node, 'rotation_degrees', 0.0, time*0.3)
+	
+	tween.connect("finished", self, 'emit_signal', ['finished_once'])

--- a/addons/dialogic/Events/Character/DialogicAnimationClass.gd
+++ b/addons/dialogic/Events/Character/DialogicAnimationClass.gd
@@ -1,0 +1,27 @@
+extends Node
+class_name DialogicAnimation
+
+var node
+var time
+var end_position
+
+var repeats
+var orig_pos
+
+signal finished_once
+signal finished
+
+func _ready():
+	connect('finished_once', self, 'finished_one_loop')
+
+# to be overridden
+func animate():
+	pass
+
+func finished_one_loop():
+	repeats -= 1
+	if repeats > 0:
+		animate()
+	elif repeats == 0:
+		emit_signal("finished")
+	

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -9,7 +9,10 @@ var ActionType = ActionTypes.Join
 var Character : DialogicCharacter
 var Portrait = ""
 var Position = 3
-var Animation = ""
+var AnimationName = ""
+var AnimationLength = 0.5
+var AnimationRepeats = 1
+var AnimationWait = false
 
 func _execute() -> void:
 	match ActionType:
@@ -18,27 +21,57 @@ func _execute() -> void:
 			if Character and Portrait:
 				var n = dialogic.Portraits.add_portrait(Character, Portrait, Position)
 				
+				if AnimationName.empty():
+					AnimationName = DialogicUtil.get_project_setting('dialogic/animations_join_default', 
+	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_in_up.gd'))
+					AnimationLength = DialogicUtil.get_project_setting('dialogic/animations_join_default_length', 0.5)
+					print('using default ', AnimationName, ' at length ', AnimationLength)
+					AnimationWait = DialogicUtil.get_project_setting('dialogic/animations_join_default_wait', true)
+				if AnimationName:
+					var anim = dialogic.Portraits.animate_portrait(Character, AnimationName, AnimationLength, AnimationRepeats)
+					
+					if AnimationWait:
+						yield(anim, 'finished')
 				
-		
 		ActionTypes.Leave:
 			if Character:
-				if Character.resource_path in dialogic.Portraits.is_character_joined(Character):
-					dialogic.Portraits.remove_portrait(Character)
-					
-		
-		ActionTypes.Update:
-			if Character and Portrait:
 				if dialogic.Portraits.is_character_joined(Character):
-					dialogic.Portraits.change_portrait(Character, Portrait)
+					if AnimationName.empty():
+						AnimationName = DialogicUtil.get_project_setting('dialogic/animations_leaven_default', 
+	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_out_down.gd'))
+						AnimationLength = DialogicUtil.get_project_setting('dialogic/animations_leave_default_length', 0.5) 
+						AnimationWait = DialogicUtil.get_project_setting('dialogic/animations_leave_default_wait', true)
+					if AnimationName:
+						var anim = dialogic.Portraits.animate_portrait(Character, AnimationName, AnimationLength, AnimationRepeats)
+						
+						anim.connect('finished', dialogic.Portraits, 'remove_portrait', [Character])
+						
+						if AnimationWait:
+							yield(anim, 'finished')
+					
+					else:
+						dialogic.Portraits.remove_portrait(Character)
+
+		ActionTypes.Update:
+			if Character:
+				if dialogic.Portraits.is_character_joined(Character):
+					if Portrait:
+						dialogic.Portraits.change_portrait(Character, Portrait)
 					if Position != -1:
 						dialogic.Portraits.move_portrait(Character, Position)
+					
+					if AnimationName:
+						var anim = dialogic.Portraits.animate_portrait(Character, AnimationName, AnimationLength, AnimationRepeats)
+						
+						if AnimationWait:
+							yield(anim, 'finished')
 					
 	finish()
 
 
 func get_required_subsystems() -> Array:
 	return [
-				['Portraits', get_script().resource_path.get_base_dir().plus_file('Subsystem_Portraits.gd')],
+				['Portraits', get_script().resource_path.get_base_dir().plus_file('Subsystem_Portraits.gd'),  get_script().resource_path.get_base_dir().plus_file('AnimationsSettings.tscn'), ],
 			]
 
 ################################################################################
@@ -69,10 +102,25 @@ func get_as_string_to_store() -> String:
 	
 	if Character:
 		result_string += Character.name
-		result_string+= " ("+Portrait+")"
+		if Portrait:
+			result_string+= " ("+Portrait+")"
 	
 	if Position:
 		result_string += " "+str(Position)
+	
+	if AnimationName:
+		result_string += ' [animation="'+DialogicUtil.pretty_name(AnimationName)+'"'
+	
+		if AnimationLength != 0.5:
+			result_string += ' length="'+str(AnimationLength)+'"'
+		
+		if AnimationWait:
+			result_string += ' wait="'+str(AnimationWait)+'"'
+			
+		if AnimationRepeats != 1:
+			result_string += ' repeat="'+str(AnimationRepeats)+'"'
+			
+		result_string += "]"
 	
 	return result_string
 
@@ -80,7 +128,7 @@ func get_as_string_to_store() -> String:
 ## THIS HAS TO READ ALL THE DATA FROM THE SAVED STRING (see above) 
 func load_from_string_to_store(string:String):
 	var regex = RegEx.new()
-	regex.compile("(?<type>Join|Update|Leave) (?<character>[^()\\d\\n]*)( *\\((?<portrait>\\S*)\\))? ?((?<position>\\d*))?")
+	regex.compile("(?<type>Join|Update|Leave) (?<character>[^()\\d\\n]*)( *\\((?<portrait>\\S*)\\))? ?((?<position>\\d*))?\\s*(\\[(?<shortcode>.*)\\])?")
 	
 	var result = regex.search(string)
 	
@@ -102,6 +150,18 @@ func load_from_string_to_store(string:String):
 
 	if result.get_string('position'):
 		Position = int(result.get_string('position'))
+	
+	if result.get_string('shortcode'):
+		var shortcode_params = parse_shortcode_parameters(result.get_string('shortcode'))
+		AnimationName = shortcode_params.get('animation', '')
+		if !AnimationName.ends_with('.gd'):
+			AnimationName = guess_animation_file(AnimationName)
+		if !AnimationName.ends_with('.gd'):
+			printerr("[Dialogic] Couldn't identify animation '"+AnimationName+"'.")
+			AnimationName = ""
+		AnimationLength = float(shortcode_params.get('length', 0.5))
+		AnimationWait = DialogicUtil.str_to_bool(shortcode_params.get('wait', 'False'))
+		AnimationRepeats = int(shortcode_params.get('repeat', 1))
 
 # RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
 func is_valid_event_string(string:String):
@@ -116,8 +176,59 @@ func is_valid_event_string(string:String):
 ################################################################################
 
 func build_event_editor():
-	add_header_edit('ActionType', ValueType.FixedOptionSelector, 'Action:', '',
+	add_header_edit('ActionType', ValueType.FixedOptionSelector, '', '',
 		 {'selector_options':{"Join":ActionTypes.Join, "Leave":ActionTypes.Leave, "Update":ActionTypes.Update}})
-	add_header_edit('Character', ValueType.Character, 'Character:')
-	add_header_edit('Portrait', ValueType.Portrait, 'Portrait:', '', {}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
+	add_header_edit('Character', ValueType.Resource, '', '', {'file_extension':'.dch'})
+	
+	add_header_edit('Portrait', ValueType.Resource, 'Portrait:', '', {'suggestions_func':[self, 'get_portrait_suggestions']}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
 	add_header_edit('Position', ValueType.Integer, 'Position:', '', {}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
+	
+	add_body_edit('AnimationName', ValueType.Resource, 'Animation:', '', {'suggestions_func':[self, 'get_animation_suggestions'], 'empty_text':'Default'}, 'Character != null')
+	add_body_edit('AnimationLength', ValueType.Float, 'Length:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName')
+	add_body_edit('AnimationWait', ValueType.Bool, 'Wait:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName')
+	add_body_edit('AnimationRepeats', ValueType.Integer, 'Repeat:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName and ActionType == %s' %ActionTypes.Update)
+
+func get_portrait_suggestions(search_text):
+	var suggestions = {}
+	if Character != null:
+		for portrait in Character.portraits:
+			if search_text.to_lower() in portrait.to_lower():
+				suggestions[portrait] = portrait
+	return suggestions
+
+func get_animation_suggestions(search_text):
+	var suggestions = {}
+	
+	match ActionType:
+		ActionTypes.Join, ActionTypes.Leave:
+			suggestions['Default'] = ""
+		ActionTypes.Update:
+			suggestions['None'] = ""
+
+	for anim in list_animations():
+		if search_text.to_lower() in anim.get_file().to_lower():
+			match ActionType:
+				ActionTypes.Join:
+					if '_in' in anim.get_file():
+						suggestions[DialogicUtil.pretty_name(anim)] = anim
+				ActionTypes.Leave:
+					if '_out' in anim.get_file():
+						suggestions[DialogicUtil.pretty_name(anim)] = anim
+				ActionTypes.Update:
+					if not ('_in' in anim.get_file() or '_out' in anim.get_file()):
+						suggestions[DialogicUtil.pretty_name(anim)] = anim
+						continue
+	return suggestions
+
+
+func list_animations() -> Array:
+	var list = DialogicUtil.listdir(get_script().resource_path.get_base_dir().plus_file('DefaultAnimations'), true, false, true)
+	list.append_array(DialogicUtil.listdir(DialogicUtil.get_project_setting('dialogic/animations_custom_folder', 'res://addons/dialogic_additions/Animations'), true, false, true))
+	return list
+
+
+func guess_animation_file(animation_name):
+	for file in list_animations():
+		if DialogicUtil.pretty_name(animation_name) == DialogicUtil.pretty_name(file):
+			return file
+	return animation_name

--- a/addons/dialogic/Events/Jump/event.gd
+++ b/addons/dialogic/Events/Jump/event.gd
@@ -47,6 +47,6 @@ func get_shortcode_parameters() -> Dictionary:
 ################################################################################
 
 func build_event_editor():
-	add_header_edit('Timeline', ValueType.Timeline, 'Timeline:')
+	add_header_edit('Timeline', ValueType.Resource, 'Timeline:', '', {'file_extension':'.dtl'})
 	add_header_edit('Label', ValueType.SinglelineText, 'Label:')
 

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -99,6 +99,15 @@ func get_original_translation_text():
 	return Text
 
 func build_event_editor():
-	add_header_edit('Character', ValueType.Character, 'Character:')
-	add_header_edit('Portrait', ValueType.Portrait, '', '', {}, 'Character != null')
+	add_header_edit('Character', ValueType.Resource, 'Character:', '', {'file_extension':'.dch'})
+	add_header_edit('Portrait', ValueType.Resource, '', '', {'suggestions_func':[self, 'get_portrait_suggestions'], 'empty_text':"Don't change"}, 'Character != null')
 	add_body_edit('Text', ValueType.MultilineText)
+
+func get_portrait_suggestions(search_text):
+	var suggestions = {}
+	suggestions["Don't change"] = ''
+	if Character != null:
+		for portrait in Character.portraits:
+			if search_text.to_lower() in portrait.to_lower():
+				suggestions[portrait] = portrait
+	return suggestions

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -14,7 +14,7 @@ static func get_editor_scale(ref) -> float:
 	return _scale
 
 
-static func listdir(path: String, files_only: bool = true, throw_error:bool = true) -> Array:
+static func listdir(path: String, files_only: bool = true, throw_error:bool = true, full_file_path:bool = false) -> Array:
 	# https://docs.godotengine.org/en/stable/classes/class_directory.html#description
 	var files: Array = []
 	var dir := Directory.new()
@@ -26,9 +26,15 @@ static func listdir(path: String, files_only: bool = true, throw_error:bool = tr
 			if not file_name.begins_with("."):
 				if files_only:
 					if not dir.current_is_dir():
-						files.append(file_name)
+						if full_file_path:
+							files.append(path.plus_file(file_name))
+						else:
+							files.append(file_name)
 				else:
-					files.append(file_name)
+					if full_file_path:
+						files.append(path.plus_file(file_name))
+					else:
+						files.append(file_name)
 			file_name = dir.get_next()
 		dir.list_dir_end()
 	else:
@@ -100,6 +106,17 @@ static func get_event_scripts(include_custom_events:bool = true) -> Array:
 			event_scripts.append("res://addons/dialogic_additions/Events/" + file + "/event.gd")
 		
 	return event_scripts
+
+
+static func pretty_name(script:String) -> String:
+	var _name = script.get_file().trim_suffix("."+script.get_extension())
+	_name = _name.replace('_', ' ')
+	_name = _name.capitalize()
+	return _name
+
+
+static func str_to_bool(boolstring:String) -> bool:
+	return true if boolstring == "True" else false
 
 # RENABLE IF REALLY NEEDED, OTHERWISE DELETE BEFORE RELEASE 
 #static func list_to_dict(list):

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -42,9 +42,9 @@ enum ValueType {
 	Bool,
 	
 	# OBJECTS ? (for the ResourcePicker)
-	Timeline,
-	Character,
-	Portrait,
+	Resource,
+	Script,
+	File,
 	
 	# INTEGERS
 	FixedOptionSelector,

--- a/timelines/testy.dtl
+++ b/timelines/testy.dtl
@@ -1,29 +1,14 @@
-[music path="res://test-project/ChillLofiR.mp3" volume="-14" fade="3" bus="Master" loop="True"]
+Join Emilio (doubt) 3
 
-Join Emilio (blink) 3
+Emilio: Tets stes tste st
 
-begin
+Emilio: Tets stes tste st
 
-[sound path="res://test-project/Goblin_03.mp3" volume="-5" bus="Master"]
+Update Emilio 3 [animation="Tada" wait="True" repeat="3"]
 
-Emilio (shy): \[Hello stranger!, Hi Travaler., What's up\, guys!] \[pause=1] \[In Brackets] 
+Emilio: Tets stes tste st
 
-- Yes
-	
-- No
-	
-	
-Update Emilio (blink) 5
+Update Emilio 3 [animation="Heartbeat" wait="True" repeat="2"]
 
-[background path="icon.png"]
-
-Emilio (hate): Some normal text.
-
-Join Jowan (avoid) 1
-
-[background]
-
-Jowan (concept): We are back in the first timeline
-
-Jowan (happy): We are back in the first timeline
+Leave Emilio 3
 


### PR DESCRIPTION
# Animations for portraits
Animations are a script file that extends the new DialogicAnimation class.
There are currently X animations:
- fade_in_up
- fade_out_down
- bounce_in
- bounce_out
- instant_in_out
- tada
- heartbeat

These scripts have to have an `animate()` function. The class has a couple of variables that you can use, most importantly the `.node` which is a reference to the node that should be animated.

The animations should emit `finished_once` once finished. The animations above use the SceneTreeTweener for animating (except for the instant animation).

# Animations on character event
The `Character event` has a couple of more settings, that show under different circumstances:
- AnimationName (the path to the animation)
- AnimationLength
- AnimationRepeats
- AnimationWait

In the text version they are stored as an additional shortcode. 
E.g.: `Join Emilio (sad) 3 [animation="Bounce In" length="2.0" wait="True"]`

# Animation settings
There is a settings page for animations where you can specify a custom animations folder as well as default settings for join and leave mode.
They default to:
- Custom Animations: 'res://addons/dialogic_additions/Animations'
- Join Animation: ['Fade In Up', length = 0.5, wait = true]
- Leave Animation: ['Fade Out Down', length = 0.5, wait = true]

# Additional changes
## Resource picker
I've decided to make the resource picker more adaptable (to use it for the animations).
You can now specify a method for listing suggestions. If you give a file_extension it will default to listing all of those files.