### PR TITLE
2.0 Settings

### DIFF
--- a/addons/dialogic/Events/Choice/ChoicesSettings.gd
+++ b/addons/dialogic/Events/Choice/ChoicesSettings.gd
@@ -1,0 +1,24 @@
+tool
+extends HBoxContainer
+
+func refresh():
+	$'%Autofocus'.pressed = DialogicUtil.get_project_setting('dialogic/choices_autofocus_first', true)
+	$'%Delay'.value = DialogicUtil.get_project_setting('dialogic/choices_delay', 0.2)
+	$'%FalseBehaviour'.select(DialogicUtil.get_project_setting('dialogic/choices_def_false_bahviour', 0))
+	$'%HotkeyType'.select(DialogicUtil.get_project_setting('dialogic/choices_hotkey_behaviour', 0))
+
+
+func _on_Autofocus_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/choices_autofocus_first', button_pressed)
+
+
+func _on_FalseBehaviour_item_selected(index):
+	ProjectSettings.set_setting('dialogic/choices_def_false_bahviour', index)
+
+
+func _on_HotkeyType_item_selected(index):
+	ProjectSettings.set_setting('dialogic/choices_hotkey_behaviour', index)
+
+
+func _on_Delay_value_changed(value):
+	ProjectSettings.set_setting('dialogic/choices_delay', value)

--- a/addons/dialogic/Events/Choice/ChoicesSettings.tscn
+++ b/addons/dialogic/Events/Choice/ChoicesSettings.tscn
@@ -1,0 +1,145 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Events/Choice/ChoicesSettings.gd" type="Script" id=2]
+
+[node name="Choices" type="HBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_constants/separation = 20
+script = ExtResource( 2 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+margin_right = 490.0
+margin_bottom = 600.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TLabel" parent="VBoxContainer" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 490.0
+margin_bottom = 14.0
+text = "Choices"
+title = true
+
+[node name="Autofocus" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 18.0
+margin_right = 490.0
+margin_bottom = 42.0
+
+[node name="TLabel" parent="VBoxContainer/Autofocus" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 462.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Autofocus first choice"
+
+[node name="Autofocus" type="CheckBox" parent="VBoxContainer/Autofocus"]
+unique_name_in_owner = true
+margin_left = 466.0
+margin_right = 490.0
+margin_bottom = 24.0
+
+[node name="Delay" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 46.0
+margin_right = 490.0
+margin_bottom = 70.0
+
+[node name="TLabel" parent="VBoxContainer/Delay" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 412.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Delay before choices can be pressed"
+
+[node name="Delay" type="SpinBox" parent="VBoxContainer/Delay"]
+unique_name_in_owner = true
+margin_left = 416.0
+margin_right = 490.0
+margin_bottom = 24.0
+step = 0.01
+
+[node name="DefaultFalseBehaviour" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 74.0
+margin_right = 490.0
+margin_bottom = 94.0
+
+[node name="TLabel" parent="VBoxContainer/DefaultFalseBehaviour" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 3.0
+margin_right = 427.0
+margin_bottom = 17.0
+size_flags_horizontal = 3
+text = "Default behaviour for false choices"
+
+[node name="FalseBehaviour" type="OptionButton" parent="VBoxContainer/DefaultFalseBehaviour"]
+unique_name_in_owner = true
+margin_left = 431.0
+margin_right = 490.0
+margin_bottom = 20.0
+text = "Hide"
+items = [ "Hide", null, false, 0, null, "Disable", null, false, 1, null ]
+selected = 0
+
+[node name="VSeparator" type="VSeparator" parent="."]
+margin_left = 510.0
+margin_right = 514.0
+margin_bottom = 600.0
+
+[node name="VBoxContainer2" type="VBoxContainer" parent="."]
+margin_left = 534.0
+margin_right = 1024.0
+margin_bottom = 600.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="TLabel" parent="VBoxContainer2" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 490.0
+margin_bottom = 14.0
+text = "Choice hotkeys"
+title = true
+
+[node name="HotkeySelection" type="HBoxContainer" parent="VBoxContainer2"]
+margin_top = 18.0
+margin_right = 490.0
+margin_bottom = 38.0
+
+[node name="TLabel" parent="VBoxContainer2/HotkeySelection" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 3.0
+margin_right = 383.0
+margin_bottom = 17.0
+size_flags_horizontal = 3
+text = "Hotkey type"
+
+[node name="HotkeyType" type="OptionButton" parent="VBoxContainer2/HotkeySelection"]
+unique_name_in_owner = true
+margin_left = 387.0
+margin_right = 490.0
+margin_bottom = 20.0
+text = "No Hotkeys"
+items = [ "No Hotkeys", null, false, 0, null, "Default (1-9)", null, false, 1, null ]
+selected = 0
+
+[node name="TLabel2" parent="VBoxContainer2" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 42.0
+margin_right = 490.0
+margin_bottom = 73.0
+text = "You can add more complex hotkeys by editing the \"shortcut\" property of a ChoiceButton. "
+autowrap = true
+
+[connection signal="toggled" from="VBoxContainer/Autofocus/Autofocus" to="." method="_on_Autofocus_toggled"]
+[connection signal="value_changed" from="VBoxContainer/Delay/Delay" to="." method="_on_Delay_value_changed"]
+[connection signal="item_selected" from="VBoxContainer/DefaultFalseBehaviour/FalseBehaviour" to="." method="_on_FalseBehaviour_item_selected"]
+[connection signal="item_selected" from="VBoxContainer2/HotkeySelection/HotkeyType" to="." method="_on_HotkeyType_item_selected"]

--- a/addons/dialogic/Events/Choice/Display_ChoiceButton.gd
+++ b/addons/dialogic/Events/Choice/Display_ChoiceButton.gd
@@ -6,4 +6,5 @@ export (int) var choice_index = -1
 
 func _ready():
 	add_to_group('dialogic_choice_button')
+	shortcut_in_tooltip = false
 	hide()

--- a/addons/dialogic/Events/Choice/event.gd
+++ b/addons/dialogic/Events/Choice/event.gd
@@ -2,7 +2,7 @@ tool
 extends DialogicEvent
 class_name DialogicChoiceEvent
 
-enum IfFalseActions {DEFAULT, HIDE, DISABLE}
+enum IfFalseActions {HIDE, DISABLE, DEFAULT}
 
 # DEFINE ALL PROPERTIES OF THE EVENT
 var Text :String = ""
@@ -15,7 +15,8 @@ func _execute() -> void:
 
 func get_required_subsystems() -> Array:
 	return [
-				['Choices', get_script().resource_path.get_base_dir().plus_file('Subsystem_Choices.gd')],
+				['Choices', get_script().resource_path.get_base_dir().plus_file('Subsystem_Choices.gd'),
+				get_script().resource_path.get_base_dir().plus_file('ChoicesSettings.tscn')],
 			]
 
 

--- a/addons/dialogic/Events/Text/Display_DialogText.gd
+++ b/addons/dialogic/Events/Text/Display_DialogText.gd
@@ -25,13 +25,14 @@ func _ready() -> void:
 	timer.connect("timeout", self, 'continue_reveal')
 	
 	# compile effects regex
-	effect_regex.compile("(?<!\\\\)\\[(?<command>[^\\[=,]*)(=(?<value>[^\\[]*))?\\]")
+	effect_regex.compile("(?<!\\\\)\\[\\s*(?<command>portrait|speed|signal|pause)\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
 	
 	# compule modifier regexs
 	modifier_words_select_regex.compile("(?<!\\\\)\\[[^\\[]+(,[^\\]]*)\\]")
-	
+
 # this is called by the DialogicGameHandler to set text
 func reveal_text(_text:String) -> void:
+	speed = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
 	bbcode_text = parse_effects(parse_modifiers(_text))
 	if Align == 'Center':
 		bbcode_text = '[center]'+bbcode_text
@@ -78,7 +79,6 @@ func execute_effects(skip :bool= false) -> void:
 	# might have to execute multiple effects
 	while effects and (visible_characters >= effects.front()[0] or visible_characters== -1):
 		var effect = effects.pop_front()
-		print(effect)
 		match effect[1]:
 			'pause':
 				if skip:
@@ -92,6 +92,8 @@ func execute_effects(skip :bool= false) -> void:
 					continue
 				if effect[2].is_valid_float():
 					speed = float(effect[2])
+				else:
+					speed = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
 			'signal':
 				Dialogic.emit_signal("text_signal", effect[2])
 			'portrait':

--- a/addons/dialogic/Events/Text/Display_InputHandler.gd
+++ b/addons/dialogic/Events/Text/Display_InputHandler.gd
@@ -1,0 +1,17 @@
+tool
+extends Node
+
+class_name DialogicInputHandler
+
+################################################################################
+## 						INPUT (WIP)
+################################################################################
+# This shouldn't be handled by this script I think, but for testing purposes this works.
+func _input(event:InputEvent) -> void:
+	if Input.is_action_just_pressed(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action')):
+		if Dialogic.current_state == Dialogic.states.IDLE:
+			Dialogic.handle_next_event()
+		
+		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT:
+			if DialogicUtil.get_project_setting('dialogic/text/skippable', true):
+				Dialogic.Text.skip_text_animation()

--- a/addons/dialogic/Events/Text/Settings_DialogText.gd
+++ b/addons/dialogic/Events/Text/Settings_DialogText.gd
@@ -1,0 +1,42 @@
+tool
+extends HBoxContainer
+
+func refresh():
+	$'%DefaultSpeed'.value = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
+	$'%Skippable'.pressed = DialogicUtil.get_project_setting('dialogic/text/skippable', true)
+	$'%Autocontinue'.pressed = DialogicUtil.get_project_setting('dialogic/text/autocontinue', false)
+	$'%Autocontinue'.pressed = DialogicUtil.get_project_setting('dialogic/text/autocolor_names', false)
+	$'%AutocontinueDelay'.value = DialogicUtil.get_project_setting('dialogic/text/autocontinue_delay', 1)
+	$'%InputAction'.set_value(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action'))
+	$'%InputAction'.get_suggestions_func = [self, 'suggest_actions']
+
+
+func _on_AutocontinueDelay_value_changed(value):
+	ProjectSettings.set_setting('dialogic/text/autocontinue_delay', value)
+
+
+func _on_Autocontinue_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/text/autocontinue', button_pressed)
+
+
+func _on_Skippable_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/text/skippable', button_pressed)
+
+
+func _on_DefaultSpeed_value_changed(value):
+	ProjectSettings.set_setting('dialogic/text/speed', value)
+
+
+func _on_InputAction_value_changed(property_name, value):
+	ProjectSettings.set_setting('dialogic/text/input_action', value)
+
+func suggest_actions(search):
+	var suggs = {}
+	for prop in ProjectSettings.get_property_list():
+		if prop.name.begins_with('input/') and search.to_lower() in prop.name.trim_prefix('input/'):
+			suggs[prop.name.trim_prefix('input/')] = prop.name.trim_prefix('input/')
+	return suggs
+
+
+func _on_AutocolorNames_toggled(button_pressed):
+	ProjectSettings.set_setting('dialogic/text/autocolor_names', button_pressed)

--- a/addons/dialogic/Events/Text/Settings_DialogText.tscn
+++ b/addons/dialogic/Events/Text/Settings_DialogText.tscn
@@ -1,0 +1,151 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/dialogic/Editor/Common/TLabel.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/dialogic/Events/Text/Settings_DialogText.gd" type="Script" id=2]
+[ext_resource path="res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn" type="PackedScene" id=3]
+
+[node name="DialogText" type="HBoxContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+script = ExtResource( 2 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+margin_right = 1024.0
+margin_bottom = 600.0
+size_flags_horizontal = 3
+
+[node name="TLabel" parent="VBoxContainer" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_right = 1024.0
+margin_bottom = 14.0
+text = "Dialog Text"
+title = true
+
+[node name="DefaultSpeed" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 18.0
+margin_right = 1024.0
+margin_bottom = 42.0
+
+[node name="TLabel" parent="VBoxContainer/DefaultSpeed" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 946.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Default speed"
+
+[node name="DefaultSpeed" type="SpinBox" parent="VBoxContainer/DefaultSpeed"]
+unique_name_in_owner = true
+margin_left = 950.0
+margin_right = 1024.0
+margin_bottom = 24.0
+step = 0.001
+
+[node name="InputAction" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 46.0
+margin_right = 1024.0
+margin_bottom = 70.0
+
+[node name="TLabel" parent="VBoxContainer/InputAction" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 868.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Input action"
+
+[node name="InputAction" parent="VBoxContainer/InputAction" instance=ExtResource( 3 )]
+unique_name_in_owner = true
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 872.0
+margin_right = 1024.0
+margin_bottom = 24.0
+
+[node name="Skippable" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 74.0
+margin_right = 1024.0
+margin_bottom = 98.0
+
+[node name="TLabel" parent="VBoxContainer/Skippable" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 996.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Skippable"
+
+[node name="Skippable" type="CheckBox" parent="VBoxContainer/Skippable"]
+unique_name_in_owner = true
+margin_left = 1000.0
+margin_right = 1024.0
+margin_bottom = 24.0
+
+[node name="ColorNames" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 102.0
+margin_right = 1024.0
+margin_bottom = 126.0
+
+[node name="TLabel" parent="VBoxContainer/ColorNames" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 996.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Autocolor names"
+
+[node name="AutocolorNames" type="CheckBox" parent="VBoxContainer/ColorNames"]
+unique_name_in_owner = true
+margin_left = 1000.0
+margin_right = 1024.0
+margin_bottom = 24.0
+
+[node name="AutoContinue" type="HBoxContainer" parent="VBoxContainer"]
+margin_top = 130.0
+margin_right = 1024.0
+margin_bottom = 154.0
+
+[node name="TLabel" parent="VBoxContainer/AutoContinue" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_top = 5.0
+margin_right = 885.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+text = "Autocontinue"
+
+[node name="Autocontinue" type="CheckBox" parent="VBoxContainer/AutoContinue"]
+unique_name_in_owner = true
+margin_left = 889.0
+margin_right = 913.0
+margin_bottom = 24.0
+
+[node name="TLabel2" parent="VBoxContainer/AutoContinue" instance=ExtResource( 1 )]
+anchor_right = 0.0
+anchor_bottom = 0.0
+margin_left = 917.0
+margin_top = 5.0
+margin_right = 946.0
+margin_bottom = 19.0
+text = "after"
+align = 1
+
+[node name="AutocontinueDelay" type="SpinBox" parent="VBoxContainer/AutoContinue"]
+unique_name_in_owner = true
+margin_left = 950.0
+margin_right = 1024.0
+margin_bottom = 24.0
+step = 0.01
+suffix = "s"
+
+[connection signal="value_changed" from="VBoxContainer/DefaultSpeed/DefaultSpeed" to="." method="_on_DefaultSpeed_value_changed"]
+[connection signal="value_changed" from="VBoxContainer/InputAction/InputAction" to="." method="_on_InputAction_value_changed"]
+[connection signal="toggled" from="VBoxContainer/Skippable/Skippable" to="." method="_on_Skippable_toggled"]
+[connection signal="toggled" from="VBoxContainer/ColorNames/AutocolorNames" to="." method="_on_AutocolorNames_toggled"]
+[connection signal="toggled" from="VBoxContainer/AutoContinue/Autocontinue" to="." method="_on_Autocontinue_toggled"]
+[connection signal="value_changed" from="VBoxContainer/AutoContinue/AutocontinueDelay" to="." method="_on_AutocontinueDelay_value_changed"]

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -26,9 +26,9 @@ func _execute() -> void:
 		
 	
 	if dialogic.has_subsystem('VAR'):
-		dialogic.Text.update_dialog_text(dialogic.VAR.parse_variables(get_translated_text()))
+		dialogic.Text.update_dialog_text(dialogic.Text.color_names(dialogic.VAR.parse_variables(get_translated_text())))
 	else:
-		dialogic.Text.update_dialog_text(get_translated_text())
+		dialogic.Text.update_dialog_text(dialogic.Text.color_names(get_translated_text()))
 	
 	# Wait for text to finish revealing
 	while true:
@@ -39,12 +39,17 @@ func _execute() -> void:
 	if dialogic.has_subsystem('Choices') and dialogic.Choices.is_question(dialogic.current_event_idx):
 		dialogic.Choices.show_current_choices()
 		dialogic.current_state = dialogic.states.AWAITING_CHOICE
-	
-	finish()
+	elif DialogicUtil.get_project_setting('dialogic/text/autocontinue', false):
+		yield(dialogic.get_tree().create_timer(DialogicUtil.get_project_setting('dialogic/text/autocontinue_delay', 1)), 'timeout')
+		dialogic.handle_next_event()
+	else:
+		finish()
 
 func get_required_subsystems() -> Array:
 	return [
-		['Text', get_script().resource_path.get_base_dir().plus_file('Subsystem_Text.gd')]
+		['Text', get_script().resource_path.get_base_dir().plus_file('Subsystem_Text.gd'),
+		get_script().resource_path.get_base_dir().plus_file('Settings_DialogText.tscn')
+		]
 	]
 ################################################################################
 ## 						INITIALIZE

--- a/addons/dialogic/Other/DefaultDialogNode.tscn
+++ b/addons/dialogic/Other/DefaultDialogNode.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=11 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://addons/dialogic/Other/DefaultDialogNode.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Events/Text/Display_DialogText.gd" type="Script" id=2]
@@ -9,10 +9,14 @@
 [ext_resource path="res://addons/dialogic/Events/Background/Display_Background.gd" type="Script" id=7]
 [ext_resource path="res://addons/dialogic/Events/Music/Display_MusicPlayer.gd" type="Script" id=8]
 [ext_resource path="res://addons/dialogic/Events/Sound/Display_SoundPlayer.gd" type="Script" id=9]
+[ext_resource path="res://addons/dialogic/Events/Text/Display_InputHandler.gd" type="Script" id=10]
 [ext_resource path="res://addons/dialogic/Events/Theme/Display_Theme.gd" type="Script" id=12]
 
 [node name="DefaultDialogNode" type="CanvasLayer"]
 script = ExtResource( 1 )
+
+[node name="DialogicInputHandler" type="Node" parent="."]
+script = ExtResource( 10 )
 
 [node name="DialogicDisplay_SoundPlayer" type="AudioStreamPlayer" parent="."]
 script = ExtResource( 9 )

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -21,17 +21,6 @@ func _ready() -> void:
 	collect_subsystems()
 	clear()
 
-################################################################################
-## 						INPUT (WIP)
-################################################################################
-# This shouldn't be handled by this script I think, but for testing purposes this works.
-func _input(event:InputEvent) -> void:
-	if event is InputEventMouseButton and event.pressed:
-		if current_state == states.IDLE:
-			handle_next_event()
-		elif current_state == states.SHOWING_TEXT:
-			self.Text.skip_text_animation()
-
 
 ################################################################################
 ## 						TIMELINE+EVENT HANDLING

--- a/addons/dialogic/plugin.gd
+++ b/addons/dialogic/plugin.gd
@@ -84,6 +84,24 @@ func edit(object):
 
 func enable_plugin():
 	add_autoload_singleton("Dialogic", "res://addons/dialogic/Other/DialogicGameHandler.gd")
+	add_dialogic_default_action()
 
 func disable_plugin():
 	remove_autoload_singleton("Dialogic")
+
+func add_dialogic_default_action():
+	if !ProjectSettings.has_setting('input/dialogic_default_action'):
+		var input_enter = InputEventKey.new()
+		input_enter.scancode = KEY_ENTER
+		var input_left_click = InputEventMouseButton.new()
+		input_left_click.button_index = BUTTON_LEFT
+		input_left_click.pressed = true
+		var input_space = InputEventKey.new()
+		input_space.scancode = KEY_SPACE
+		var input_x = InputEventKey.new()
+		input_x.scancode = KEY_X
+		var input_controller = InputEventJoypadButton.new()
+		input_controller.button_index = JOY_BUTTON_0
+	
+		ProjectSettings.set_setting('input/dialogic_default_action', {'deadzone':0.5, 'events':[input_enter, input_left_click, input_space, input_x, input_controller]})
+		ProjectSettings.save()


### PR DESCRIPTION
- mainly related to #963

WIP
So far I've got

# Choice Settings
- autofocus first choice -> default true
- choice delay -> default 0.2
- auto hotkeys (1-9) -> off
- default false behaviour -> hide

# Text settings
- default speed -> default 0.01
- input action  -> defaults 'dialogic_default_action' that is now added once the plugin is enabled
- skippable -> default true
- autocolor names -> default false
- autocontinue -> default false
- autocontinue_delay -> default 1



# Input Handler
The DialogicInputHandler is a very simple node that has to be added to a dialog scene like the display nodes (unless you want to manage calling the next event yourself). 

It just uses the input action defined in the settings and also cares for the skippable setting.

# Other small changes/bugfixes
- You couldn't use bbcode anymore, so I had to change some regexes a bit.
- writing just [speed] without a parameter will now reset to the current default speed.
