### PR TITLE
add inline method calls

### DIFF
--- a/addons/dialogic/Events/Call Node/event.gd
+++ b/addons/dialogic/Events/Call Node/event.gd
@@ -10,7 +10,7 @@ var Wait: bool = false
 
 var Signal_Name: String
 var Inline: bool = false
-var One_Off: bool = true
+var One_Off: bool = false
 
 
 
@@ -45,7 +45,8 @@ func _call_on_signal(arg):
 	n.callv(Method, Arguments)
 
 func _disconnect_signal():
-	dialogic.disconnect("text_signal", self, "_call_on_signal")
+	if dialogic.is_connected('text_signal', self, '_call_on_signal'):
+		dialogic.disconnect("text_signal", self, "_call_on_signal")
 
 ################################################################################
 ## 						INITIALIZE

--- a/addons/dialogic/Events/Call Node/event.gd
+++ b/addons/dialogic/Events/Call Node/event.gd
@@ -90,6 +90,6 @@ func build_event_editor():
 	add_body_edit('Wait', ValueType.Bool, 'Wait:')
 	add_body_edit('Inline', ValueType.Bool, 'Inline:')
 	add_body_edit('Signal_Name', ValueType.SinglelineText, 'Signal Name', '', {}, 'Inline == true')
-	add_body_edit('Single_Use', ValueType.Bool, 'Signle Use', '', {}, 'Inline == true')
+	add_body_edit('Single_Use', ValueType.Bool, 'Single Use', '', {}, 'Inline == true')
 	add_body_line_break()
 	add_body_edit('Arguments', ValueType.StringArray, 'Arguments:')

--- a/addons/dialogic/Events/Call Node/event.gd
+++ b/addons/dialogic/Events/Call Node/event.gd
@@ -4,15 +4,20 @@ class_name DialogicCallNodeEvent
 
 # DEFINE ALL PROPERTIES OF THE EVENT
 var Path: String = ""
-var Method:String = ""
-var Arguments:Array=[]
+var Method: String = ""
+var Arguments: Array = []
+var Wait: bool = false
 
-var Wait:bool = false
+var Signal_Name: String
 var Inline: bool = false
-var Signal_Number: int = 1
+var One_Off: bool = true
+
 
 
 func _execute() -> void:
+	if Inline:
+		dialogic.connect('timeline_ended', self, '_disconnect_signal')
+	
 	if Path.begins_with('root'):
 		Path = "/"+Path
 	if not "/" in Path and dialogic.get_node('/root').has_node(Path):
@@ -30,14 +35,17 @@ func _execute() -> void:
 	
 	finish()
 
-func _call_on_signal(number):
+func _call_on_signal(arg):
 	
-	#	_call_on_signal()
-	if number != str(Signal_Number):
+	if arg != Signal_Name:
 		return
-	dialogic.disconnect("text_signal", self, "_call_on_signal")
+	if One_Off:
+		dialogic.disconnect("text_signal", self, "_call_on_signal")
 	var n = dialogic.get_node_or_null(Path)
 	n.callv(Method, Arguments)
+
+func _disconnect_signal():
+	dialogic.disconnect("text_signal", self, "_call_on_signal")
 
 ################################################################################
 ## 						INITIALIZE
@@ -65,7 +73,8 @@ func get_shortcode_parameters() -> Dictionary:
 		"method"	: "Method",
 		"args"		: "Arguments",
 		"wait"		: "Wait",
-		"inline"	: "Inline"
+		"inline"	: "Inline",
+		"signal_name": "Signal_Name",
 	}
 
 
@@ -78,6 +87,7 @@ func build_event_editor():
 	add_body_edit('Method', ValueType.SinglelineText, 'Method:')
 	add_body_edit('Wait', ValueType.Bool, 'Wait:')
 	add_body_edit('Inline', ValueType.Bool, 'Inline:')
-	add_body_edit('Signal_Number', ValueType.Integer, 'Signal Number', '', {}, 'Inline == true')
+	add_body_edit('Signal_Name', ValueType.SinglelineText, 'Signal Name', '', {}, 'Inline == true')
+	add_body_edit('One_Off', ValueType.Bool, 'One Off', '', {}, 'Inline == true')
 	add_body_line_break()
 	add_body_edit('Arguments', ValueType.StringArray, 'Arguments:')

--- a/addons/dialogic/Events/Call Node/event.gd
+++ b/addons/dialogic/Events/Call Node/event.gd
@@ -8,6 +8,9 @@ var Method:String = ""
 var Arguments:Array=[]
 
 var Wait:bool = false
+var Inline: bool = false
+var Signal_Number: int = 1
+
 
 func _execute() -> void:
 	if Path.begins_with('root'):
@@ -18,12 +21,23 @@ func _execute() -> void:
 	var n = dialogic.get_node_or_null(Path)
 	if n:
 		if n.has_method(Method):
-			if Wait:
+			if Inline:
+				dialogic.connect("text_signal", self, "_call_on_signal", [], CONNECT_PERSIST)
+			elif Wait:
 				yield(n.callv(Method, Arguments), "completed")
 			else:
 				n.callv(Method, Arguments)
 	
 	finish()
+
+func _call_on_signal(number):
+	
+	#	_call_on_signal()
+	if number != str(Signal_Number):
+		return
+	dialogic.disconnect("text_signal", self, "_call_on_signal")
+	var n = dialogic.get_node_or_null(Path)
+	n.callv(Method, Arguments)
 
 ################################################################################
 ## 						INITIALIZE
@@ -50,7 +64,8 @@ func get_shortcode_parameters() -> Dictionary:
 		"path"		: "Path",
 		"method"	: "Method",
 		"args"		: "Arguments",
-		"wait"		: "Wait"
+		"wait"		: "Wait",
+		"inline"	: "Inline"
 	}
 
 
@@ -62,5 +77,7 @@ func build_event_editor():
 	add_header_edit('Path', ValueType.SinglelineText, 'Path:')
 	add_body_edit('Method', ValueType.SinglelineText, 'Method:')
 	add_body_edit('Wait', ValueType.Bool, 'Wait:')
+	add_body_edit('Inline', ValueType.Bool, 'Inline:')
+	add_body_edit('Signal_Number', ValueType.Integer, 'Signal Number', '', {}, 'Inline == true')
 	add_body_line_break()
 	add_body_edit('Arguments', ValueType.StringArray, 'Arguments:')

--- a/addons/dialogic/Events/Call Node/event.gd
+++ b/addons/dialogic/Events/Call Node/event.gd
@@ -10,7 +10,7 @@ var Wait: bool = false
 
 var Signal_Name: String
 var Inline: bool = false
-var One_Off: bool = false
+var Single_Use: bool = false
 
 
 
@@ -39,7 +39,7 @@ func _call_on_signal(arg):
 	
 	if arg != Signal_Name:
 		return
-	if One_Off:
+	if Single_Use:
 		dialogic.disconnect("text_signal", self, "_call_on_signal")
 	var n = dialogic.get_node_or_null(Path)
 	n.callv(Method, Arguments)
@@ -75,7 +75,8 @@ func get_shortcode_parameters() -> Dictionary:
 		"args"		: "Arguments",
 		"wait"		: "Wait",
 		"inline"	: "Inline",
-		"signal_name": "Signal_Name",
+		"signal": "Signal_Name",
+		"single_use": "Single_Use",
 	}
 
 
@@ -89,6 +90,6 @@ func build_event_editor():
 	add_body_edit('Wait', ValueType.Bool, 'Wait:')
 	add_body_edit('Inline', ValueType.Bool, 'Inline:')
 	add_body_edit('Signal_Name', ValueType.SinglelineText, 'Signal Name', '', {}, 'Inline == true')
-	add_body_edit('One_Off', ValueType.Bool, 'One Off', '', {}, 'Inline == true')
+	add_body_edit('Single_Use', ValueType.Bool, 'Signle Use', '', {}, 'Inline == true')
 	add_body_line_break()
 	add_body_edit('Arguments', ValueType.StringArray, 'Arguments:')


### PR DESCRIPTION
enable the inline option in the call_node event and add a code name (e.g. shake or flash or whatever).

use the [signal=code_name] and put the code name that you put in the call_node to call the method

one off means that you can only call the method once (useful if you want to free up the code name for something else)
disabling it means it will be active until the timeline ends (has to end, not be changed. although I might add an option about that)