### PR TITLE
2.0 Improve Resource Picker

### DIFF
--- a/addons/dialogic/Editor/Events/EventNode/EventNode.gd
+++ b/addons/dialogic/Editor/Events/EventNode/EventNode.gd
@@ -209,6 +209,11 @@ func build_editor():
 			editor_node.file_extension = p.display_info.get('file_extension', '')
 			editor_node.get_suggestions_func = p.display_info.get('suggestions_func', editor_node.get_suggestions_func)
 			editor_node.empty_text = p.display_info.get('empty_text', '')
+			editor_node.placeholder_text = p.display_info.get('placeholder', 'Select Resource')
+			editor_node.resource_icon = p.display_info.get('icon', null)
+			if editor_node.resource_icon == null and p.display_info.has('editor_icon'):
+				editor_node.resource_icon = callv('get_icon', p.display_info.editor_icon)
+			
 		## INTEGERS
 		elif p.dialogic_type == resource.ValueType.Integer:
 			editor_node = load("res://addons/dialogic/Editor/Events/Fields/Number.tscn").instance()

--- a/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
+++ b/addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://addons/dialogic/Editor/Events/Fields/DialogicResourcePicker.gd" type="Script" id=1]
 [ext_resource path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" type="Theme" id=2]
 
-[sub_resource type="Image" id=1]
+[sub_resource type="Image" id=3]
 data = {
 "data": PoolByteArray( 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
 "format": "LumAlpha8",
@@ -15,7 +15,7 @@ data = {
 [sub_resource type="ImageTexture" id=2]
 flags = 4
 flags = 4
-image = SubResource( 1 )
+image = SubResource( 3 )
 size = Vector2( 16, 16 )
 
 [node name="DialogicResourcePicker" type="HBoxContainer"]
@@ -51,11 +51,26 @@ placeholder_text = "Select Resource"
 caret_blink = true
 caret_blink_speed = 0.5
 
+[node name="Icon" type="TextureRect" parent="Search"]
+unique_name_in_owner = true
+anchor_bottom = 1.0
+margin_right = 20.0
+rect_min_size = Vector2( 24, 0 )
+expand = true
+stretch_mode = 4
+
 [node name="Suggestions" type="PopupMenu" parent="Search"]
 margin_left = 6.0
 margin_top = 27.0
 margin_right = 440.0
 margin_bottom = 139.0
+
+[node name="SelectButton" type="ToolButton" parent="Search"]
+anchor_left = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -12.0
+grow_horizontal = 0
 
 [node name="OpenButton" type="ToolButton" parent="Search"]
 visible = false
@@ -74,6 +89,8 @@ margin_top = 5.0
 margin_right = 503.0
 margin_bottom = 19.0
 
+[connection signal="focus_entered" from="Search" to="." method="_on_Search_focus_entered"]
 [connection signal="text_changed" from="Search" to="." method="_on_Search_text_changed"]
 [connection signal="text_entered" from="Search" to="." method="_on_Search_text_entered"]
+[connection signal="pressed" from="Search/SelectButton" to="." method="_on_SelectButton_pressed"]
 [connection signal="pressed" from="Search/OpenButton" to="." method="_on_OpenButton_pressed"]

--- a/addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres
+++ b/addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres
@@ -1,8 +1,24 @@
-[gd_resource type="Theme" load_steps=2 format=2]
+[gd_resource type="Theme" load_steps=3 format=2]
 
 [sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 30.0
+content_margin_right = 20.0
+content_margin_top = 5.0
+content_margin_bottom = 5.0
+bg_color = Color( 0.12549, 0.141176, 0.192157, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 0.0980392, 0.113725, 0.152941, 1 )
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[sub_resource type="StyleBoxFlat" id=2]
 content_margin_left = 11.0
-content_margin_right = 9.0
+content_margin_right = 20.0
 content_margin_top = 5.0
 content_margin_bottom = 5.0
 bg_color = Color( 0.12549, 0.141176, 0.192157, 1 )
@@ -28,5 +44,7 @@ LineEdit/constants/minimum_spaces = 10
 LineEdit/fonts/font = null
 LineEdit/icons/clear = null
 LineEdit/styles/focus = SubResource( 1 )
-LineEdit/styles/normal = SubResource( 1 )
+LineEdit/styles/normal = SubResource( 2 )
 LineEdit/styles/read_only = SubResource( 1 )
+LineEditWithIcon/base_type = "LineEdit"
+LineEditWithIcon/styles/normal = SubResource( 1 )

--- a/addons/dialogic/Events/Character/PortraitSettings.gd
+++ b/addons/dialogic/Events/Character/PortraitSettings.gd
@@ -12,6 +12,8 @@ func refresh():
 	get_node('%CustomAnimationsFolder').text = DialogicUtil.get_project_setting('dialogic/animations/custom_folder', 'res://addons/dialogic_additions/Animations')
 	$'%PortraitMode'.select(DialogicUtil.get_project_setting('dialogic/portrait_mode', 0))
 	
+	$'%JoinDefault'.resource_icon = get_icon("Animation", "EditorIcons")
+	$'%LeaveDefault'.resource_icon = get_icon("Animation", "EditorIcons")
 	$'%JoinDefault'.set_value(DialogicUtil.get_project_setting('dialogic/animations/join_default', 
 	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_in_up.gd')))
 	$'%LeaveDefault'.set_value(DialogicUtil.get_project_setting('dialogic/animations/leave_default', 
@@ -47,7 +49,7 @@ func _on_LeaveDefaultWait_toggled(button_pressed):
 func get_join_animation_suggestions(search_text):
 	var suggestions = {}
 	for anim in list_animations():
-		if search_text.to_lower() in anim.get_file().to_lower():
+		if !search_text or search_text.to_lower() in anim.get_file().to_lower():
 			if '_in' in anim.get_file():
 				suggestions[DialogicUtil.pretty_name(anim)] = anim
 	return suggestions
@@ -55,7 +57,7 @@ func get_join_animation_suggestions(search_text):
 func get_leave_animation_suggestions(search_text):
 	var suggestions = {}
 	for anim in list_animations():
-		if search_text.to_lower() in anim.get_file().to_lower():
+		if !search_text or search_text.to_lower() in anim.get_file().to_lower():
 			if '_out' in anim.get_file():
 				suggestions[DialogicUtil.pretty_name(anim)] = anim
 	return suggestions

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -112,7 +112,7 @@ func get_as_string_to_store() -> String:
 	if Position and ActionType != ActionTypes.Leave:
 		result_string += " "+str(Position)
 	
-	if !AnimationName.empty():
+	if AnimationName:
 		result_string += ' [animation="'+DialogicUtil.pretty_name(AnimationName)+'"'
 	
 		if AnimationLength != 0.5:
@@ -181,21 +181,21 @@ func is_valid_event_string(string:String):
 func build_event_editor():
 	add_header_edit('ActionType', ValueType.FixedOptionSelector, '', '',
 		 {'selector_options':{"Join":ActionTypes.Join, "Leave":ActionTypes.Leave, "Update":ActionTypes.Update}})
-	add_header_edit('Character', ValueType.Resource, '', '', {'file_extension':'.dch'})
+	add_header_edit('Character', ValueType.Resource, '', '', {'file_extension':'.dch', 'icon':load("res://addons/dialogic/Editor/Images/Resources/character.svg")})
 	
-	add_header_edit('Portrait', ValueType.Resource, 'Portrait:', '', {'suggestions_func':[self, 'get_portrait_suggestions']}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
+	add_header_edit('Portrait', ValueType.Resource, 'Portrait:', '', {'suggestions_func':[self, 'get_portrait_suggestions'], 'icon':load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
 	add_header_edit('Position', ValueType.Integer, 'Position:', '', {}, 'Character != null and ActionType != %s' %ActionTypes.Leave)
 	
-	add_body_edit('AnimationName', ValueType.Resource, 'Animation:', '', {'suggestions_func':[self, 'get_animation_suggestions'], 'empty_text':'Default'}, 'Character != null')
-	add_body_edit('AnimationLength', ValueType.Float, 'Length:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName')
-	add_body_edit('AnimationWait', ValueType.Bool, 'Wait:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName')
-	add_body_edit('AnimationRepeats', ValueType.Integer, 'Repeat:', '', {}, 'Character != null and AnimationName != "" and AnimationName != null and not "instant" in AnimationName and ActionType == %s' %ActionTypes.Update)
+	add_body_edit('AnimationName', ValueType.Resource, 'Animation:', '', {'suggestions_func':[self, 'get_animation_suggestions'], 'editor_icon':["Animation", "EditorIcons"], 'placeholder':'Default'}, 'Character != null')
+	add_body_edit('AnimationLength', ValueType.Float, 'Length:', '', {}, 'Character and AnimationName')
+	add_body_edit('AnimationWait', ValueType.Bool, 'Wait:', '', {}, 'Character and AnimationName')
+	add_body_edit('AnimationRepeats', ValueType.Integer, 'Repeat:', '', {},'Character and AnimationName and ActionType == %s)' %ActionTypes.Update)
 
 func get_portrait_suggestions(search_text):
 	var suggestions = {}
 	if Character != null:
 		for portrait in Character.portraits:
-			if search_text.to_lower() in portrait.to_lower():
+			if search_text.empty() or search_text.to_lower() in portrait.to_lower():
 				suggestions[portrait] = portrait
 	return suggestions
 
@@ -207,9 +207,9 @@ func get_animation_suggestions(search_text):
 			suggestions['Default'] = ""
 		ActionTypes.Update:
 			suggestions['None'] = ""
-
+	
 	for anim in list_animations():
-		if search_text.to_lower() in anim.get_file().to_lower():
+		if search_text.empty() or search_text.to_lower() in anim.get_file().to_lower():
 			match ActionType:
 				ActionTypes.Join:
 					if '_in' in anim.get_file():

--- a/addons/dialogic/Events/Jump/event.gd
+++ b/addons/dialogic/Events/Jump/event.gd
@@ -47,6 +47,6 @@ func get_shortcode_parameters() -> Dictionary:
 ################################################################################
 
 func build_event_editor():
-	add_header_edit('Timeline', ValueType.Resource, 'Timeline:', '', {'file_extension':'.dtl'})
+	add_header_edit('Timeline', ValueType.Resource, 'Timeline:', '', {'file_extension':'.dtl', 'icon':load("res://addons/dialogic/Editor/Images/Resources/timeline.svg")})
 	add_header_edit('Label', ValueType.SinglelineText, 'Label:')
 

--- a/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.gd
+++ b/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.gd
@@ -46,7 +46,7 @@ func _on_portrait_selected(previous, current):
 func mood_suggestions(filter):
 	var suggestions = {}
 	for child in $'%Moods'.get_children():
-		if filter.to_lower() in child.get_data().name.to_lower():
+		if !filter or filter.to_lower() in child.get_data().name.to_lower():
 			suggestions[child.get_data().name] = child.get_data().name
 	return suggestions
 

--- a/addons/dialogic/Events/Text/Settings_DialogText.gd
+++ b/addons/dialogic/Events/Text/Settings_DialogText.gd
@@ -7,6 +7,7 @@ func refresh():
 	$'%Autocontinue'.pressed = DialogicUtil.get_project_setting('dialogic/text/autocontinue', false)
 	$'%Autocontinue'.pressed = DialogicUtil.get_project_setting('dialogic/text/autocolor_names', false)
 	$'%AutocontinueDelay'.value = DialogicUtil.get_project_setting('dialogic/text/autocontinue_delay', 1)
+	$'%InputAction'.resource_icon = get_icon("Mouse", "EditorIcons")
 	$'%InputAction'.set_value(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action'))
 	$'%InputAction'.get_suggestions_func = [self, 'suggest_actions']
 
@@ -33,7 +34,7 @@ func _on_InputAction_value_changed(property_name, value):
 func suggest_actions(search):
 	var suggs = {}
 	for prop in ProjectSettings.get_property_list():
-		if prop.name.begins_with('input/') and search.to_lower() in prop.name.trim_prefix('input/'):
+		if prop.name.begins_with('input/') and (!search or search.to_lower() in prop.name.trim_prefix('input/')):
 			suggs[prop.name.trim_prefix('input/')] = prop.name.trim_prefix('input/')
 	return suggs
 

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -77,7 +77,7 @@ func _init() -> void:
 ## THIS RETURNS A READABLE REPRESENTATION, BUT HAS TO CONTAIN ALL DATA (This is how it's stored)
 func get_as_string_to_store() -> String:
 	if Character:
-		if not Portrait.empty():
+		if Portrait and not Portrait.empty():
 			return Character.name+" ("+Portrait+"): "+Text.replace("\n", "<br>")
 		return Character.name+": "+Text.replace("\n", "<br>")
 	return Text.replace("\n", "<br>")
@@ -110,8 +110,8 @@ func get_original_translation_text():
 	return Text
 
 func build_event_editor():
-	add_header_edit('Character', ValueType.Resource, 'Character:', '', {'file_extension':'.dch'})
-	add_header_edit('Portrait', ValueType.Resource, '', '', {'suggestions_func':[self, 'get_portrait_suggestions'], 'empty_text':"Don't change"}, 'Character != null')
+	add_header_edit('Character', ValueType.Resource, 'Character:', '', {'file_extension':'.dch', 'icon':load("res://addons/dialogic/Editor/Images/Resources/character.svg")})
+	add_header_edit('Portrait', ValueType.Resource, '', '', {'suggestions_func':[self, 'get_portrait_suggestions'], 'placeholder':"Don't change", 'icon':load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")}, 'Character')
 	add_body_edit('Text', ValueType.MultilineText)
 
 func get_portrait_suggestions(search_text):
@@ -119,6 +119,6 @@ func get_portrait_suggestions(search_text):
 	suggestions["Don't change"] = ''
 	if Character != null:
 		for portrait in Character.portraits:
-			if search_text.to_lower() in portrait.to_lower():
+			if search_text.empty() or search_text.to_lower() in portrait.to_lower():
 				suggestions[portrait] = portrait
 	return suggestions


### PR DESCRIPTION
# Icons
You can now specify an icon for the resource picker.
You can do that also in the info dict in add_header_edit() or add_body_edit().
The keys are 'icon' for a texture or 'editor_icon' for an array like ['Animation', 'EditorIcons'] (because get_icon() is impossible in resources)

- icons have been added to the character, portrait, animation and timeline pickers.

# Dropdown / Empty suggestions
If the search is empty or you click the new drop down button, the first 12 suggestions will show up. This is an arbitrary number that could be changed. If there are more then 12 suggestions a "..." will display at the bottom of the panel.
- many suggestion functions had to be updated to allow an empty search.