### PR TITLE
Make serial audio region width-greedy

### DIFF
--- a/addons/dialogic/Events/Voice/SerialAudioregion.tscn
+++ b/addons/dialogic/Events/Voice/SerialAudioregion.tscn
@@ -6,6 +6,7 @@
 [node name="SerialAudioRegion" type="VBoxContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
+size_flags_horizontal = 3
 script = ExtResource("2")
 
 [node name="NumRegions" type="HBoxContainer" parent="."]


### PR DESCRIPTION
this makes it compete with the audiobus field in Voice event, and saves a little bit of space in the UI.