### PR TITLE
2.0 Conditional Variable Format Improvement

### DIFF
--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -112,6 +112,16 @@ func clear():
 ################################################################################
 
 func execute_condition(condition:String) -> bool:
+	var regex = RegEx.new()
+	regex.compile('{(\\w.*)}')
+	var result = regex.search_all(condition)
+	if result:
+		for res in result:			
+			var r_string = res.get_string()
+			var replacement = "VAR." + r_string.substr(1,r_string.length()-2)
+			condition = condition.replace(r_string, replacement)
+	
+	
 	var expr = Expression.new()
 	var autoload_names = []
 	var autoloads = []


### PR DESCRIPTION
Adds an additional regex replace to the conditional evaluator, so that conditions can be written with the same {path.to.variable} format that is used for variables everywher elese, instead of only VAR.path.to.variable like it was. can still be done the latter way, too 