### PR TITLE
Add default portrait and mood

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -19,6 +19,7 @@ func new_character(path: String) -> void:
 	resource.name = path.get_file().trim_suffix("."+path.get_extension())
 	resource.display_name = path.get_file().trim_suffix("."+path.get_extension())
 	resource.color = Color(1,1,1,1)
+	resource.default_portrait = ""
 	resource.custom_info = {}
 	ResourceSaver.save(path, resource)
 	find_parent('EditorView').edit_character(resource)
@@ -36,6 +37,7 @@ func load_character(resource: DialogicCharacter) -> void:
 		%NicknameLineEdit.text += nickname +", "
 	%NicknameLineEdit.text = %NicknameLineEdit.text.trim_suffix(', ')
 	%DescriptionTextEdit.text = resource.description
+	%DefaultPortraitPicker.set_value(resource.default_portrait)
 	%MainScale.value = 100*resource.scale
 	%MainOffsetX.value = resource.offset.x
 	%MainOffsetY.value = resource.offset.y
@@ -59,6 +61,18 @@ func save_character() -> void:
 		nicknames.append(n_name.strip_edges())
 	current_character.nicknames = nicknames
 	current_character.description = %DescriptionTextEdit.text
+	
+	current_character.portraits = {}
+	for node in $'%PortraitList'.get_children():
+		current_character.portraits[node.get_portrait_name()] = node.portrait_data
+	
+	if $'%DefaultPortraitPicker'.current_value in current_character.portraits.keys():
+		current_character.default_portrait = $'%DefaultPortraitPicker'.current_value
+	elif !current_character.portraits.is_empty():
+		current_character.default_portrait = current_character.portraits.keys()[0]
+	else:
+		current_character.default_portrait = ""
+	
 	current_character.scale = %MainScale.value/100.0
 	current_character.offset = Vector2(%MainOffsetX.value, %MainOffsetY.value) 
 	current_character.mirror = %MainMirror.button_pressed
@@ -66,10 +80,6 @@ func save_character() -> void:
 	for main_edit in %MainEditTabs.get_children():
 		if main_edit.has_method('save_character'):
 			main_edit.save_character(current_character)
-	
-	current_character.portraits = {}
-	for node in %PortraitList.get_children():
-		current_character.portraits[node.get_portrait_name()] = node.portrait_data
 	
 	ResourceSaver.save(current_character.resource_path, current_character)
 	toolbar.set_resource_saved()
@@ -81,13 +91,15 @@ func save_character() -> void:
 
 func _ready() -> void:
 	DialogicUtil.get_dialogic_plugin().dialogic_save.connect(save_character)
-	
 	# Let's go connecting!
 	%NameLineEdit.text_changed.connect(something_changed)
 	%ColorPickerButton.color_changed.connect(something_changed)
 	%DisplayNameLineEdit.text_changed.connect(something_changed)
 	%NicknameLineEdit.text_changed.connect(something_changed)
 	%DescriptionTextEdit.text_changed.connect(something_changed)
+	%DefaultPortraitPicker.resource_icon = load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")
+	%DefaultPortraitPicker.get_suggestions_func = [self, 'suggest_portraits']
+	%DefaultPortraitPicker.value_changed.connect(something_changed)
 	%MainScale.value_changed.connect(main_portrait_settings_update)
 	%MainOffsetX.value_changed.connect(main_portrait_settings_update)
 	%MainOffsetY.value_changed.connect(main_portrait_settings_update)
@@ -126,9 +138,15 @@ func _ready() -> void:
 	hide()
 
 
-func something_changed(fake_argument = "") -> void:
+func something_changed(fake_argument = "", fake_arg2 = null) -> void:
 	toolbar.set_resource_unsaved()
 
+func suggest_portraits(search:String):
+	var suggestions = {}
+	for portrait in $'%PortraitList'.get_children():
+		if search.is_empty() or search.to_lower() in portrait.get_portrait_name().to_lower():
+			suggestions[portrait.get_portrait_name()] = {'value':portrait.get_portrait_name()}
+	return suggestions
 
 func open_portrait_folder_select() -> void:
 	find_parent("EditorView").godot_file_dialog(_on_dir_selected, "*", EditorFileDialog.FILE_MODE_OPEN_DIR)
@@ -151,7 +169,12 @@ func _on_dir_selected(path:String) -> void:
 		print("An error occurred when trying to access the path.")
 
 
-func create_portrait_entry_instance(name:String, portait_data:Dictionary) -> Node:
+func create_portrait_entry_instance(name:String, portait_data:Dictionary, loading = false) -> Node:
+	# if this is the first portrait, use as default
+	if !$'%PortraitList'.get_child_count() and !loading:
+		if name.is_empty():
+			name = "default"
+		$'%DefaultPortraitPicker'.set_value(name)
 	var instance = portrait_entry.instantiate()
 	instance.load_data(name, portait_data.duplicate(), self)
 	%PortraitList.add_child(instance)
@@ -171,7 +194,7 @@ func update_portrait_list(filter_term:String = '') -> void:
 	current_portrait = null
 	var first_visible_item = null
 	for portrait in current_character.portraits.keys():
-		var port = create_portrait_entry_instance(portrait, current_character.portraits[portrait])
+		var port = create_portrait_entry_instance(portrait, current_character.portraits[portrait], true)
 		if filter_term.is_empty() or filter_term.to_lower() in portrait.to_lower():
 			if not first_visible_item: first_visible_item = port
 			if portrait == prev_portrait_name:

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd
@@ -99,6 +99,7 @@ func _ready() -> void:
 	%DescriptionTextEdit.text_changed.connect(something_changed)
 	%DefaultPortraitPicker.resource_icon = load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")
 	%DefaultPortraitPicker.get_suggestions_func = [self, 'suggest_portraits']
+	%DefaultPortraitPicker.set_left_text("")
 	%DefaultPortraitPicker.value_changed.connect(something_changed)
 	%MainScale.value_changed.connect(main_portrait_settings_update)
 	%MainOffsetX.value_changed.connect(main_portrait_settings_update)

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -156,11 +156,11 @@ offset_right = 596.0
 offset_bottom = 26.0
 size_flags_horizontal = 3
 
-[node name="HBoxContainer" type="HBoxContainer" parent="Split/EditorScroll/Editor/MainEditTabs/General"]
+[node name="DefaultPortrait" type="HBoxContainer" parent="Split/EditorScroll/Editor/MainEditTabs/General"]
 offset_right = 40.0
 offset_bottom = 40.0
 
-[node name="TLabel6" parent="Split/EditorScroll/Editor/MainEditTabs/General/HBoxContainer" instance=ExtResource("3")]
+[node name="TLabel6" parent="Split/EditorScroll/Editor/MainEditTabs/General/DefaultPortrait" instance=ExtResource("3")]
 custom_minimum_size = Vector2(150, 0)
 anchor_right = 0.0
 anchor_bottom = 0.0
@@ -168,11 +168,11 @@ offset_top = 74.0
 offset_right = 150.0
 offset_bottom = 100.0
 size_flags_vertical = 0
-text = "Description:"
-text_key = "Description: "
+text = "Default Portrait:"
+text_key = "Default Portrait:"
 mode = 0
 
-[node name="DefaultPortraitPicker" parent="Split/EditorScroll/Editor/MainEditTabs/General/HBoxContainer" instance=ExtResource("4_jo7m8")]
+[node name="DefaultPortraitPicker" parent="Split/EditorScroll/Editor/MainEditTabs/General/DefaultPortrait" instance=ExtResource("4_jo7m8")]
 unique_name_in_owner = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Split/EditorScroll/Editor"]

--- a/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/CharacterEditor.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://bak1jk2glij8r"]
+[gd_scene load_steps=9 format=3 uid="uid://bak1jk2glij8r"]
 
 [ext_resource type="PackedScene" uid="uid://dfwnfu41utt3d" path="res://addons/dialogic/Editor/CharacterEditor/PortraitEntry.tscn" id="1"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/CharacterEditor.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://duj8nl0vpms35" path="res://addons/dialogic/Editor/Common/TLabel.tscn" id="3"]
 [ext_resource type="Texture2D" uid="uid://25qi7yo6ep6o" path="res://icon.png" id="4"]
+[ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="4_jo7m8"]
 [ext_resource type="Theme" uid="uid://d3g4i4dshtdpu" path="res://addons/dialogic/Editor/Events/styles/InputFieldsStyle.tres" id="5"]
 
-[sub_resource type="Image" id="Image_5xllx"]
+[sub_resource type="Image" id="Image_80h4x"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -15,8 +16,8 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_yy51n"]
-image = SubResource("Image_5xllx")
+[sub_resource type="ImageTexture" id="ImageTexture_sbro6"]
+image = SubResource("Image_80h4x")
 
 [node name="CharacterEditor" type="Control"]
 visible = false
@@ -154,6 +155,25 @@ offset_left = 154.0
 offset_right = 596.0
 offset_bottom = 26.0
 size_flags_horizontal = 3
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Split/EditorScroll/Editor/MainEditTabs/General"]
+offset_right = 40.0
+offset_bottom = 40.0
+
+[node name="TLabel6" parent="Split/EditorScroll/Editor/MainEditTabs/General/HBoxContainer" instance=ExtResource("3")]
+custom_minimum_size = Vector2(150, 0)
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_top = 74.0
+offset_right = 150.0
+offset_bottom = 100.0
+size_flags_vertical = 0
+text = "Description:"
+text_key = "Description: "
+mode = 0
+
+[node name="DefaultPortraitPicker" parent="Split/EditorScroll/Editor/MainEditTabs/General/HBoxContainer" instance=ExtResource("4_jo7m8")]
+unique_name_in_owner = true
 
 [node name="VBoxContainer" type="VBoxContainer" parent="Split/EditorScroll/Editor"]
 offset_top = 43.0
@@ -309,7 +329,7 @@ unique_name_in_owner = true
 offset_right = 134.0
 offset_bottom = 31.0
 text = "  New portrait"
-icon = SubResource("ImageTexture_yy51n")
+icon = SubResource("ImageTexture_sbro6")
 
 [node name="ImportFromFolder" type="Button" parent="Split/EditorScroll/Editor/VBoxContainer/PortraitPanel/VBoxContainer/Labels/HBoxContainer"]
 unique_name_in_owner = true
@@ -317,7 +337,7 @@ offset_left = 138.0
 offset_right = 276.0
 offset_bottom = 31.0
 text = "  Import folder"
-icon = SubResource("ImageTexture_yy51n")
+icon = SubResource("ImageTexture_sbro6")
 
 [node name="ScrollContainer" type="ScrollContainer" parent="Split/EditorScroll/Editor/VBoxContainer/PortraitPanel/VBoxContainer"]
 offset_top = 35.0
@@ -358,7 +378,6 @@ size_flags_vertical = 3
 
 [node name="PreviewFullRect" type="TextureRect" parent="Split/Preview/Background"]
 unique_name_in_owner = true
-visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = 39.0
@@ -373,6 +392,7 @@ metadata/_edit_layout_mode = 1
 
 [node name="PreviewReal" type="CenterContainer" parent="Split/Preview/Background"]
 unique_name_in_owner = true
+visible = false
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = 445.0
@@ -402,7 +422,7 @@ unique_name_in_owner = true
 size_flags_horizontal = 3
 size_flags_vertical = 3
 mouse_filter = 2
-texture = SubResource("ImageTexture_yy51n")
+texture = SubResource("ImageTexture_sbro6")
 stretch_mode = 4
 
 [node name="PreviewLabel" parent="Split/Preview/Background" instance=ExtResource("3")]
@@ -419,7 +439,7 @@ anchor_left = 1.0
 anchor_right = 1.0
 grow_horizontal = 0
 item_count = 2
-selected = 1
+selected = 0
 popup/item_0/text = "Full View"
 popup/item_0/id = 0
 popup/item_1/text = "Real Size"

--- a/addons/dialogic/Editor/Events/Fields/ComplexPicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/ComplexPicker.gd
@@ -39,7 +39,7 @@ func set_left_text(value:String):
 	$LeftText.text = str(value)
 	$LeftText.visible = !value.is_empty()
 
-func set_rightt_text(value:String):
+func set_right_text(value:String):
 	$RightText.text = str(value)
 	$RightText.visible = !value.is_empty()
 

--- a/addons/dialogic/Events/Character/Subsystem_Portraits.gd
+++ b/addons/dialogic/Events/Character/Subsystem_Portraits.gd
@@ -25,6 +25,9 @@ func load_game_state():
 func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int) -> Node:
 	var character_node = null
 	
+	if portrait.is_empty():
+		portrait = character.default_portrait
+	
 	if not character:
 		assert(false, "[Dialogic] Cannot add portrait of null character.")
 	if not portrait in character.portraits:
@@ -49,6 +52,9 @@ func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:in
 func change_portrait(character:DialogicCharacter, portrait:String) -> void:
 	if not character or not is_character_joined(character):
 		assert(false, "[Dialogic] Cannot change portrait of null/not joined character.")
+	
+	if portrait.is_empty():
+		portrait = character.default_portrait
 	
 	var char_node :Node = dialogic.current_state_info.portraits[character.resource_path].node
 	

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -19,7 +19,7 @@ func _execute() -> void:
 	match ActionType:
 		ActionTypes.Join:
 			
-			if Character and Portrait:
+			if Character:
 				var n = dialogic.Portraits.add_portrait(Character, Portrait, Position)
 				
 				if AnimationName.is_empty():
@@ -192,7 +192,7 @@ func build_event_editor():
 		{'selector_options':{"Join":ActionTypes.Join, "Leave":ActionTypes.Leave, "Update":ActionTypes.Update}})
 	add_header_edit('Character', ValueType.ComplexPicker, '', '', {'suggestions_func':[self, 'get_character_suggestions'],'file_extension':'.dch', 'icon':load("res://addons/dialogic/Editor/Images/Resources/character.svg")})
 	
-	add_header_edit('Portrait', ValueType.ComplexPicker, 'Portrait:', '', {'suggestions_func':[self, 'get_portrait_suggestions'], 'icon':load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")}, 'Character != null and !has_no_portraits() and ActionType != %s' %ActionTypes.Leave)
+	add_header_edit('Portrait', ValueType.ComplexPicker, 'Portrait:', '', {'empty_text':'Default', 'suggestions_func':[self, 'get_portrait_suggestions'], 'icon':load("res://addons/dialogic/Editor/Images/Resources/Portrait.svg")}, 'Character != null and !has_no_portraits() and ActionType != %s' %ActionTypes.Leave)
 	add_header_label('Character has no portraits!', 'has_no_portraits()')
 	add_header_edit('Position', ValueType.Integer, 'Position:', '', {}, 'Character != null and !has_no_portraits() and ActionType != %s' %ActionTypes.Leave)
 	
@@ -217,6 +217,8 @@ func get_portrait_suggestions(search_text):
 	var suggestions = {}
 	if ActionType == ActionTypes.Update:
 		suggestions["Don't Change"] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
+	if ActionType == ActionTypes.Join:
+		suggestions["Default Portrait"] = {'value':'', 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
 	if Character != null:
 		for portrait in Character.portraits:
 			if search_text.is_empty() or search_text.to_lower() in portrait.to_lower():

--- a/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.gd
+++ b/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.gd
@@ -6,12 +6,14 @@ signal changed
 func _ready():
 	find_parent('CharacterEditor').portrait_selected.connect(_on_portrait_selected)
 	%PortraitMood.get_suggestions_func = [self, 'mood_suggestions']
+	%DefaultMood.get_suggestions_func = [self, 'mood_suggestions']
 
 func load_character(character:DialogicCharacter):
 	for mood in %Moods.get_children():
 		mood.queue_free()
 	
 	%PortraitMood.set_value('')
+	%DefaultMood.set_value(character.custom_info.get('sound_moods_default', ''))
 	
 	for mood in character.custom_info.get('sound_moods', {}):
 		create_mood_item(character.custom_info.sound_moods[mood])
@@ -20,6 +22,7 @@ func save_character(character:DialogicCharacter):
 	var moods = {}
 	for node in %Moods.get_children():
 		moods[node.get_data().name] = node.get_data()
+	character.custom_info['sound_mood_default'] = %DefaultMood.current_value
 	character.custom_info['sound_moods'] = moods
 
 func _on_AddMood_pressed():
@@ -40,13 +43,13 @@ func duplicate_mood_item(item):
 func _on_portrait_selected(previous, current):
 	if current and is_instance_valid(current):
 		%PortraitMood.set_value(current.portrait_data.get('sound_mood', ''))
-		%PortraitMoodLabel.text = 'Typing-Sound-Mood for portrait "%s":'%current.get_portrait_name()
+		%PortraitMoodLabel.text = 'Mood for "%s":'%current.get_portrait_name()
 
 
 func mood_suggestions(filter):
 	var suggestions = {}
 	for child in %Moods.get_children():
-		if !filter or filter.to_lower() in child.get_data().name.to_lower():
+		if filter.is_empty() or filter.to_lower() in child.get_data().name.to_lower():
 			suggestions[child.get_data().name] = {'value':child.get_data().name}
 	return suggestions
 
@@ -54,4 +57,10 @@ func mood_suggestions(filter):
 func _on_PortraitMood_value_changed(property_name, value):
 	if find_parent('CharacterEditor').current_portrait:
 		find_parent('CharacterEditor').current_portrait.portrait_data['sound_mood'] = value
+	emit_signal("changed")
+
+
+func _on_default_mood_value_changed(property_name, value):
+	if find_parent('CharacterEditor').current_portrait:
+		find_parent('CharacterEditor').current_portrait.portrait_data['sound_mood_default'] = value
 	emit_signal("changed")

--- a/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.tscn
+++ b/addons/dialogic/Events/Text/CharacterEdit_TypingSounds.tscn
@@ -10,31 +10,54 @@ offset_bottom = 100.0
 size_flags_vertical = 3
 script = ExtResource("1")
 
-[node name="HBoxContainer2" type="HBoxContainer" parent="."]
-offset_right = 443.0
+[node name="DefaultMood" type="HBoxContainer" parent="."]
+offset_right = 315.0
 offset_bottom = 33.0
+size_flags_horizontal = 0
 
-[node name="PortraitMoodLabel" type="Label" parent="HBoxContainer2"]
-unique_name_in_owner = true
+[node name="DefaultMoodLabel" type="Label" parent="DefaultMood"]
 offset_top = 3.0
-offset_right = 239.0
+offset_right = 111.0
 offset_bottom = 29.0
 size_flags_horizontal = 3
-text = "Sound mood for portrait \"sad\":"
+text = "Default mood:"
 
-[node name="PortraitMood" parent="HBoxContainer2" instance=ExtResource("2")]
+[node name="DefaultMood" parent="DefaultMood" instance=ExtResource("2")]
 unique_name_in_owner = true
 anchor_right = 0.0
 anchor_bottom = 0.0
-offset_left = 243.0
-offset_right = 443.0
+offset_left = 115.0
+offset_right = 315.0
+offset_bottom = 33.0
+placeholder_text = "Select Mood"
+
+[node name="PortraitMood" type="HBoxContainer" parent="."]
+offset_top = 37.0
+offset_right = 325.0
+offset_bottom = 70.0
+size_flags_horizontal = 0
+
+[node name="PortraitMoodLabel" type="Label" parent="PortraitMood"]
+unique_name_in_owner = true
+offset_top = 3.0
+offset_right = 121.0
+offset_bottom = 29.0
+size_flags_horizontal = 3
+text = "Mood for \"sad\":"
+
+[node name="PortraitMood" parent="PortraitMood" instance=ExtResource("2")]
+unique_name_in_owner = true
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 125.0
+offset_right = 325.0
 offset_bottom = 33.0
 placeholder_text = "Select Mood"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="."]
-offset_top = 37.0
+offset_top = 74.0
 offset_right = 443.0
-offset_bottom = 68.0
+offset_bottom = 105.0
 alignment = 2
 
 [node name="AddMood" type="Button" parent="HBoxContainer"]
@@ -45,7 +68,7 @@ offset_bottom = 31.0
 text = "Add mood"
 
 [node name="ScrollContainer" type="ScrollContainer" parent="."]
-offset_top = 72.0
+offset_top = 109.0
 offset_right = 443.0
 offset_bottom = 130.0
 size_flags_vertical = 3
@@ -54,9 +77,10 @@ horizontal_scroll_mode = 0
 [node name="Moods" type="VBoxContainer" parent="ScrollContainer"]
 unique_name_in_owner = true
 offset_right = 443.0
-offset_bottom = 58.0
+offset_bottom = 21.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[connection signal="value_changed" from="HBoxContainer2/PortraitMood" to="." method="_on_PortraitMood_value_changed"]
+[connection signal="value_changed" from="DefaultMood/DefaultMood" to="." method="_on_default_mood_value_changed"]
+[connection signal="value_changed" from="PortraitMood/PortraitMood" to="." method="_on_PortraitMood_value_changed"]
 [connection signal="pressed" from="HBoxContainer/AddMood" to="." method="_on_AddMood_pressed"]

--- a/addons/dialogic/Events/Text/DialogicDisplay_TypeSounds.gd
+++ b/addons/dialogic/Events/Text/DialogicDisplay_TypeSounds.gd
@@ -56,8 +56,9 @@ func _on_continued_revealing_text(new_character) -> void:
 		return
 		
 	#don't play if a voice-track is running
-	if dialogic.has_subsystem("Voice") and dialogic.Voice.isRunning():
-		return
+	if !Engine.is_editor_hint() and get_parent() is DialogicDisplay_DialogText:
+		if dialogic.has_subsystem("Voice") and dialogic.Voice.isRunning():
+			return
 	
 	#if sound playing and can't interrupt
 	if !sound_finished and !interrupt:

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -21,8 +21,11 @@ func _execute() -> void:
 		
 		if Portrait and dialogic.has_subsystem('Portraits') and dialogic.Portraits.is_character_joined(Character):
 				dialogic.Portraits.change_portrait(Character, Portrait)
-		if Portrait:
-			dialogic.Text.update_typing_sound_mood(Character.custom_info.get('sound_moods', {}).get(Character.portraits[Portrait].get('sound_mood', {}), {}))
+		var check_portrait = Portrait if !Portrait.is_empty() else dialogic.current_state_info['portraits'].get(Character.resource_path, {}).get('portrait', '')
+		if Character.portraits[check_portrait].get('sound_mood', '') in Character.custom_info.get('sound_moods', {}):
+			dialogic.Text.update_typing_sound_mood(Character.custom_info.get('sound_moods', {}).get(Character.portraits[check_portrait].get('sound_mood', {}), {}))
+		elif !Character.custom_info.get('sound_mood_default', '').is_empty():
+			dialogic.Text.update_typing_sound_mood(Character.custom_info.get('sound_moods', {}).get(Character.custom_info.get('sound_mood_default')))
 	else:
 		dialogic.Text.update_name_label(null)
 	

--- a/addons/dialogic/Resources/character.gd
+++ b/addons/dialogic/Resources/character.gd
@@ -14,6 +14,7 @@ class_name DialogicCharacter
 @export var offset:Vector2 = Vector2()
 @export var mirror:bool = false
 
+@export var default_portrait:String = ""
 @export var portraits:Dictionary = {}
 
 @export var custom_info:Dictionary = {}

--- a/characters/Emilio.dch
+++ b/characters/Emilio.dch
@@ -6,6 +6,7 @@
 "sound_moods": {},
 "theme": ""
 },
+"default_portrait": "default",
 "description": "THE dialogic developer!",
 "display_name": "Emi",
 "mirror": false,

--- a/characters/Jowan.dch
+++ b/characters/Jowan.dch
@@ -23,6 +23,7 @@
 },
 "theme": ""
 },
+"default_portrait": "happy",
 "description": "A dialogic developer.",
 "display_name": "Jowan",
 "mirror": false,


### PR DESCRIPTION
- should fix #1038 

Adds a default_portrait property to the character resource, an editor field in the character editor and an option to the portrait picker on the Join event (the new default)

Adds a default mood setting to the TypeSound editor. This mood will be used if no custom mood is set for the current portrait.