### PR TITLE
2.0 Settings Window Fix

### DIFF
--- a/addons/dialogic/Editor/EditorView.gd
+++ b/addons/dialogic/Editor/EditorView.gd
@@ -40,8 +40,9 @@ func edit_character(object):
 
 
 func show_settings():
-	$SettingsEditor.size = get_viewport().size/1.5
+	
 	$SettingsEditor.popup_centered()
+	$SettingsEditor.size = get_viewport().size/1.5
 
 func save_current_resource():
 	$SaveConfirmationDialog.popup_centered()

--- a/addons/dialogic/Editor/Settings/SettingsEditor.tscn
+++ b/addons/dialogic/Editor/Settings/SettingsEditor.tscn
@@ -6,7 +6,7 @@
 
 [node name="SettingsEditor" type="Popup"]
 title = "Dialogic Settings"
-size = Vector2i(700, 500)
+size = Vector2i(1024, 600)
 borderless = false
 min_size = Vector2i(700, 500)
 script = ExtResource("1")


### PR DESCRIPTION
Sets the main popup size to match the size of the panel that the General tab was designed for. Also switches the order of the commands for the show_settings() command, which makes it actually change the size of the popup properly