### PR TITLE
Add dependency updates when moving files in godot

### DIFF
--- a/addons/dialogic/Resources/CharacterResourceLoader.gd
+++ b/addons/dialogic/Resources/CharacterResourceLoader.gd
@@ -40,3 +40,19 @@ func _load(path: String, original_path: String, use_sub_threads: bool, cache_mod
 	
 	# Everything went well, and you parsed your file data into your resource. Life is good, return it
 	return res
+
+func _get_dependencies(path:String, add_type:bool):
+	var depends_on : PackedStringArray
+	var character:DialogicCharacter = load(path)
+	for p in character.portraits.values():
+		if p.path:
+			depends_on.append(p.path)
+	return depends_on
+
+func _rename_dependencies(path: String, renames: Dictionary):
+	var character:DialogicCharacter = load(path)
+	for p in character.portraits:
+		if character.portraits[p].path in renames:
+			character.portraits[p].path = renames[character.portraits[p].path]
+	ResourceSaver.save(path, character)
+	return OK

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -94,3 +94,32 @@ func _load(path: String, original_path: String, use_sub_threads: bool, cache_mod
 	res._events = events
 	
 	return res
+
+
+func _get_dependencies(path:String, add_type:bool):
+	var depends_on : PackedStringArray
+	var timeline:DialogicTimeline = load(path)
+	for event in timeline._events:
+		for property in event.get_shortcode_parameters().values():
+			if event.get(property) is DialogicTimeline:
+				depends_on.append(event.get(property).resource_path)
+			elif event.get(property) is DialogicCharacter:
+				depends_on.append(event.get(property).resource_path)
+			elif typeof(event.get(property)) == TYPE_STRING and event.get(property).begins_with('res://'):
+				depends_on.append(event.get(property))
+	return depends_on
+
+func _rename_dependencies(path: String, renames: Dictionary):
+	var timeline:DialogicTimeline = load(path)
+	for event in timeline._events:
+		for property in event.get_shortcode_parameters().values():
+			if event.get(property) is DialogicTimeline:
+				if event.get(property).resource_path in renames:
+					event.set(property, load(renames[event.get(property).resource_path]))
+			elif event.get(property) is DialogicCharacter:
+				if event.get(property).resource_path in renames:
+					event.set(property, load(renames[event.get(property).resource_path]))
+			elif typeof(event.get(property)) == TYPE_STRING and event.get(property) in renames:
+				event.set(property, renames[event.get(property)])
+	ResourceSaver.save(path, timeline)
+	return OK


### PR DESCRIPTION
Works for:
- Character portraits paths
- References to characters, timelines or strings that start with "res://" in all properties of events that are listed in the get_shortcode_parameters() method. This means that currently it does NOT work on the Text event, but that shouldn't be too much of a problem, because characters are only stored by reference anyways.

I would be very glad if someone could test this, because I have no idea if it will work in all edge-cases or have any negative performance costs. Didn't notice any so far, but my test project is relatively small in scope.