### PR TITLE
2.0 Loading Issue

### DIFF
--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -38,7 +38,8 @@ func start_timeline(timeline_resource, label_or_idx = "") -> void:
 	# load the resource if only the path is given
 	if typeof(timeline_resource) == TYPE_STRING:
 		timeline_resource = load(timeline_resource)
-	
+		if timeline_resource == null:
+			assert(false, "There was an error loading this timeline. Check the filename, and the timeline for errors")
 	
 	current_timeline = timeline_resource
 	current_timeline_events = current_timeline.get_events()

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -31,12 +31,12 @@ func _load(path: String, original_path: String, use_sub_threads: bool, cache_mod
 	var file := File.new()
 	var err:int
 	
-	var res = DialogicTimeline.new()
-	
 	err = file.open(path, File.READ)
 	if err != OK:
 		push_error("For some reason, loading custom resource failed with error code: %s"%err)
 		return err
+		
+	var res = DialogicTimeline.new()
 	
 	# Parse the lines as seperate events and recreate them as resources
 	var prev_indent = ""

--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -90,12 +90,13 @@ func _get_property_list() -> Array:
 	var usage = PROPERTY_USAGE_SCRIPT_VARIABLE
 	usage |= PROPERTY_USAGE_NO_EDITOR
 	usage |= PROPERTY_USAGE_EDITOR # Comment this line to hide events from editor
-	for event_idx in _events.size():
-		p.append(
-			{
-				"name":"event/{idx}".format({"idx":event_idx}),
-				"type":TYPE_OBJECT,
-				"usage":PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_SCRIPT_VARIABLE
-			}
-		)
+	if _events != null:
+		for event_idx in _events.size():
+			p.append(
+				{
+					"name":"event/{idx}".format({"idx":event_idx}),
+					"type":TYPE_OBJECT,
+					"usage":PROPERTY_USAGE_DEFAULT|PROPERTY_USAGE_SCRIPT_VARIABLE
+				}
+			)
 	return p


### PR DESCRIPTION
Fix for a weird locking issue I was running into stepping through to see why Dialogic.start_timeline() wasn't working by filename. Moves the file check to be before the resource creation, so it aborts if the filename is wrong, and asserts an error. Also, as I was stepping through one by one, as soon as it hit DialogicTimeline.new(), then the debugger got filled with infinite errors from the "for event_idx in _events.size():" line having size() fail because it was null, so checks to make sure it's not null before running that also