### PR TITLE
2.0 Change Basic Portraits Into Scene

### DIFF
--- a/addons/dialogic/Events/Character/Subsystem_Portraits.gd
+++ b/addons/dialogic/Events/Character/Subsystem_Portraits.gd
@@ -1,5 +1,6 @@
 extends DialogicSubsystem
 
+var default_portrait_scene
 
 ####################################################################################################
 ##					STATE
@@ -14,15 +15,17 @@ func load_game_state():
 	for character_path in dialogic.current_state_info['portraits']:
 		add_portrait(
 			load(character_path), 
-			dialogic.current_state_info['portraits'][character_path].portrait, dialogic.current_state_info['portraits'][character_path].position_index
-			)
+			dialogic.current_state_info['portraits'][character_path].portrait, dialogic.current_state_info['portraits'][character_path].position_index,
+			false)
 
+func _ready():
+	default_portrait_scene = load("res://addons/dialogic/Other/DefaultPortrait.tscn")
 
 ####################################################################################################
 ##					MAIN METHODS
 ####################################################################################################
 
-func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int) -> Node:
+func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int, mirrored: bool) -> Node:
 	var character_node = null
 	
 	if portrait.is_empty():
@@ -45,11 +48,11 @@ func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:in
 	if character_node:
 		dialogic.current_state_info['portraits'][character.resource_path] = {'portrait':portrait, 'node':character_node, 'position_index':position_idx}
 	if portrait:
-		change_portrait(character, portrait)
+		change_portrait(character, portrait,mirrored)
 	
 	return character_node
 
-func change_portrait(character:DialogicCharacter, portrait:String) -> void:
+func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool) -> void:
 	if not character or not is_character_joined(character):
 		assert(false, "[Dialogic] Cannot change portrait of null/not joined character.")
 	
@@ -58,7 +61,7 @@ func change_portrait(character:DialogicCharacter, portrait:String) -> void:
 	
 	var char_node :Node = dialogic.current_state_info.portraits[character.resource_path].node
 	
-	if char_node.get_child_count() and 'does_custom_portrait_change' in char_node.get_child(0) and char_node.get_child(0).does_custom_portrait_change():
+	if char_node.get_child_count() and 'does_custom_portrait_change' in char_node.get_child(0) and char_node.get_child(0).does_portrait_change():
 		char_node.get_child(0).change_portrait(character, portrait)
 	else:
 		# remove previous portrait
@@ -67,15 +70,22 @@ func change_portrait(character:DialogicCharacter, portrait:String) -> void:
 		
 		var path = character.portraits[portrait].path
 		if not path.ends_with('.tscn'):
-			var sprite = Sprite2D.new()
-			sprite.texture = load(path)
-			sprite.centered = false
-			sprite.scale = Vector2(1,1)*character.portraits[portrait].get('scale', 1)*character.scale
+			var sprite = default_portrait_scene.instantiate()
+			sprite.change_portrait(character, portrait)
+			sprite.position.x -= sprite.portrait_width/2.0
+			sprite.position.y -= sprite.portrait_height
+			
+			if sprite.does_portrait_mirror():
+				sprite.mirror_portrait(mirrored)
+			
 			char_node.add_child(sprite)
-			sprite.position = character.portraits[portrait].get('offset', Vector2(0,0))
-			sprite.position.x -= sprite.texture.get_width()/2.0*character.portraits[portrait].get('scale', 1)*character.scale
-			sprite.position.y -= sprite.texture.get_height()*character.portraits[portrait].get('scale', 1)*character.scale
-	
+		else:
+			var sprite = load(path)
+			sprite.position.x -= sprite.portrait_width/2.0
+			sprite.position.y -= sprite.portrait_height
+			if sprite.does_portrait_mirror():
+				sprite.mirror_portrait(mirrored)
+			char_node.add_child(path)
 	dialogic.current_state_info['portraits'][character.resource_path]['portrait'] = portrait
 
 
@@ -155,6 +165,6 @@ func update_rpg_portrait_mode(character:DialogicCharacter = null, portrait:Strin
 			var AnimationName = DialogicUtil.get_project_setting('dialogic/animations/join_default', 
 	get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_in_up.gd'))
 			var AnimationLength = DialogicUtil.get_project_setting('dialogic/animations/join_default_length', 0.5)
-			add_portrait(character, portrait, 0)
+			add_portrait(character, portrait, 0, false)
 			var anim = animate_portrait(character, AnimationName, AnimationLength)
 			

--- a/addons/dialogic/Events/Character/Subsystem_Portraits.gd
+++ b/addons/dialogic/Events/Character/Subsystem_Portraits.gd
@@ -25,7 +25,7 @@ func _ready():
 ##					MAIN METHODS
 ####################################################################################################
 
-func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int, mirrored: bool) -> Node:
+func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int, mirrored: bool = false) -> Node:
 	var character_node = null
 	
 	if portrait.is_empty():
@@ -52,7 +52,7 @@ func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:in
 	
 	return character_node
 
-func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool) -> void:
+func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool = false) -> void:
 	if not character or not is_character_joined(character):
 		assert(false, "[Dialogic] Cannot change portrait of null/not joined character.")
 	
@@ -89,7 +89,7 @@ func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool
 	dialogic.current_state_info['portraits'][character.resource_path]['portrait'] = portrait
 
 
-func animate_portrait(character:DialogicCharacter, animation_path:String, length:float, repeats = 1):
+func animate_portrait(character:DialogicCharacter, animation_path:String, length:float, repeats = 1) -> DialogicAnimation:
 	if not character or not is_character_joined(character):
 		assert(false, "[Dialogic] Cannot animate portrait of null/not joined character.")
 	

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -31,7 +31,7 @@ func _execute() -> void:
 					AnimationLength = DialogicUtil.get_project_setting('dialogic/animations/join_default_length', 0.5)
 					AnimationWait = DialogicUtil.get_project_setting('dialogic/animations/join_default_wait', true)
 				if AnimationName:
-					var anim = dialogic.Portraits.animate_portrait(Character, AnimationName, AnimationLength, AnimationRepeats)
+					var anim:DialogicAnimation = dialogic.Portraits.animate_portrait(Character, AnimationName, AnimationLength, AnimationRepeats)
 					
 					if AnimationWait:
 						dialogic.current_state = Dialogic.states.ANIMATING

--- a/addons/dialogic/Events/Choice/Subsystem_Choices.gd
+++ b/addons/dialogic/Events/Choice/Subsystem_Choices.gd
@@ -45,7 +45,10 @@ func show_current_choices() -> void:
 			show_choice(button_idx, choice_event.get_translated_text(), true, choice_index)
 			button_idx += 1
 	
-	choice_blocker.start(DialogicUtil.get_project_setting('dialogic/choices/delay', 0.2))
+	if typeof(DialogicUtil.get_project_setting('dialogic/choices/delay')) != TYPE_FLOAT:
+		choice_blocker.start(DialogicUtil.get_project_setting('dialogic/choices/delay', 0.2).to_float())
+	else:
+		choice_blocker.start(DialogicUtil.get_project_setting('dialogic/choices/delay', 0.2))
 
 
 func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -> void:

--- a/addons/dialogic/Events/Converter/Settings_Converter.gd
+++ b/addons/dialogic/Events/Converter/Settings_Converter.gd
@@ -361,7 +361,7 @@ func convertTimelines():
 											eventLine += "Update "
 											eventLine += characterFolderBreakdown[event['character']]['name']
 											if 'portrait' in event:
-												if (event['portrait'] != ""):
+												if (event['portrait'] != "") && (event['portrait'] != "(Don't change)"):
 													eventLine += " (" + event['portrait'] + ") "
 
 											var positionCheck = false
@@ -373,7 +373,7 @@ func convertTimelines():
 														eventLine += str(i.to_int() + 1)
 													
 											if !positionCheck:
-												eventLine += " -1"
+												eventLine += " 0"
 												
 											if (event['animation'] != "[Default]" && event['animation'] != "") || ('z_index' in event) || ('mirror_portrait' in event):
 												# Note: due to Anima changes, animations will be converted into a default. Times and wait will be perserved

--- a/addons/dialogic/Other/DefaultDialogNode.tscn
+++ b/addons/dialogic/Other/DefaultDialogNode.tscn
@@ -322,17 +322,18 @@ theme_override_constants/separation = 0
 alignment = 1
 
 [node name="DialogicDisplay_NameLabel" type="Label" parent="SpecialTheme/PanelContainer/MarginContainer/VBoxContainer"]
+offset_top = 11.0
 offset_right = 386.0
-offset_bottom = 26.0
+offset_bottom = 37.0
 text = "Name"
 horizontal_alignment = 1
 script = ExtResource("3")
 use_character_color = false
 
 [node name="DialogicDisplay_DialogText" type="RichTextLabel" parent="SpecialTheme/PanelContainer/MarginContainer/VBoxContainer"]
-offset_top = 26.0
+offset_top = 37.0
 offset_right = 386.0
-offset_bottom = 49.0
+offset_bottom = 37.0
 text = "Some default text"
 fit_content_height = true
 script = ExtResource("2")

--- a/addons/dialogic/Other/DefaultPortrait.gd
+++ b/addons/dialogic/Other/DefaultPortrait.gd
@@ -1,0 +1,65 @@
+extends Node
+# Default portrait scene
+# Can be extended for custom portrait scenes, this has the minimum requirements
+
+# The following minimum features should be supported by all portrait scenes:
+# @export var portrait_width: int
+# @export var portrait_height: int
+# func does_portrait_change() -> bool
+#    If the above is returning true: func change_portrait(DialogicCharacter, String) -> void:
+# func does_portrait_mirror() -> bool:
+#    If the above is returning true: func mirror_portrait(mirror:bool) -> void:
+
+class_name DialogicDefaultPortrait
+
+@export var portrait_width: int
+@export var portrait_height: int
+var character: DialogicCharacter
+var portrait: String
+
+# This function is needed on every custom portrait scene
+func does_portrait_change() -> bool:
+	return true
+	
+# If the custom portrait accepts a change, then accept it here
+func change_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
+	if passed_portrait == "":
+		passed_portrait = passed_character['default_portrait']
+	portrait = passed_portrait
+	if passed_character != null:
+		if character == null || character != passed_character:
+			character = passed_character
+		
+		
+	var path = character.portraits[portrait].path
+	$Portrait.texture = null
+	$Portrait.texture = load(path)
+	$Portrait.centered = false
+	$Portrait.scale = Vector2(1,1)*character.portraits[portrait].get('scale', 1)*character.scale
+	
+	# Offset is for re-orienting the picutre at 1x scale, and so position in the scene needs to include the scale in the offset
+	$Portrait.position.x = character.portraits[portrait]['offset']['x'] * character.portraits[portrait].scale *character.scale
+	$Portrait.position.y = character.portraits[portrait]['offset']['y'] * character.portraits[portrait].scale *character.scale
+	
+	if character.portraits[portrait].mirror:
+			$Portrait.flip_h = true
+
+	# Set the portrait dimensions that are reported back to Dialogic. Scale is included in the math here
+	portrait_width = $Portrait.texture.get_width() * character.portraits[portrait].scale * character.portraits[portrait].scale *character.scale
+	portrait_height = $Portrait.texture.get_height() * character.portraits[portrait].scale * character.scale
+	
+# These are from the separate Join/Update "Mirror" toggles, to override the default mirror
+func does_portrait_mirror() -> bool:
+	return true
+	
+func mirror_portrait(mirror:bool) -> void:
+	if mirror:
+		if character.portraits[portrait].mirror:
+			$Portrait.flip_h = false
+		else:
+			$Portrait.flip_h = true
+	else:
+		if character.portraits[portrait].mirror:
+			$Portrait.flip_h = true
+		else:
+			$Portrait.flip_h = false

--- a/addons/dialogic/Other/DefaultPortrait.tscn
+++ b/addons/dialogic/Other/DefaultPortrait.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://addons/dialogic/Other/DefaultPortrait.gd" id="1_wn77n"]
+
+[sub_resource type="Texture2D" id="Texture2D_sny5f"]
+resource_local_to_scene = false
+resource_name = ""
+
+[node name="DefaultPortrait" type="Node2D"]
+script = ExtResource("1_wn77n")
+
+[node name="Portrait" type="Sprite2D" parent="."]
+texture = SubResource("Texture2D_sny5f")


### PR DESCRIPTION
Changes plain portraits into a scene, allowing them to be manipulated the same way as custom scenes by having all scenes uniform: 

- Adds the `DefaultPortrait` tscn and gd files, as the template for custom scenes. Dialogic will expect all portrait scenes to have the exported values and functions as listed in the top of this script as baseline for custom scene portraits to implement
- Updates `Subsystem_Portraits` and `Character\event' to use this new calling method
- Changes the position Update function. Was previously entered that -1 will be 'no change' for Update position, but the regex doesn't read this value properly, so it's been changed to 0. This shouldn't affect any other actual portrait positioning, as their indexes start from 1

Other changes:
- Updates the 1.x Converter to use the new Update position directive
- Fixes occasional crash from `Subsystem_Choices` due to value type