### PR TITLE
2.0 Resource Loader Further Speedups

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -678,7 +678,8 @@ func add_event_node(event_resource:Resource, at_index:int = -1, auto_select: boo
 		return create_end_branch_event(at_index, %Timeline.get_child(0))
 	
 	if event_resource['event_node_ready'] == false:
-		event_resource._load_from_string(event_resource['deferred_processing_text'])
+		if event_resource['deferred_processing_text'] != "":
+			event_resource._load_from_string(event_resource['deferred_processing_text'])
 	
 	var piece = load("res://addons/dialogic/Editor/Events/EventNode/EventNode.tscn").instantiate()
 	var resource = event_resource

--- a/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TimelineEditor.gd
@@ -677,6 +677,9 @@ func add_event_node(event_resource:Resource, at_index:int = -1, auto_select: boo
 	if event_resource is DialogicEndBranchEvent:
 		return create_end_branch_event(at_index, %Timeline.get_child(0))
 	
+	if event_resource['event_node_ready'] == false:
+		event_resource._load_from_string(event_resource['deferred_processing_text'])
+	
 	var piece = load("res://addons/dialogic/Editor/Events/EventNode/EventNode.tscn").instantiate()
 	var resource = event_resource
 	piece.resource = event_resource

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -85,15 +85,13 @@ func _load(path: String, original_path: String, use_sub_threads: bool, cache_mod
 		
 
 		
-		if Engine.is_editor_hint():
+
+			# a few types have exceptions with how they're currently written
+		if (event['event_name'] == "Label") || (event['event_name'] == "Choice"):
 			event._load_from_string(event_content)
 		else:
-			# a few types have exceptions with how they're currently written
-			if (event['event_name'] == "Label") || (event['event_name'] == "Choice"):
-				event._load_from_string(event_content)
-			else:
-				#hold it for later if we're not processing it right now
-				event['deferred_processing_text'] = event_content
+			#hold it for later if we're not processing it right now
+			event['deferred_processing_text'] = event_content
 		events.append(event)
 		prev_was_opener = event.can_contain_events
 

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -36,6 +36,11 @@ func _save(path: String, resource: Resource, flags: int) -> int:
 	for idx in range(0, len(resource._events)):
 		var event = resource._events[idx]
 		
+		#it shouldn't be trying to save if the node's not been prepared, but if it does then it will just save default values instead so prepare it from what was there before
+		if event['event_node_ready'] == false:
+			event._load_from_string(event['deferred_processing_text'])
+		
+		
 		if event is DialogicEndBranchEvent:
 			indent -= 1
 			continue


### PR DESCRIPTION
Sometimes - not all the time - when starting Godot 4 current alpha, it seems to lose it's resource cache, and needs to reload everything. When this happens the Dialogic resource loader blocks Godot's UI from finishing indexing the rest of the project, and it sits there with an empty directory until it's done. 

Initially, before other speed improvement I had put in before, this was taking a very long time, upwards of 10 minutes for my VN project - which consists of 33 character files, 50 timeline files, and about 5000 events - as the baseline. My pverious changes brought it down to 2 minutes. This brings it down further, to under 20 seconds.  

This is implemented by just not actually doing the event processing at all, using the same changes that were happening on runtime as well. This defers almost all the event processing until actually needed, which in Editor is only when using the timeline editor, so it loads it as part of the step for preparing the timeline editor object  