### PR TITLE
Add pause() and resume() methods

### DIFF
--- a/addons/dialogic/Events/Character/DefaultAnimations/bounce_in.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/bounce_in.gd
@@ -1,8 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = (node.get_tree().create_tween() as Tween)
-	tween.bind_node(self)
+	var tween = (node.create_tween() as Tween)
 	node.scale = Vector2()
 	node.modulate.a = 0
 	

--- a/addons/dialogic/Events/Character/DefaultAnimations/bounce_out.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/bounce_out.gd
@@ -1,8 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = (node.get_tree().create_tween() as Tween)
-	tween.bind_node(self)
+	var tween = (node.create_tween() as Tween)
 	node.scale = Vector2(1,1)
 	node.modulate.a = 1
 	

--- a/addons/dialogic/Events/Character/DefaultAnimations/fade_in_up.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/fade_in_up.gd
@@ -1,7 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = node.create_tween()
+	var tween = (node.create_tween() as Tween)
 	node.position.y = orig_pos.y + node.get_viewport().size.y/5
 	node.modulate.a = 0
 	tween.set_ease(Tween.EASE_IN_OUT)

--- a/addons/dialogic/Events/Character/DefaultAnimations/fade_out_down.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/fade_out_down.gd
@@ -1,8 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = (node.get_tree().create_tween() as Tween)
-	tween.bind_node(self)
+	var tween = (node.create_tween() as Tween)
 	tween.set_ease(Tween.EASE_IN_OUT)
 	tween.set_trans(Tween.TRANS_SINE)
 	tween.set_parallel()

--- a/addons/dialogic/Events/Character/DefaultAnimations/heartbeat.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/heartbeat.gd
@@ -1,8 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = (node.get_tree().create_tween() as Tween)
-	tween.bind_node(self)
+	var tween = (node.create_tween() as Tween)
 	#tween.set_parallel(true)
 	#node.scale = Vector2(1,1)*1.2
 	tween.tween_property(node, 'scale', Vector2(1,1)*1.2, time*0.5).set_trans(Tween.TRANS_ELASTIC).set_ease(Tween.EASE_OUT)

--- a/addons/dialogic/Events/Character/DefaultAnimations/tada.gd
+++ b/addons/dialogic/Events/Character/DefaultAnimations/tada.gd
@@ -1,7 +1,7 @@
 extends DialogicAnimation
 
 func animate():
-	var tween = create_tween()
+	var tween = (node.create_tween() as Tween)
 	tween.set_parallel(true)
 	tween.set_trans(Tween.TRANS_SINE)
 	tween.set_ease(Tween.EASE_OUT)

--- a/addons/dialogic/Events/Character/DialogicAnimationClass.gd
+++ b/addons/dialogic/Events/Character/DialogicAnimationClass.gd
@@ -25,3 +25,10 @@ func finished_one_loop():
 	elif repeats == 0:
 		emit_signal("finished")
 	
+func pause():
+	print('anim paused')
+	process_mode = Node.PROCESS_MODE_DISABLED
+
+func resume():
+	print('anim unpaused')
+	process_mode = Node.PROCESS_MODE_INHERIT

--- a/addons/dialogic/Events/Character/Subsystem_Portraits.gd
+++ b/addons/dialogic/Events/Character/Subsystem_Portraits.gd
@@ -18,6 +18,16 @@ func load_game_state():
 			dialogic.current_state_info['portraits'][character_path].portrait, dialogic.current_state_info['portraits'][character_path].position_index,
 			false)
 
+func pause() -> void:
+	for portrait in dialogic.current_state_info['portraits'].values():
+		if portrait.has('animation_node'):
+			portrait.animation_node.pause()
+
+func resume() -> void:
+	for portrait in dialogic.current_state_info['portraits'].values():
+		if portrait.has('animation_node'):
+			portrait.animation_node.resume()
+
 func _ready():
 	default_portrait_scene = load("res://addons/dialogic/Other/DefaultPortrait.tscn")
 

--- a/addons/dialogic/Events/Choice/Subsystem_Choices.gd
+++ b/addons/dialogic/Events/Choice/Subsystem_Choices.gd
@@ -84,7 +84,7 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 ##					HELPERS
 ####################################################################################################
 func choice_selected(event_index:int) -> void:
-	if not choice_blocker.is_stopped():
+	if Dialogic.paused or not choice_blocker.is_stopped():
 		return
 	hide_all_choices()
 	dialogic.current_state = dialogic.states.IDLE

--- a/addons/dialogic/Events/Music/Subsystem_Audio.gd
+++ b/addons/dialogic/Events/Music/Subsystem_Audio.gd
@@ -16,7 +16,7 @@ func load_game_state():
 	else:
 		update_music(info.path, info.volume, info.audio_bus, 0, info.loop)
 
-func pause():
+func pause() -> void:
 	for node in get_tree().get_nodes_in_group('dialogic_music_player'):
 		node.stream_paused = true
 	for child in get_children():

--- a/addons/dialogic/Events/Music/Subsystem_Audio.gd
+++ b/addons/dialogic/Events/Music/Subsystem_Audio.gd
@@ -22,7 +22,7 @@ func pause():
 	for child in get_children():
 		child.stream_paused = true
 
-func resume():
+func resume() -> void:
 	for node in get_tree().get_nodes_in_group('dialogic_music_player'):
 		node.stream_paused = false
 	for child in get_children():

--- a/addons/dialogic/Events/Music/Subsystem_Audio.gd
+++ b/addons/dialogic/Events/Music/Subsystem_Audio.gd
@@ -16,6 +16,18 @@ func load_game_state():
 	else:
 		update_music(info.path, info.volume, info.audio_bus, 0, info.loop)
 
+func pause():
+	for node in get_tree().get_nodes_in_group('dialogic_music_player'):
+		node.stream_paused = true
+	for child in get_children():
+		child.stream_paused = true
+
+func resume():
+	for node in get_tree().get_nodes_in_group('dialogic_music_player'):
+		node.stream_paused = false
+	for child in get_children():
+		child.stream_paused = false
+
 ####################################################################################################
 ##					MAIN METHODS
 ####################################################################################################

--- a/addons/dialogic/Events/Text/DialogicDisplay_TypeSounds.gd
+++ b/addons/dialogic/Events/Text/DialogicDisplay_TypeSounds.gd
@@ -57,7 +57,7 @@ func _on_continued_revealing_text(new_character) -> void:
 		
 	#don't play if a voice-track is running
 	if !Engine.is_editor_hint() and get_parent() is DialogicDisplay_DialogText:
-		if dialogic.has_subsystem("Voice") and dialogic.Voice.isRunning():
+		if dialogic.has_subsystem("Voice") and dialogic.Voice.is_running():
 			return
 	
 	#if sound playing and can't interrupt

--- a/addons/dialogic/Events/Text/Display_DialogText.gd
+++ b/addons/dialogic/Events/Text/Display_DialogText.gd
@@ -5,7 +5,7 @@ class_name DialogicDisplay_DialogText, "icon.png"
 enum ALIGNMENT {LEFT, CENTER, RIGHT}
 
 @export var Align : ALIGNMENT = ALIGNMENT.LEFT
-@onready var timer = null
+@onready var timer :Timer = null
 
 var effect_regex = RegEx.new()
 var modifier_words_select_regex = RegEx.new()
@@ -67,7 +67,7 @@ func continue_reveal() -> void:
 
 # shows all the text imidiatly
 # called by this thing itself or the DialogicGameHandler
-func finish_text():
+func finish_text() -> void:
 	percent_visible = 1
 	execute_effects(true)
 	timer.stop()
@@ -133,3 +133,9 @@ func parse_modifiers(_text:String) -> String:
 	# [br] effect
 	_text = _text.replace('[br]', '\n')
 	return _text
+
+func pause() -> void: 
+	timer.stop()
+
+func resume() -> void:
+	continue_reveal()

--- a/addons/dialogic/Events/Text/Display_InputHandler.gd
+++ b/addons/dialogic/Events/Text/Display_InputHandler.gd
@@ -9,6 +9,8 @@ class_name DialogicInputHandler
 # This shouldn't be handled by this script I think, but for testing purposes this works.
 func _input(event:InputEvent) -> void:
 	if Input.is_action_just_pressed(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action')):
+		if Dialogic.paused: return
+		
 		if Dialogic.current_state == Dialogic.states.IDLE:
 			Dialogic.handle_next_event()
 		

--- a/addons/dialogic/Events/Text/Subsystem_Text.gd
+++ b/addons/dialogic/Events/Text/Subsystem_Text.gd
@@ -1,20 +1,19 @@
 extends DialogicSubsystem
 
 # used to color names without searching for all characters each time
-var character_colors = {}
-var color_regex = RegEx.new()
+var character_colors := {}
+var color_regex := RegEx.new()
+
 ####################################################################################################
 ##					STATE
 ####################################################################################################
-
-func clear_game_state():
+func clear_game_state() -> void:
 	update_dialog_text('')
 	update_name_label(null)
 	dialogic.current_state_info['character'] = null
 	dialogic.current_state_info['text'] = ''
 
-
-func load_game_state():
+func load_game_state() -> void:
 	update_dialog_text(dialogic.current_state_info.get('text', ''))
 	var character:DialogicCharacter = null
 	if dialogic.current_state_info.get('character', null):
@@ -22,6 +21,16 @@ func load_game_state():
 	
 	if character:
 		update_name_label(character)
+
+func pause() -> void:
+	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
+		if text_node.is_visible_in_tree():
+			text_node.pause()
+
+func resume() -> void:
+	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
+		if text_node.is_visible_in_tree():
+			text_node.resume()
 
 ####################################################################################################
 ##					MAIN METHODS
@@ -69,7 +78,7 @@ func skip_text_animation() -> void:
 		if text_node.is_visible_in_tree():
 			text_node.finish_text()
 	if dialogic.has_subsystem('Voice'):
-		dialogic.Voice.stopAudio()
+		dialogic.Voice.stop_audio()
 
 func get_current_speaker() -> DialogicCharacter:
 	return (load(dialogic.current_state_info['character']) as DialogicCharacter)

--- a/addons/dialogic/Events/Text/event.gd
+++ b/addons/dialogic/Events/Text/event.gd
@@ -46,8 +46,8 @@ func _execute() -> void:
 		dialogic.Text.update_dialog_text(dialogic.Text.color_names(final_text))
 		
 		#Plays the audio region for the current line.
-		if dialogic.has_subsystem('Voice') and dialogic.Voice.isVoiced(dialogic.current_event_idx):
-			dialogic.Voice.playVoiceRegion(index) #voice data is set by voice event.
+		if dialogic.has_subsystem('Voice') and dialogic.Voice.is_voiced(dialogic.current_event_idx):
+			dialogic.Voice.play_voice_region(index) #voice data is set by voice event.
 		
 		# Wait for text to finish revealing
 		while true:

--- a/addons/dialogic/Events/Voice/Subsystem_Voice.gd
+++ b/addons/dialogic/Events/Voice/Subsystem_Voice.gd
@@ -1,20 +1,39 @@
 extends DialogicSubsystem
 
-const audioplayer_name = "dialogic_dialog_voice"
-
-var voiceregions = []
-
+const audioplayer_name := "dialogic_dialog_voice"
+var voiceregions := []
 var voicetimer:Timer
-
 var currentAudio:String
 
-func isVoiced(index:int) -> bool:
+####################################################################################################
+##					STATE
+####################################################################################################
+func clear_game_state() -> void:
+	pass
+
+func load_game_state() -> void:
+	pass
+
+func pause() -> void:
+	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
+		audio_node.stream_paused = true
+	voicetimer.paused = true
+
+func resume() -> void:
+	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
+		audio_node.stream_paused = false
+	voicetimer.paused = false
+
+####################################################################################################
+##					MAIN METHODS
+####################################################################################################
+func is_voiced(index:int) -> bool:
 	if dialogic.current_timeline_events[index] is DialogicTextEvent:
 		if dialogic.current_timeline_events[index-1] is DialogicVoiceEvent:
 			return true
 	return false
 
-func playVoiceRegion(index:int):
+func play_voice_region(index:int):
 	if index >= len(voiceregions):
 		return
 	var start:float = voiceregions[index][0]
@@ -24,9 +43,9 @@ func playVoiceRegion(index:int):
 		if "visible" in audio_node and not audio_node.visible:
 			continue
 		audio_node.play(start)
-	setTimer(stop - start)
-	
-func setFile(path:String):
+	set_timer(stop - start)
+
+func set_file(path:String):
 	if currentAudio == path:
 		return
 	currentAudio = path
@@ -35,46 +54,35 @@ func setFile(path:String):
 	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
 		audio_node.stream = audio
 	
-func setVolume(value:float):
+func set_volume(value:float):
 	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
 		audio_node.volume_db = value
 
-func setRegions(value:Array):
+func set_regions(value:Array):
 	voiceregions = value
 
-func setBus(value:String):
+func set_bus(value:String):
 	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
 		audio_node.bus = value
 
-func stopAudio():
+func stop_audio():
 	for audio_node in get_tree().get_nodes_in_group(audioplayer_name):
 		audio_node.stop()
 
-func setTimer(time:float):
+func set_timer(time:float):
 	if !voicetimer:
 		voicetimer = Timer.new()
 		voicetimer.one_shot = true
 		add_child(voicetimer)
-		voicetimer.timeout.connect(stopAudio)
+		voicetimer.timeout.connect(stop_audio)
 	voicetimer.stop()
 	voicetimer.start(time)
 
-func getRemainingTime() -> float:
+func get_remaining_time() -> float:
 	if not voicetimer or voicetimer.is_stopped():
 		return 0.0 #contingency
 	return voicetimer.time_left
 
-func isRunning() -> bool:
-	return getRemainingTime() > 0.0
-	
-# To be overriden by sub-classes
-# Fill in everything that should be cleared (for example before loading a different state)
-func clear_game_state():
-	pass
+func is_running() -> bool:
+	return get_remaining_time() > 0.0
 
-# To be overriden by sub-classes
-# Fill in everything that should be loaded using the dialogic_game_handler.current_state_info
-# This is called when a save is loaded
-func load_game_state():
-	pass
-	

--- a/addons/dialogic/Events/Voice/event.gd
+++ b/addons/dialogic/Events/Voice/event.gd
@@ -3,9 +3,9 @@ extends DialogicEvent
 class_name DialogicVoiceEvent
 
 func _execute() -> void:
-	dialogic.Voice.setFile(FilePath)
-	dialogic.Voice.setVolume(Volume)
-	dialogic.Voice.setBus(AudioBus)
+	dialogic.Voice.set_file(FilePath)
+	dialogic.Voice.set_volume(Volume)
+	dialogic.Voice.set_bus(AudioBus)
 	#NOTE need better way of reading the regiondata. This deems messy
 	var regiondata = []
 
@@ -19,7 +19,7 @@ func _execute() -> void:
 		var data2:PackedStringArray = d.split(",", false)
 		regiondata.append([data2[0].to_float(), data2[1].to_float()])
 
-	dialogic.Voice.setRegions(regiondata)
+	dialogic.Voice.set_regions(regiondata)
 
 	finish() #the rest is executed by a text event
 

--- a/addons/dialogic/Other/DefaultPortrait.gd
+++ b/addons/dialogic/Other/DefaultPortrait.gd
@@ -38,15 +38,15 @@ func change_portrait(passed_character:DialogicCharacter, passed_portrait:String)
 	$Portrait.scale = Vector2(1,1)*character.portraits[portrait].get('scale', 1)*character.scale
 	
 	# Offset is for re-orienting the picutre at 1x scale, and so position in the scene needs to include the scale in the offset
-	$Portrait.position.x = character.portraits[portrait]['offset']['x'] * character.portraits[portrait].scale *character.scale
-	$Portrait.position.y = character.portraits[portrait]['offset']['y'] * character.portraits[portrait].scale *character.scale
+	$Portrait.position = character.portraits[portrait].get('offset', Vector2()) * character.portraits[portrait].get('scale', Vector2(1,1)) *character.scale
+	#$Portrait.position.y = character.portraits[portrait]['offset']['y'] * character.portraits[portrait].scale *character.scale
 	
-	if character.portraits[portrait].mirror:
+	if character.portraits[portrait].get('mirror', false):
 			$Portrait.flip_h = true
 
 	# Set the portrait dimensions that are reported back to Dialogic. Scale is included in the math here
-	portrait_width = $Portrait.texture.get_width() * character.portraits[portrait].scale * character.portraits[portrait].scale *character.scale
-	portrait_height = $Portrait.texture.get_height() * character.portraits[portrait].scale * character.scale
+	portrait_width = $Portrait.texture.get_width() * character.portraits[portrait].get('scale', 1) * character.scale
+	portrait_height = $Portrait.texture.get_height() * character.portraits[portrait].get('scale', 1) * character.scale
 	
 # These are from the separate Join/Update "Mirror" toggles, to override the default mirror
 func does_portrait_mirror() -> bool:
@@ -54,12 +54,12 @@ func does_portrait_mirror() -> bool:
 	
 func mirror_portrait(mirror:bool) -> void:
 	if mirror:
-		if character.portraits[portrait].mirror:
+		if character.portraits[portrait].get('mirror', false):
 			$Portrait.flip_h = false
 		else:
 			$Portrait.flip_h = true
 	else:
-		if character.portraits[portrait].mirror:
+		if character.portraits[portrait].get('mirror', false):
 			$Portrait.flip_h = true
 		else:
 			$Portrait.flip_h = false

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -5,16 +5,14 @@ enum states {IDLE, SHOWING_TEXT, ANIMATING, AWAITING_CHOICE, WAITING}
 var current_timeline = null
 var current_timeline_events = []
 
-
 var current_state = null:
 	get:
 		return current_state
 	set(new_state):
 		current_state = new_state
 		emit_signal('state_changed', new_state)
-
+var paused = false
 var current_event_idx = 0
-
 var current_state_info :Dictionary = {}
 
 # Thread and variables for handling delayed loader
@@ -161,6 +159,20 @@ func clear():
 	current_state = states.IDLE
 	return true
 
+
+func pause():
+	if paused: return
+	paused = true
+	for subsystem in get_children():
+		if subsystem.has_method('pause'):
+			subsystem.pause()
+
+func resume():
+	if !paused: return
+	paused = false
+	for subsystem in get_children():
+		if subsystem.has_method('resume'):
+			subsystem.resume()
 
 ################################################################################
 ## 						STATE

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -11,7 +11,7 @@ var current_state = null:
 	set(new_state):
 		current_state = new_state
 		emit_signal('state_changed', new_state)
-var paused = false
+var paused := false
 var current_event_idx = 0
 var current_state_info :Dictionary = {}
 
@@ -160,14 +160,14 @@ func clear():
 	return true
 
 
-func pause():
+func pause() -> void:
 	if paused: return
 	paused = true
 	for subsystem in get_children():
 		if subsystem.has_method('pause'):
 			subsystem.pause()
 
-func resume():
+func resume() -> void:
 	if !paused: return
 	paused = false
 	for subsystem in get_children():

--- a/addons/dialogic/Other/TestTimelineScene.gd
+++ b/addons/dialogic/Other/TestTimelineScene.gd
@@ -1,27 +1,35 @@
 extends Control
 
-
-func _ready():
-	var dialog_scene_path = DialogicUtil.get_project_setting(
+func _ready() -> void:
+	$PauseIndictator.hide()
+	var dialog_scene_path :String= DialogicUtil.get_project_setting(
 		'dialogic/editor/test_dialog_scene', 'res://addons/dialogic/Example Assets/ExampleScenes/DefaultDialogNode.tscn')
 	var scene = load(dialog_scene_path).instantiate()
 	add_child(scene)
-	if !get_child(0) is CanvasLayer:
-		if get_child(0) is Control:
-			get_child(0).rect_position = get_viewport_rect().size/2.0
-		if get_child(0) is Node2D:
-			get_child(0).position = get_viewport_rect().size/2.0
+	if scene is CanvasLayer:
+		if scene is Control:
+			scene.rect_position = get_viewport_rect().size/2.0
+		if scene is Node2D:
+			scene.position = get_viewport_rect().size/2.0
 	
 	randomize()
-	var current_timeline = ProjectSettings.get_setting('dialogic/editor/current_timeline_path')
+	var current_timeline :String= ProjectSettings.get_setting('dialogic/editor/current_timeline_path')
 	Dialogic.start_timeline(current_timeline)
 	Dialogic.timeline_ended.connect(get_tree().quit)
 	Dialogic.signal_event.connect(recieve_event_signal)
 	Dialogic.text_signal.connect(recieve_text_signal)
 
-func recieve_event_signal(argument):
+func recieve_event_signal(argument:String) -> void:
 	print("[Dialogic] Encountered a signal event: ", argument)
 
-func recieve_text_signal(argument):
+func recieve_text_signal(argument:String) -> void:
 	print("[Dialogic] Encountered a signal in text: ", argument)
 	
+func _input(event:InputEvent) -> void:
+	if event is InputEventKey and event.pressed and event.keycode == KEY_P:
+		if Dialogic.paused: 
+			Dialogic.resume()
+			$PauseIndictator.hide()
+		else: 
+			Dialogic.pause()
+			$PauseIndictator.show()

--- a/addons/dialogic/Other/TestTimelineScene.tscn
+++ b/addons/dialogic/Other/TestTimelineScene.tscn
@@ -6,3 +6,14 @@
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("1")
+
+[node name="PauseIndictator" type="Label" parent="."]
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -65.0
+offset_top = 7.0
+offset_right = -8.0
+offset_bottom = 33.0
+grow_horizontal = 0
+text = "Paused"
+metadata/_edit_layout_mode = 1


### PR DESCRIPTION
- supposed to fix #1075

This adds pause() and resume() methods to the DialogicGameHandler.
These will propagate down to the Subsystems and set the paused boolean of the DialogicGameHandler.

Pausing is implmented for:
- text/input/voice
- sound/music
- choices (won't trigger when paused)

Making the character animations pause did not yet work, because the portraits themselves are a bit broken a the moment. Also I haven't yet found a good way to get the tweens to pause them.
We can either wait, or fix that in a follow-up PR.

Also adds the ability to pause in the timeline test scene (Play Timeline) with KEY_P. 

Includes some changes to the Subsystem_Voice to have method names in snake_case.