### PR TITLE
2.0 Extra Data on Character Event (#1138)

### DIFF
--- a/addons/dialogic/Events/Character/Subsystem_Portraits.gd
+++ b/addons/dialogic/Events/Character/Subsystem_Portraits.gd
@@ -39,7 +39,7 @@ func _ready():
 ##					MAIN METHODS
 ####################################################################################################
 
-func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int, mirrored: bool = false, z_index: int = 0) -> Node:
+func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:int, mirrored: bool = false, z_index: int = 0, extra_data:String = "") -> Node:
 	var character_node = null
 	
 	if portrait.is_empty():
@@ -64,11 +64,11 @@ func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:in
 	if character_node:
 		dialogic.current_state_info['portraits'][character.resource_path] = {'portrait':portrait, 'node':character_node, 'position_index':position_idx}
 	if portrait:
-		change_portrait(character, portrait, mirrored, z_index)
+		change_portrait(character, portrait, mirrored, z_index, false, extra_data)
 	
 	return character_node
 
-func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool = false, z_index: int = 0, update_zindex:bool = false) -> void:
+func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool = false, z_index: int = 0, update_zindex:bool = false, extra_data:String = "") -> void:
 	if not character or not is_character_joined(character):
 		assert(false, "[Dialogic] Cannot change portrait of null/not joined character.")
 	
@@ -80,7 +80,7 @@ func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool
 	if update_zindex:
 		char_node.z_index = z_index
 	
-	if char_node.get_child_count() and 'does_custom_portrait_change' in char_node.get_child(0) and char_node.get_child(0).does_portrait_change():
+	if char_node.get_child_count() and 'does_custom_portrait_change' in char_node.get_child(0) and char_node.get_child(0).has_method('change_portrait'):
 		char_node.get_child(0).change_portrait(character, portrait)
 	else:
 		# remove previous portrait
@@ -94,16 +94,23 @@ func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool
 			sprite.position.x -= sprite.portrait_width/2.0
 			sprite.position.y -= sprite.portrait_height
 			
-			if sprite.does_portrait_mirror():
-				sprite.mirror_portrait(mirrored)
+			sprite.mirror_portrait(mirrored)
 			
 			char_node.add_child(sprite)
 		else:
 			var sprite = load(path)
 			sprite.position.x -= sprite.portrait_width/2.0
 			sprite.position.y -= sprite.portrait_height
-			if sprite.does_portrait_mirror():
+			
+			if sprite.has_method('change_portrait'):
+				sprite.change_portrait(character, portrait)
+			
+			if sprite.has_method('mirror_portrait'):
 				sprite.mirror_portrait(mirrored)
+				
+			if sprite.has_method('set_portrait_extra_data'):
+				sprite.set_portrait_extra_data(extra_data)
+				
 			char_node.add_child(path)
 	dialogic.current_state_info['portraits'][character.resource_path]['portrait'] = portrait
 

--- a/addons/dialogic/Events/Character/event.gd
+++ b/addons/dialogic/Events/Character/event.gd
@@ -19,13 +19,14 @@ var Z_Index: int = 0
 var Mirrored: bool = false
 var _leave_all:bool = false
 var _update_zindex: bool = false
+var ExtraData: String = ""
 
 func _execute() -> void:
 	match ActionType:
 		ActionTypes.Join:
 			
 			if Character:
-				var n = dialogic.Portraits.add_portrait(Character, Portrait, Position, Mirrored, Z_Index)
+				var n = dialogic.Portraits.add_portrait(Character, Portrait, Position, Mirrored, Z_Index, ExtraData)
 				
 				if AnimationName.is_empty():
 					AnimationName = DialogicUtil.get_project_setting('dialogic/animations/join_default', 
@@ -86,7 +87,7 @@ get_script().resource_path.get_base_dir().plus_file('DefaultAnimations/fade_out_
 		ActionTypes.Update:
 			if Character:
 				if dialogic.Portraits.is_character_joined(Character):
-					dialogic.Portraits.change_portrait(Character, Portrait, Mirrored, Z_Index, _update_zindex)
+					dialogic.Portraits.change_portrait(Character, Portrait, Mirrored, Z_Index, _update_zindex, ExtraData)
 					if Position != 0:
 						dialogic.Portraits.move_portrait(Character, Position, Z_Index, _update_zindex, PositionMoveTime)
 					
@@ -146,7 +147,7 @@ func get_as_string_to_store() -> String:
 	
 	if Position and ActionType != ActionTypes.Leave:
 		result_string += " "+str(Position)
-	if AnimationName != "" || Z_Index != 0 || Mirrored != false || PositionMoveTime != 0.0:
+	if AnimationName != "" || Z_Index != 0 || Mirrored != false || PositionMoveTime != 0.0 || ExtraData != "":
 		result_string += " ["
 		if AnimationName:
 			result_string += 'animation="'+DialogicUtil.pretty_name(AnimationName)+'"'
@@ -167,6 +168,9 @@ func get_as_string_to_store() -> String:
 		
 		if PositionMoveTime != 0:
 			result_string += ' move_time="' + str(PositionMoveTime) + '"'
+		
+		if ExtraData != "":
+			result_string += ' extra_data="' + ExtraData + '"'
 			
 		result_string += "]"
 	return result_string
@@ -237,6 +241,8 @@ func load_from_string_to_store(string:String):
 			Z_Index = 	shortcode_params.get('z-index', 0).to_int()
 			_update_zindex = true 
 		Mirrored = DialogicUtil.str_to_bool(shortcode_params.get('mirrored', 'false'))
+		ExtraData = shortcode_params.get('extra_data', "")
+		
 # RETURN TRUE IF THE GIVEN LINE SHOULD BE LOADED AS THIS EVENT
 func is_valid_event_string(string:String):
 	

--- a/addons/dialogic/Other/DefaultPortrait.gd
+++ b/addons/dialogic/Other/DefaultPortrait.gd
@@ -2,13 +2,14 @@ extends Node
 # Default portrait scene
 # Can be extended for custom portrait scenes, this has the minimum requirements
 
-# The following minimum features should be supported by all portrait scenes:
+# The following minimum features are expected and should be supported by all portrait scenes. They are used for calculating positions:
 # @export var portrait_width: int
 # @export var portrait_height: int
-# func does_portrait_change() -> bool
-#    If the above is returning true: func change_portrait(DialogicCharacter, String) -> void:
-# func does_portrait_mirror() -> bool:
-#    If the above is returning true: func mirror_portrait(mirror:bool) -> void:
+
+# The following methods are verified by has_method calls, and called with the variable types defined here:
+# func change_portrait(DialogicCharacter, String) -> void:
+# func mirror_portrait(bool) -> void:
+# func set_portrait_extra_data(String) -> void:
 
 class_name DialogicDefaultPortrait
 
@@ -20,7 +21,7 @@ var portrait: String
 # This function is needed on every custom portrait scene
 func does_portrait_change() -> bool:
 	return true
-	
+
 # If the custom portrait accepts a change, then accept it here
 func change_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
 	if passed_portrait == "":
@@ -60,11 +61,6 @@ func change_portrait(passed_character:DialogicCharacter, passed_portrait:String)
 
 	portrait_width = $Portrait.texture.get_width() * $Portrait.scale.x
 	portrait_height = $Portrait.texture.get_height() * $Portrait.scale.y
-
-	
-# These are from the separate Join/Update "Mirror" toggles, to override the default mirror
-func does_portrait_mirror() -> bool:
-	return true
 	
 func mirror_portrait(mirror:bool) -> void:
 	if mirror:
@@ -77,3 +73,12 @@ func mirror_portrait(mirror:bool) -> void:
 			$Portrait.flip_h = true
 		else:
 			$Portrait.flip_h = false
+			
+
+# Function to accept and use the extra data, if the custom portrait wants to accept it
+func set_portrait_extra_data(data: String) -> void:
+	# This function can only receive paratmeters on an Update event, but it is called as part of Join
+	# If the extra_data parameter is not set, it will call with "" string, so make sure to handle that properly
+	
+	# As DefaultPortrait does not accept this, and this is a reference example class, we are not doing anything here so it just passes
+	pass


### PR DESCRIPTION
Allows to add a string of information on Join and Update:
`Join Emilio 3 [extra_data="Cool Sword"]`
If you use a custom scene, you can add a method called `func set_portrait_extra_data(data: String) -> void:`
If such a method exists, it will be called with the data as the argument.

This has no editor field for now. Showing it in an advanced mode was considered. It can be used in text-mode.