### PR TITLE
- added the ability to customize the focus property of a choice button.

### DIFF
--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.gd
@@ -129,6 +129,7 @@ onready var n : Dictionary = {
 	# Button modifiers (Inherited scenes)
 	'button_normal': $"VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer/Normal",
 	'button_hover': $"VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer/Hover",
+	'button_focus': $"VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer/Focus",
 	'button_pressed': $"VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer/Pressed",
 	'button_disabled': $"VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer/Disabled",
 	
@@ -234,11 +235,13 @@ func _ready() -> void:
 	# Choice button style modifiers
 	n['button_normal'].connect('picking_background', self, '_on_ButtonTextureButton_pressed')
 	n['button_hover'].connect('picking_background', self, '_on_ButtonTextureButton_pressed')
+	n['button_focus'].connect('picking_background', self, '_on_ButtonTextureButton_pressed')
 	n['button_pressed'].connect('picking_background', self, '_on_ButtonTextureButton_pressed')
 	n['button_disabled'].connect('picking_background', self, '_on_ButtonTextureButton_pressed')
 	
 	n['button_normal'].connect('style_modified', self, '_on_choice_style_modified')
 	n['button_hover'].connect('style_modified', self, '_on_choice_style_modified')
+	n['button_focus'].connect('style_modified', self, '_on_choice_style_modified')
 	n['button_pressed'].connect('style_modified', self, '_on_choice_style_modified')
 	n['button_disabled'].connect('style_modified', self, '_on_choice_style_modified')
 	
@@ -407,6 +410,7 @@ func load_theme(filename):
 	var hover_style = [true, Color( 0.698039, 0.698039, 0.698039, 1 ), false, Color.black, true, default_background, false, Color.white]
 	n['button_normal'].load_style(theme.get_value('buttons', 'normal', default_style))
 	n['button_hover'].load_style(theme.get_value('buttons', 'hover', hover_style))
+	n['button_focus'].load_style(theme.get_value('buttons', 'focus', hover_style))
 	n['button_pressed'].load_style(theme.get_value('buttons', 'pressed', default_style))
 	n['button_disabled'].load_style(theme.get_value('buttons', 'disabled', default_style))
 	

--- a/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
+++ b/addons/dialogic/Editor/ThemeEditor/ThemeEditor.tscn
@@ -1535,6 +1535,15 @@ margin_top = 32.0
 margin_right = -4.0
 margin_bottom = -4.0
 
+[node name="Focus" parent="VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer" instance=ExtResource( 6 )]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 4.0
+margin_top = 32.0
+margin_right = -4.0
+margin_bottom = -4.0
+
 [node name="Pressed" parent="VBoxContainer/TabContainer/Choice Buttons/Column/TabContainer" instance=ExtResource( 6 )]
 visible = false
 anchor_right = 1.0

--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -1198,6 +1198,7 @@ func get_classic_choice_button(label: String):
 	
 	var style_normal = theme.get_value('buttons', 'normal', default_style)
 	var style_hover = theme.get_value('buttons', 'hover', hover_style)
+	var style_focus = theme.get_value('buttons', 'focus', hover_style)
 	var style_pressed = theme.get_value('buttons', 'pressed', default_style)
 	var style_disabled = theme.get_value('buttons', 'disabled', default_style)
 	
@@ -1205,6 +1206,7 @@ func get_classic_choice_button(label: String):
 	var default_color = Color(theme.get_value('text', 'color', '#ffffff'))
 	button.set('custom_colors/font_color', default_color)
 	button.set('custom_colors/font_color_hover', default_color.lightened(0.2))
+	button.set('custom_colors/font_color_focus', default_color.lightened(0.2))
 	button.set('custom_colors/font_color_pressed', default_color.darkened(0.2))
 	button.set('custom_colors/font_color_disabled', default_color.darkened(0.8))
 	
@@ -1212,6 +1214,8 @@ func get_classic_choice_button(label: String):
 		button.set('custom_colors/font_color', style_normal[1])
 	if style_hover[0]:
 		button.set('custom_colors/font_color_hover', style_hover[1])
+	if style_focus[0]:
+		button.set('custom_colors/font_color_focus', style_focus[1])
 	if style_pressed[0]:
 		button.set('custom_colors/font_color_pressed', style_pressed[1])
 	if style_disabled[0]:
@@ -1221,6 +1225,7 @@ func get_classic_choice_button(label: String):
 	# Style normal
 	button_style_setter('normal', style_normal, button, theme)
 	button_style_setter('hover', style_hover, button, theme)
+	button_style_setter('focus', style_focus, button, theme)
 	button_style_setter('pressed', style_pressed, button, theme)
 	button_style_setter('disabled', style_disabled, button, theme)
 	return button


### PR DESCRIPTION
At the moment there is no possibility to customize the "focus" property of the choice buttons. This is important for situations where the game is not controlled mainly by mouse, which relies on the hover property. 

With this simple implementation and having the "Autofocus choice buttons" active in the settings it is possible to customize these buttons appearance upon getting focus, this feature is mainly targeted for controller and keyboard inputs. 