### PR TITLE
Multiple bug fixes + Background Fade improvements

### DIFF
--- a/addons/dialogic/Events/Background/Subsystem_Backgrounds.gd
+++ b/addons/dialogic/Events/Background/Subsystem_Backgrounds.gd
@@ -18,25 +18,34 @@ func update_background(path:String = '', fade_time:float = 0.0) -> void:
 	dialogic.current_state_info['background'] = path
 	for node in get_tree().get_nodes_in_group('dialogic_bg_image'):
 		if node.is_visible_in_tree():
-			for child in node.get_children():
-				child.queue_free()
-				
-			# Custom scene's will need to support their own fades
-			# We should probably make a signal here to send into them with the data if they want to use it
-			if path.ends_with('.tscn'):
-				node.add_child(load(path).instantiate())
 			
-			elif fade_time > 0: 
-				node.add_child(node.duplicate())
-				node.texture = load(path)
-				for child in node.get_children():
-					var tween = child.create_tween()
-					tween.tween_property(child, "modulate", Color.TRANSPARENT, fade_time)
-					tween.tween_callback(child.queue_free)
+			# remove previous backgrounds
+			for old_bg in node.get_children():
+				if old_bg.has_method('_fade_out'):
+					old_bg._fade_out(fade_time)
+				elif "modulate" in old_bg:
+					var tween = old_bg.create_tween()
+					tween.tween_property(old_bg, "modulate", Color.TRANSPARENT, fade_time)
+					tween.tween_callback(old_bg.queue_free)
+				else:
+					old_bg.queue_free()
+			
+			var new_node
+			if path.ends_with('.tscn'):
+				new_node = load(path).instantiate()
+			elif File.file_exists(path):
+				new_node = node.duplicate()
+				new_node.texture = load(path)
+			else:
+				new_node = null
+			
+			if new_node:
+				node.add_child(new_node)
 				
-			else:	
-				node.texture = null
-				if not path.is_empty():
-					node.texture = load(path)
+				if new_node.has_method('_fade_in'):
+					new_node._fade_in(fade_time)
 					
-
+				elif "modulate" in new_node:
+					new_node.modulate = Color.TRANSPARENT
+					var tween = new_node.create_tween()
+					tween.tween_property(new_node, "modulate", Color.WHITE, fade_time)

--- a/addons/dialogic/Events/Text/Display_DialogText.gd
+++ b/addons/dialogic/Events/Text/Display_DialogText.gd
@@ -24,6 +24,7 @@ func _ready() -> void:
 	add_to_group('dialogic_dialog_text')
 	
 	bbcode_enabled = true
+	text = ""
 	
 	# setup my timer
 	timer = Timer.new()

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -116,7 +116,8 @@ func handle_event(event_index:int) -> void:
 	#print("\n[D] Handle Event ", event_index, ": ", event)
 	if current_timeline_events[event_index].continue_at_end:
 		#print("    -> WILL AUTO CONTINUE!")
-		current_timeline_events[event_index].event_finished.connect(handle_next_event, CONNECT_ONESHOT)
+		if not current_timeline_events[event_index].event_finished.is_connected(handle_next_event):
+			current_timeline_events[event_index].event_finished.connect(handle_next_event, CONNECT_ONESHOT)
 	current_timeline_events[event_index].execute(self)
 	emit_signal('event_handled', current_timeline_events[event_index])
 


### PR DESCRIPTION
- Fix for #1167
Will just reset the text of the dialog text in _ready()

- Fix for #1188 + Background Fade improvements
Fade now works on the first event. Also you can node implement _fade_in(*time) and _fade_out(*time) on your custom background scenes.

- Fix for #1166
Added a is_conected() check before connecting

Edit: accidently tagged a user named time.