### PR TITLE
Speaking_Character Signal

### DIFF
--- a/addons/dialogic/Events/Text/Subsystem_Text.gd
+++ b/addons/dialogic/Events/Text/Subsystem_Text.gd
@@ -5,6 +5,7 @@ var character_colors := {}
 var color_regex := RegEx.new()
 
 signal text_finished
+signal speaking_character(argument)
 
 ####################################################################################################
 ##					STATE
@@ -60,10 +61,12 @@ func update_name_label(character:DialogicCharacter) -> void:
 				name_label.text = character.display_name
 			if !'use_character_color' in name_label or name_label.use_character_color:
 				name_label.self_modulate = character.color
+			speaking_character.emit(name_label.text)
 		else:
 			dialogic.current_state_info['character'] = null
 			name_label.text = ''
 			name_label.self_modulate = Color(1,1,1,1)
+			speaking_character.emit("(Nobody)")
 
 func update_typing_sound_mood(mood:Dictionary = {}) -> void:
 	for typing_sound in get_tree().get_nodes_in_group('dialogic_type_sounds'):


### PR DESCRIPTION
Adds a signal `speaking_character` to the Text subsystem. Sends the current display name of a Text event's character to the signal, or "(Nobody)" if there's not any character on that event. 

Purpose is to allow a game to listen for that event and do something with it, if they choose. For example, using multiple text boxes for different characters in a 2D/3D game that are positioned with that character, without any manipulation of themes in the timeline.