### PR TITLE
Fix for allowing character resources to be saved.

### DIFF
--- a/addons/dialogic/Resources/CharacterResourceSaver.gd
+++ b/addons/dialogic/Resources/CharacterResourceSaver.gd
@@ -20,8 +20,7 @@ func _recognize(resource: Resource) -> bool:
 
 # Save the resource
 func _save(resource: Resource, path: String = '', flags: int = 0):
-	if FileAccess.file_exists(path):
-		var file := FileAccess.open(path, FileAccess.READ)
-		var result := var_to_str(inst_to_dict(resource))
-		file.store_string(result)
-		print('[Dialogic] Saved character "' , path, '"')
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	var result := var_to_str(inst_to_dict(resource))
+	file.store_string(result)
+	print('[Dialogic] Saved character "' , path, '"')


### PR DESCRIPTION
There were two issues with character saving:
  * There was a check to see if the file exists first, resulting in new files never being created
  * The files were opened in READ mode instead of WRITE