### PR TITLE
Timeline Saving Fixes (Again)

### DIFF
--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -29,6 +29,7 @@ func _save(resource: Resource, path: String = '', flags: int = 0) -> int:
 			print('[Dialogic] Saving timeline...')
 			if FileAccess.file_exists(path):
 				var file := FileAccess.open(path, FileAccess.WRITE)
+				var file := FileAccess.open(path, FileAccess.READ_WRITE)
 				
 				#var result = events_to_text(resource.events)
 				var result := ""
@@ -75,7 +76,7 @@ func _save(resource: Resource, path: String = '', flags: int = 0) -> int:
 			printerr(path + ": Timeline was not in ready state for saving! Timeline was not saved!")
 			return ERR_INVALID_DATA
 	else:
-		var file := FileAccess.open(path, FileAccess.WRITE)
+		var file := FileAccess.open(path, FileAccess.READ_WRITE)
 		return OK
 
 func update_translations(path:String, translation_updates:Dictionary):


### PR DESCRIPTION
Timelines started blanking out again, so this is to fix that issue. Also found a few other issues with saving as well, as well as loading, so I'll get them fixed in here.

It appears that part of the problem, and the solution in this initial commit, might actually be a Godot bug with the Enum's not acting properly. I'll have to play with it more to try and figure that out. So that fix might be temporary.