### PR TITLE
Fixes for Conditions

### DIFF
--- a/addons/dialogic/Editor/Events/EventNode/EventNode.gd
+++ b/addons/dialogic/Editor/Events/EventNode/EventNode.gd
@@ -136,6 +136,7 @@ func _on_Indent_visibility_changed():
 
 
 func _request_selection():
+	# TODO doesn't work. I'm sure - JS
 	var timeline_editor = editor_reference.get_node_or_null('MainPanel/TimelineEditor')
 	if (timeline_editor != null):
 		# @todo select item and clear selection is marked as "private" in TimelineEditor.gd
@@ -154,7 +155,7 @@ func focus():
 func toggle_collapse(toggled):
 	collapsed = toggled
 	$PanelContainer/MarginContainer/VBoxContainer/CollapsedBody.visible = toggled
-	var timeline_editor = find_parent('TimelineEditor')
+	var timeline_editor = find_parent('TimelineVisualEditor')
 	if (timeline_editor != null):
 		# @todo select item and clear selection is marked as "private" in TimelineEditor.gd
 		# consider to make it "public" or add a public helper function

--- a/addons/dialogic/Editor/Events/Fields/ConditionPicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/ConditionPicker.gd
@@ -83,13 +83,17 @@ func is_too_complex(condition:String) -> bool:
 func complex2simple(condition:String) -> Array:
 	if is_too_complex(condition) or condition.strip_edges().is_empty():
 		return ['', '==','']
-	return Array(condition.split(' ', false))
+	var cond_split = Array(condition.split(' ', false))
+	if cond_split[2].begins_with('"'): cond_split[2] = cond_split[2].trim_prefix('"').trim_suffix('"')
+	return cond_split
 
 func simple2complex(value1, operator, value2) -> String:
 	if value1 == null: value1 = ''
 	if value1.is_empty():
 		return ''
 	if value2 == null: value2 = ''
+	if !value2.is_valid_float() and !value2.begins_with('{'):
+		value2 = '"'+value2+'"'
 	return value1 +" "+ operator +" "+ value2
 
 func _on_toggle_complex_toggled(button_pressed) -> void:

--- a/addons/dialogic/Editor/VisualEditor/VisualEditor.gd
+++ b/addons/dialogic/Editor/VisualEditor/VisualEditor.gd
@@ -132,6 +132,7 @@ func load_timeline(object) -> void:
 	current_timeline.set_meta("timeline_not_saved", false)
 	
 	
+	_building_timeline = true
 	
 	if current_timeline.events.size() == 0:
 		pass
@@ -936,6 +937,7 @@ func indent_events() -> void:
 				indent += 1
 		
 		if event.resource is DialogicEndBranchEvent:
+			event.parent_node_changed()
 			delayed_indent -= 1
 			if event.parent_node.resource.needs_parent_event:
 				delayed_indent -= 1

--- a/addons/dialogic/Events/Condition/Condition_End.gd
+++ b/addons/dialogic/Events/Condition/Condition_End.gd
@@ -9,13 +9,27 @@ func _ready():
 
 func refresh():
 	if parent_resource is DialogicConditionEvent:
-		show()
-		$Label.text = "End of IF ("+parent_resource.Condition+")"
+		# hide add elif and add else button on ELSE event
+		$AddElif.visible = parent_resource.ConditionType != DialogicConditionEvent.ConditionTypes.ELSE
+		$AddElse.visible = parent_resource.ConditionType != DialogicConditionEvent.ConditionTypes.ELSE
+		$Label.text = "End of "+["IF", "ELIF", "ELSE"][parent_resource.ConditionType]+" ("+parent_resource.Condition+")"
+		
+		# hide add add else button if followed by ELIF or ELSE event
+		var timeline_editor = find_parent('TimelineVisualEditor')
+		if timeline_editor:
+			var next_event = null
+			if timeline_editor.get_block_below(get_parent()):
+				next_event = timeline_editor.get_block_below(get_parent()).resource
+				if next_event is DialogicConditionEvent:
+					if next_event.ConditionType != DialogicConditionEvent.ConditionTypes.IF:
+						$AddElse.hide()
+		if parent_resource.ConditionType == DialogicConditionEvent.ConditionTypes.ELSE:
+			$Label.text = "End of ELSE"
 	else:
 		hide()
 
 func add_elif():
-	var timeline = find_parent('TimelineEditor')
+	var timeline = find_parent('TimelineVisualEditor')
 	if timeline:
 		var resource = DialogicConditionEvent.new()
 		resource.ConditionType = DialogicConditionEvent.ConditionTypes.ELIF
@@ -23,7 +37,7 @@ func add_elif():
 		timeline.indent_events()
 
 func add_else():
-	var timeline = find_parent('TimelineEditor')
+	var timeline = find_parent('TimelineVisualEditor')
 	if timeline:
 		var resource = DialogicConditionEvent.new()
 		resource.ConditionType = DialogicConditionEvent.ConditionTypes.ELSE


### PR DESCRIPTION
Conditions with strings should not fail anymore. They require to be put in quotationmarks though which the visual editor will do if you entered a string.

 Also the AddElif and AddElse buttons work again. Also they now hide if the event is of type ELSE and the Add Else button is hidden if the next event is a ELIF or ELSE event. I hope these checks are not to intensive, as they have to be done everytime indentation is done.

- should fix #1258 and #1178