### PR TITLE
Timeline Jump Stack

### DIFF
--- a/addons/dialogic/Events/Jump/event.gd
+++ b/addons/dialogic/Events/Jump/event.gd
@@ -6,10 +6,13 @@ class_name DialogicJumpEvent
 var Timeline :DialogicTimeline = null :
 	set = _set_timeline
 var LabelName : String = ""
+var Return: bool = false
 var _timeline_file: String = ""
 var _timeline_loaded: bool = false
 
 func _execute() -> void:
+	if Return:
+		dialogic.push_to_jump_stack()
 	if Timeline and Timeline != dialogic.current_timeline:
 		#print("---------------switching timelines----------------")
 		dialogic.start_timeline(Timeline, LabelName)
@@ -51,6 +54,7 @@ func get_shortcode_parameters() -> Dictionary:
 		#param_name : property_name
 		"timeline"	: "_timeline_file",
 		"label"		: "LabelName",
+		"return"	: "Return"
 	}
 
 func load_timeline() -> void:
@@ -72,6 +76,7 @@ func build_event_editor():
 		'empty_text': '(this timeline)'
 	})
 	add_header_edit("LabelName", ValueType.SinglelineText, "at", '', {'placeholder':'the beginning'})
+	add_body_edit("Return", ValueType.Bool, "Return to this spot after completed?")
 #	add_header_edit('LabelName', ValueType.ComplexPicker, 'at', '', {
 #		'suggestions_func': get_label_suggestions,
 #		'editor_icon': ['Label', 'EditorIcons'],

--- a/addons/dialogic/Events/Jump/event.gd
+++ b/addons/dialogic/Events/Jump/event.gd
@@ -6,12 +6,12 @@ class_name DialogicJumpEvent
 var Timeline :DialogicTimeline = null :
 	set = _set_timeline
 var LabelName : String = ""
-var Return: bool = false
+var ReturnAfter: bool = false
 var _timeline_file: String = ""
 var _timeline_loaded: bool = false
 
 func _execute() -> void:
-	if Return:
+	if ReturnAfter:
 		dialogic.push_to_jump_stack()
 	if Timeline and Timeline != dialogic.current_timeline:
 		#print("---------------switching timelines----------------")
@@ -54,7 +54,7 @@ func get_shortcode_parameters() -> Dictionary:
 		#param_name : property_name
 		"timeline"	: "_timeline_file",
 		"label"		: "LabelName",
-		"return"	: "Return"
+		"return_after"	: "ReturnAfter"
 	}
 
 func load_timeline() -> void:

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -144,7 +144,7 @@ func push_to_jump_stack() -> void:
 	timeline_jump_stack.push_front(current_point)
 
 func pop_from_jump_stack() -> void:
-	var stack_point = timeline_jump_stack.pop_front()
+	var stack_point:Dictionary = timeline_jump_stack.pop_front()
 	current_timeline = stack_point['timeline']
 	current_timeline_events = current_timeline.get_events()
 	current_event_idx = stack_point['index']

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -4,6 +4,7 @@ enum states {IDLE, SHOWING_TEXT, ANIMATING, AWAITING_CHOICE, WAITING}
 
 var current_timeline: Variant = null
 var current_timeline_events: Array = []
+var timeline_jump_stack: Array = []
 var character_directory: Dictionary = {}
 var timeline_directory: Dictionary = {}
 var _event_script_cache: Array = []
@@ -101,8 +102,12 @@ func handle_event(event_index:int) -> void:
 		return
 	
 	if event_index >= len(current_timeline_events):
-		end_timeline()
-		return
+		if timeline_jump_stack.size() > 0:
+			pop_from_jump_stack()
+			event_index = current_event_idx+1
+		else:
+			end_timeline()
+			return
 	
 	#actually process the event now, since we didnt earlier at runtime
 	#this needs to happen before we create the copy DialogicEvent variable, so it doesn't throw an error if not ready
@@ -132,6 +137,18 @@ func jump_to_label(label:String) -> void:
 			break
 	current_event_idx = idx
 
+func push_to_jump_stack() -> void:
+	var current_point:Dictionary = {}
+	current_point['timeline'] = current_timeline 
+	current_point['index'] = current_event_idx
+	timeline_jump_stack.push_front(current_point)
+
+func pop_from_jump_stack() -> void:
+	var stack_point = timeline_jump_stack.pop_front()
+	current_timeline = stack_point['timeline']
+	current_timeline_events = current_timeline.get_events()
+	current_event_idx = stack_point['index']
+	
 
 func clear() -> bool:
 	for subsystem in get_children():

--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -44,7 +44,7 @@ func remove_event(position:int) -> void:
 func get_event(index):
 	if index >= len(events):
 		return null
-	return events[index].duplicate()
+	return events[index]
 
 
 func get_events() -> Array:


### PR DESCRIPTION
Adds a stack for timeline jumping, and option on the Jump event to return to the timeline after completing the timeline jumped to. Once reaching the end of a timeline, it will check the stack, and take the top one off if there's still more on the stack, and only call end_timeline() once the stack is empty

For example, take the following three timelines:
![image](https://user-images.githubusercontent.com/2214793/197437093-1c150421-16c4-4951-bda5-b6cd6eea72ee.png)
![image](https://user-images.githubusercontent.com/2214793/197437125-bcf5e603-f8ce-4cb9-81f7-9349cc2fd935.png)
![image](https://user-images.githubusercontent.com/2214793/197437163-35e13fde-0789-45c4-930f-03f9d94a423a.png)


Running the timeline from sub1.dtl will then have the timleine events play in this order:

base 1

base 2

sub 1

sub 2

sub sub 1

sub sub 2

sub sub 3

sub sub 4

sub 3

sub 4

base 3

base 4

