### PR TITLE
Fix autocoloring

### DIFF
--- a/addons/dialogic/Events/Text/Subsystem_Text.gd
+++ b/addons/dialogic/Events/Text/Subsystem_Text.gd
@@ -140,5 +140,4 @@ func update_character_names() -> void:
 			if nickname.strip_edges():
 				character_colors[nickname.strip_edges()] = dch.color
 	
-	color_regex.compile('(?<=\\W)(?<name>'+str(character_colors.keys()).trim_prefix('[').trim_suffix(']').replace(', ', '|')+')(?=\\W|$)')
-	
+	color_regex.compile('(?<=\\W)(?<name>'+str(character_colors.keys()).trim_prefix('["').trim_suffix('"]').replace('", "', '|')+')(?=\\W|$)')


### PR DESCRIPTION
Converting an array to a string now adds " to all strings, so I had to remove them from the regex.

 - Should fix #1276 