### PR TITLE
Fixes for Timeline End and Timeline Start

### DIFF
--- a/addons/dialogic/Nodes/DialogNode.gd
+++ b/addons/dialogic/Nodes/DialogNode.gd
@@ -82,6 +82,7 @@ signal event_end(type)
 signal text_complete(text_data)
 # Timeline end/start
 signal timeline_start(timeline_name)
+signal timeline_changed(old_timeline_name, new_timeline_name)
 signal timeline_end(timeline_name)
 # Custom user signal
 signal dialogic_signal(value)
@@ -1030,6 +1031,8 @@ func event_handler(event: Dictionary):
 				
 func change_timeline(timeline):
 	dialog_script = set_current_dialog(timeline)
+	emit_signal("timeline_changed", timeline_name, dialog_script['metadata']['name'])
+	timeline_name = dialog_script['metadata']['name']
 	_init_dialog()
 
 

--- a/addons/dialogic/Nodes/DialogProxy.gd
+++ b/addons/dialogic/Nodes/DialogProxy.gd
@@ -33,6 +33,7 @@ var _signals_to_copy = [
 	'text_complete',
 	'timeline_start',
 	'timeline_end',
+	'timeline_changed',
 	'dialogic_signal',
 	'letter_displayed',
 	'auto_advance_toggled',
@@ -48,6 +49,7 @@ signal text_complete(text_data)
 # Timeline end/start
 signal timeline_start(timeline_name)
 signal timeline_end(timeline_name)
+signal timeline_changed(old_timeline_name, new_timeline_name)
 # Custom user signal
 signal dialogic_signal(value)
 signal letter_displayed(lastLetter)

--- a/addons/dialogic/Nodes/canvas_dialog_node.gd
+++ b/addons/dialogic/Nodes/canvas_dialog_node.gd
@@ -10,6 +10,7 @@ signal event_end(type)
 # Timeline end/start
 signal timeline_start(timeline_name)
 signal timeline_end(timeline_name)
+signal timeline_changed(old_timeline_name, new_timeline_name)
 signal text_complete(text_event)
 # Custom user signal
 signal dialogic_signal(value)
@@ -32,6 +33,8 @@ func set_dialog_node_scene(scene) -> void:
 		_err = dialog_node.connect("timeline_start", self, "_on_timeline_start")
 		assert(_err == OK)
 		_err = dialog_node.connect("timeline_end", self, "_on_timeline_end")
+		assert(_err == OK)
+		_err = dialog_node.connect("timeline_changed", self, "_on_timeline_changed")
 		assert(_err == OK)
 		_err = dialog_node.connect("text_complete", self, "_on_text_complete")
 		assert(_err == OK)
@@ -65,6 +68,10 @@ func _on_event_start(type, event) -> void:
 
 func _on_event_end(type) -> void:
 	emit_signal("event_end", type)
+
+
+func _on_timeline_changed(old_timeline_name, new_timeline_name) -> void:
+	emit_signal("timeline_changed", old_timeline_name, new_timeline_name)
 
 
 func _on_timeline_start(timeline_name) -> void:


### PR DESCRIPTION
**timeline_end** and **timeline_start** now appropriately recognize when a timeline change event occurs and update their output appropriately.

Added **timeline_changed** signal. 
**timeline_changed** fires when a Change Timeline Event occurs, and returns the old timeline and the new timeline in that order