### PR TITLE
get_saved_definitions() new loop function to add / delete default definitions

### DIFF
--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -416,9 +416,51 @@ static func get_saved_definitions(save_name: String = '') -> Dictionary:
 		print("[D] Wasn't able to find save '"+save_name+"'. Loaded the default definitions.")
 		return get_default_definitions()
 	
-	return load_json(WORKING_DIR+"/"+save_name+"/definitions.json", {})
+#	return load_json(WORKING_DIR+"/"+save_name+"/definitions.json", {})
 
+	var default_definitions : Dictionary = get_default_definitions()
 
+	var saved_definitions : Dictionary = {}
+
+	if save_name == '':
+		saved_definitions = load_json(get_config_files_paths()['DEFINITIONS_DEFAULT_SAVE'], default_definitions)
+		print("empty save slot, loaded saved definition from default save definitions")
+
+	else:
+		saved_definitions = load_json(WORKING_DIR+"/"+save_name+"/definitions.json", {})
+		print("saved user definitions on ''user://'' loaded")
+	
+	# Store variables in arrays from saved and default data
+	var base_def_var = default_definitions.variables
+	var saved_user_def_var = saved_definitions.variables
+
+	#filler out depreciated variables
+	var distilled_saved_data: Array = []
+	for sd in saved_user_def_var:
+		var sd_id = sd.id
+		var bd_id
+		for bd in base_def_var:
+			bd_id = bd.id
+			if sd_id == bd_id:
+				distilled_saved_data.append (sd)
+
+	#adds missing new variables not in saved game
+	for dd in base_def_var:
+		var dd_id = dd.id
+		var sd_id
+		for sd in distilled_saved_data:
+			var sd_keys = sd.id
+			if dd_id == sd_keys:
+				sd_id = sd_keys
+		if dd_id == sd_id:
+			pass
+		else:
+			distilled_saved_data.append (dd)
+
+	#adds it back distilled data into main Saved Definitions
+	saved_definitions.variables = distilled_saved_data
+
+	return saved_definitions
 
 ## *****************************************************************************
 ##						FOLDER STRUCTURE

--- a/addons/dialogic/Other/DialogicResources.gd
+++ b/addons/dialogic/Other/DialogicResources.gd
@@ -327,6 +327,12 @@ static func delete_default_definition(id: String):
 static func get_saves_folders() -> Array:
 	var save_folders = []
 	var directory := Directory.new()
+	if (OS.get_name() == "HTML5"):
+		if (OS.has_feature("JavaScript")):	
+			directory.make_dir(WORKING_DIR)
+			print("get saves fold func: got working dir ", WORKING_DIR)
+		else:
+			printerr("JavaScript not enabled")
 	if directory.open(WORKING_DIR) != OK:
 		print("[D] Error: Failed to access working directory.")
 		return []


### PR DESCRIPTION
commit = 56ca167

**Dialogic 1.4.5+**
Additional functions added to get_save_definitions()
Helps games already published to be able to expand dialogic vn game by:
Adding new default variables, and deleting depreciated default variables (which help function's loop speed).

Addresses issue #1278, and would close it.