### PR TITLE
Add a few improvements to the text editor

### DIFF
--- a/addons/dialogic/Editor/TextEditor/TextEditor.gd
+++ b/addons/dialogic/Editor/TextEditor/TextEditor.gd
@@ -18,6 +18,19 @@ func _on_text_editor_text_changed():
 	current_timeline.set_meta("timeline_not_saved", true)
 
 
+func _gui_input(event):
+	if not event is InputEventKey: return
+	if not event.is_pressed(): return
+	
+	match event.as_text():
+		"Ctrl+K":
+			toggle_comment()
+		"Alt+Up":
+			move_line(-1)
+		"Alt+Down":
+			move_line(1)
+
+
 func _exit_tree():
 	# Explicitly free any open cache resources on close, so we don't get leaked resource errors on shutdown
 	current_timeline = null
@@ -52,11 +65,11 @@ func load_timeline(object:DialogicTimeline) -> void:
 			continue
 		
 		if event != null:
-			result += "\t".repeat(indent)+event['event_node_as_text'].replace('\n', "\n"+"\t".repeat(indent)) + "\n"
+			result += "\t".repeat(indent) + event['event_node_as_text'].replace('\n', "\n" + "\t".repeat(indent)) + "\n"
 		if event.can_contain_events:
 			indent += 1
-		if indent < 0: indent = 0
-		result += "\t".repeat(indent)+"\n"
+		if indent < 0: 
+			indent = 0
 		
 	text = result
 	current_timeline.set_meta("timeline_not_saved", false)
@@ -93,21 +106,42 @@ func save_timeline():
 func add_highlighting():
 	# This is a dumpster fire, so hopefully it will be improved during beta?
 	var editor_settings = DialogicUtil.get_dialogic_plugin().editor_interface.get_editor_settings()
+	
+	var keywords_color: Color = editor_settings.get('text_editor/theme/highlighting/keyword_color')
+	var functions_color: Color = editor_settings.get('text_editor/theme/highlighting/function_color')
+	var strings_color: Color = editor_settings.get('text_editor/theme/highlighting/string_color')
+	var numbers_color: Color = editor_settings.get("text_editor/theme/highlighting/number_color")
+	var types_color: Color = editor_settings.get('text_editor/theme/highlighting/engine_type_color')
+	var jumps_color: Color = editor_settings.get("text_editor/theme/highlighting/control_flow_keyword_color")
+	var symbols_color: Color = editor_settings.get('text_editor/theme/highlighting/text_color')
+	var text_color: Color = editor_settings.get('text_editor/theme/highlighting/text_color')
+	var comments_color: Color = editor_settings.get('text_editor/theme/highlighting/comment_color')
+	
 	var s := CodeHighlighter.new()
+	
 	s.color_regions = {
-		'[ ]': editor_settings.get('text_editor/theme/highlighting/function_color'),
-		'< >': editor_settings.get('text_editor/theme/highlighting/function_color'),
-		'" "': editor_settings.get('text_editor/theme/highlighting/string_color'),
-		'{ }': editor_settings.get('text_editor/theme/highlighting/engine_type_color'),
+		'[ ]': functions_color,
+		'< >': functions_color,
+		'" "': strings_color,
+		'{ }': types_color
 	}
-	#s.keyword_colors = {
-	#	'jump': Color('#00abc7')
-	#}
-	s.symbol_color = editor_settings.get('text_editor/theme/highlighting/text_color')
-	s.number_color = editor_settings.get('text_editor/theme/highlighting/text_color')
-	s.member_variable_color = editor_settings.get('text_editor/theme/highlighting/text_color')
-	s.function_color = editor_settings.get('text_editor/theme/highlighting/text_color')
-	s.add_color_region('- ', '', editor_settings.get('text_editor/theme/highlighting/engine_type_color'), true)
+	s.add_color_region('- ', '', types_color, true)
+	s.add_color_region('# ', '', comments_color, true)
+	s.add_color_region(': ', '', text_color, true)
+	
+	s.keyword_colors = {
+		"if": keywords_color,
+		"elif": keywords_color,
+		"else": keywords_color,
+		"and": keywords_color,
+		"or": keywords_color
+	}
+
+	s.symbol_color = symbols_color
+	s.number_color = numbers_color
+	s.member_variable_color = text_color
+	s.function_color = text_color
+	
 	set('syntax_highlighter', s)
 
 
@@ -157,4 +191,57 @@ func text_timeline_to_array(text:String) -> Array:
 	return events
 
 
+# Toggle the selected lines as comments
+func toggle_comment() -> void:
+	var cursor: Vector2 = Vector2(get_caret_column(), get_caret_line())
+	var from: int = cursor.y
+	var to: int = cursor.y
+	if has_selection():
+		from = get_selection_from_line()
+		to = get_selection_to_line()
+	
+	var lines: PackedStringArray = text.split("\n")
+	var will_comment: bool = not lines[from].begins_with("# ")
+	for i in range(from, to + 1):
+		lines[i] = "# " + lines[i] if will_comment else lines[i].substr(2)
+	
+	text = "\n".join(lines)
+	select(from, 0, to, get_line_width(to))
+	set_caret_line(cursor.y)
+	set_caret_column(cursor.x)
+	text_changed.emit()
 
+
+# Move the selected lines up or down
+func move_line(offset: int) -> void:
+	offset = clamp(offset, -1, 1)
+	
+	var cursor: Vector2 = Vector2(get_caret_column(), get_caret_line())
+	var reselect: bool = false
+	var from: int = cursor.y
+	var to: int = cursor.y
+	if has_selection():
+		reselect = true
+		from = get_selection_from_line()
+		to = get_selection_to_line()
+	
+	var lines := text.split("\n")
+	
+	if from + offset < 0 or to + offset >= lines.size(): return
+	
+	var target_from_index: int = from - 1 if offset == -1 else to + 1
+	var target_to_index: int = to if offset == -1 else from
+	var line_to_move: String = lines[target_from_index]
+	lines.remove_at(target_from_index)
+	lines.insert(target_to_index, line_to_move)
+	
+	text = "\n".join(lines)
+	
+	cursor.y += offset
+	from += offset
+	to += offset
+	if reselect:
+		select(from, 0, to, get_line_width(to))
+	set_caret_line(cursor.y)
+	set_caret_column(cursor.x)
+	text_changed.emit()

--- a/addons/dialogic/Editor/TextEditor/TextEditor.tscn
+++ b/addons/dialogic/Editor/TextEditor/TextEditor.tscn
@@ -2,26 +2,36 @@
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/TextEditor/TextEditor.gd" id="1_1kbx2"]
 
-[sub_resource type="CodeHighlighter" id="CodeHighlighter_vs5bt"]
-number_color = Color(0.8025, 0.81, 0.8225, 1)
-symbol_color = Color(0.8025, 0.81, 0.8225, 1)
-function_color = Color(0.8025, 0.81, 0.8225, 1)
-member_variable_color = Color(0.8025, 0.81, 0.8225, 1)
+[sub_resource type="CodeHighlighter" id="CodeHighlighter_q5u0f"]
+number_color = Color(0.741176, 0.576471, 0.976471, 1)
+symbol_color = Color(0.972549, 0.972549, 0.94902, 1)
+function_color = Color(0.972549, 0.972549, 0.94902, 1)
+member_variable_color = Color(0.972549, 0.972549, 0.94902, 1)
+keyword_colors = {
+"and": Color(1, 0.47451, 0.776471, 1),
+"elif": Color(1, 0.47451, 0.776471, 1),
+"else": Color(1, 0.47451, 0.776471, 1),
+"if": Color(1, 0.47451, 0.776471, 1),
+"or": Color(1, 0.47451, 0.776471, 1)
+}
 color_regions = {
-"\" \"": Color(1, 0.93, 0.63, 1),
-"- ": Color(0.56, 1, 0.86, 1),
-"< >": Color(0.34, 0.7, 1, 1),
-"[ ]": Color(0.34, 0.7, 1, 1),
-"{ }": Color(0.56, 1, 0.86, 1)
+"\" \"": Color(0.945098, 0.980392, 0.54902, 1),
+"# ": Color(0.384314, 0.447059, 0.643137, 1),
+"- ": Color(0.545098, 0.913725, 0.992157, 1),
+": ": Color(0.972549, 0.972549, 0.94902, 1),
+"< >": Color(0.545098, 0.913725, 0.992157, 1),
+"[ ]": Color(0.545098, 0.913725, 0.992157, 1),
+"{ }": Color(0.545098, 0.913725, 0.992157, 1)
 }
 
 [node name="TimelineTextEditor" type="CodeEdit"]
 offset_top = 592.0
 offset_right = 1024.0
 offset_bottom = 600.0
+theme_override_constants/line_spacing = 10
 highlight_current_line = true
 draw_tabs = true
-syntax_highlighter = SubResource("CodeHighlighter_vs5bt")
+syntax_highlighter = SubResource("CodeHighlighter_q5u0f")
 minimap_draw = true
 caret_blink = true
 line_folding = true


### PR DESCRIPTION
This PR adds a couple of keyboard shortcuts for toggling comments and moving selected lines up and down. 

It also adds extra syntax highlighting and replaces the literal newline spacing with line spacing in the text editor itself.
    
![syntax-with-spacing](https://user-images.githubusercontent.com/78984/203057822-6f44c9dc-cceb-4754-994b-0edaf3637990.jpg)
