### PR TITLE
Fixed Speed tag resolve in HistoryRow

### DIFF
--- a/addons/dialogic/Example Assets/History/HistoryRow.gd
+++ b/addons/dialogic/Example Assets/History/HistoryRow.gd
@@ -29,6 +29,9 @@ func _ready():
 
 
 func add_history(historyString, newAudio=''):
+	var regex = RegEx.new()
+	regex.compile("\\[\\s{0,}speed\\s{0,}\\=\\s{0,}\\d{0,}\\s{0,}\\]")
+	historyString = regex.sub(historyString, "")
 	TextLabel.append_bbcode(historyString)
 	audioPath = newAudio
 	if newAudio != '':

--- a/addons/dialogic/Nodes/History.gd
+++ b/addons/dialogic/Nodes/History.gd
@@ -222,7 +222,11 @@ func add_history_row_event(eventData):
 	# event logging handled here
 	# Text Events, replacing br with linebreaks
 	if eventData.event_id == 'dialogic_001':
-		newHistoryRow.add_history(str(characterPrefix, eventData.text.replace('[br]', '\n')), audioData)
+		eventData.text = eventData.text.replace('[br]', '\n')
+		var regex = RegEx.new()
+		regex.compile("\\[[^\\]]{0,}speed[^\\]]{0,}\\]")
+		eventData.text = regex.sub(eventData.text, "")
+		newHistoryRow.add_history(str(characterPrefix, eventData.text), audioData)
 	# Character Arrivals
 	elif eventData.event_id == 'dialogic_002':
 		var logText = get_parent().settings.get_value('history', 'text_arrivals', 'has arrived')

--- a/addons/dialogic/Nodes/History.gd
+++ b/addons/dialogic/Nodes/History.gd
@@ -222,11 +222,7 @@ func add_history_row_event(eventData):
 	# event logging handled here
 	# Text Events, replacing br with linebreaks
 	if eventData.event_id == 'dialogic_001':
-		eventData.text = eventData.text.replace('[br]', '\n')
-		var regex = RegEx.new()
-		regex.compile("\\[[^\\]]{0,}speed[^\\]]{0,}\\]")
-		eventData.text = regex.sub(eventData.text, "")
-		newHistoryRow.add_history(str(characterPrefix, eventData.text), audioData)
+		newHistoryRow.add_history(str(characterPrefix, eventData.text.replace('[br]', '\n')), audioData)
 	# Character Arrivals
 	elif eventData.event_id == 'dialogic_002':
 		var logText = get_parent().settings.get_value('history', 'text_arrivals', 'has arrived')


### PR DESCRIPTION
Since resolving it in History.gd will disable the speed effect. I am resolving it in the HistoryRow.gd instead.

The speed tag is removed using Regex. It will cater below situation:
[speed=1234567890]
[speed=23 ]
[ speed=23]
[speed = 23]
[ speed = 23 ]

But not
[custom_effect speed=23 span=23]

Just in case anyone wants to use speed as an argument for a custom RichTextEffect.