### PR TITLE
Timeline saving simplification, emty_line preserving, label event fix

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -53,6 +53,8 @@ func load_timeline(object:DialogicTimeline) -> void:
 			continue
 		
 		if event != null:
+			for i in event.empty_lines_above:
+				result += "\t".repeat(indent)+"\n"
 			result += "\t".repeat(indent)+event['event_node_as_text'].replace('\n', "\n"+"\t".repeat(indent)) + "\n"
 		if event.can_contain_events:
 			indent += 1
@@ -65,23 +67,15 @@ func load_timeline(object:DialogicTimeline) -> void:
 
 func save_timeline():
 	if get_parent().current_resource:
-			# The translations need this to be actual Events, so we do a few steps of conversion here
-			
-			var text_array:Array = text_timeline_to_array(text)
-			get_parent().current_resource.events = text_array
-			
-			# Build new processed timeline for the ResourceSaver to use
-			# ResourceSaver needs a DialogicEvents timeline so the translation builder can run
-			get_parent().current_resource.events_processed = false
-			get_parent().editors_manager.resource_helper.process_timeline(get_parent().current_resource)
-			get_parent().current_resource.events_processed = false		
-			ResourceSaver.save(get_parent().current_resource, get_parent().current_resource.resource_path)
-			
-			#Switch back to the text event array, in case we're switching editor modes
-			get_parent().current_resource.events = text_array
-			get_parent().current_resource.set_meta("timeline_not_saved", false)
-			get_parent().current_resource_state = DialogicEditor.ResourceStates.Saved
-			get_parent().editors_manager.resource_helper.rebuild_timeline_directory()
+		var text_array:Array = text_timeline_to_array(text)
+		
+		get_parent().current_resource.events = text_array
+		get_parent().current_resource.events_processed = false
+		ResourceSaver.save(get_parent().current_resource, get_parent().current_resource.resource_path)
+
+		get_parent().current_resource.set_meta("timeline_not_saved", false)
+		get_parent().current_resource_state = DialogicEditor.ResourceStates.Saved
+		get_parent().editors_manager.resource_helper.rebuild_timeline_directory()
 		
 
 
@@ -127,11 +121,7 @@ func add_highlighting():
 
 func text_timeline_to_array(text:String) -> Array:
 	# Parse the lines down into an array
-	var prev_indent := ""
 	var events := []
-	
-	# this is needed to add a end branch event even to empty conditions/choices
-	var prev_was_opener := false
 	
 	var lines := text.split('\n', true)
 	var idx := -1
@@ -140,8 +130,7 @@ func text_timeline_to_array(text:String) -> Array:
 		idx += 1
 		var line :String = lines[idx]
 		var line_stripped :String = line.strip_edges(true, true)
-		if !line_stripped.is_empty():
-			events.append(line)
+		events.append(line)
 	
 	
 	return events

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -48,41 +48,24 @@ func save_timeline() -> void:
 	if get_parent().current_resource_state != DialogicEditor.ResourceStates.Unsaved:
 		return
 	
-	
 	# create a list of text versions of all the events with the right indent
-	var new_events = []
+	var new_events := []
 	var indent := 0
 	
 	for event in %Timeline.get_children():
 		
 		if 'event_name' in event.resource:
-			
-			if event.resource['event_name'] == 'End Branch':
-					indent -= 1
-					continue
-			
-			new_events.append("\t".repeat(indent) + event.resource._store_as_string())
-			
-			if event.resource.can_contain_events:
-				indent += 1
-			if indent < 0: 
-				indent = 0
-	
-	# 
+			event.resource.update_text_version() 
+			new_events.append(event.resource)
+
 	if !get_parent().current_resource:
 		return
 
 	get_parent().current_resource.set_events(new_events)
-	
-	# Build new processed timeline for the ResourceSaver to use
-	# ResourceSaver needs a DialogicEvents timeline so the translation builder can run
-	get_parent().current_resource.events_processed = false
-	get_parent().editors_manager.resource_helper.process_timeline(get_parent().current_resource)
-	get_parent().current_resource.events_processed = false		
-	print("Error code : ", ResourceSaver.save(get_parent().current_resource, get_parent().current_resource.resource_path))
-	
-	#Switch back to the text event array, in case we're switching editor modes
-	get_parent().current_resource.set_events(new_events)
+	get_parent().current_resource.events_processed = true
+	var error :int = ResourceSaver.save(get_parent().current_resource, get_parent().current_resource.resource_path)
+	if error != OK:
+		print('[Dialogic] Saving error: ', error)
 	
 	get_parent().current_resource.set_meta("unsaved", false)
 	get_parent().current_resource_state = DialogicEditor.ResourceStates.Saved

--- a/addons/dialogic/Events/Label/event.gd
+++ b/addons/dialogic/Events/Label/event.gd
@@ -52,4 +52,4 @@ func get_shortcode_parameters() -> Dictionary:
 ################################################################################
 
 func build_event_editor():
-	add_header_edit('Name', ValueType.SinglelineText, '')
+	add_header_edit('name', ValueType.SinglelineText, '')

--- a/addons/dialogic/Resources/CharacterResourceLoader.gd
+++ b/addons/dialogic/Resources/CharacterResourceLoader.gd
@@ -26,7 +26,7 @@ func _handles_type(typename: StringName) -> bool:
 
 # parse the file and return a resource
 func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int):
-	print('[Dialogic] Reimporting character "' , path, '"')
+#	print('[Dialogic] Reimporting character "' , path, '"')
 	if FileAccess.file_exists(path):
 		var file = FileAccess.open(path, FileAccess.READ)
 		return dict_to_inst(str_to_var(file.get_as_text()))

--- a/addons/dialogic/Resources/CharacterResourceSaver.gd
+++ b/addons/dialogic/Resources/CharacterResourceSaver.gd
@@ -23,4 +23,4 @@ func _save(resource: Resource, path: String = '', flags: int = 0):
 	var file := FileAccess.open(path, FileAccess.WRITE)
 	var result := var_to_str(inst_to_dict(resource))
 	file.store_string(result)
-	print('[Dialogic] Saved character "' , path, '"')
+#	print('[Dialogic] Saved character "' , path, '"')

--- a/addons/dialogic/Resources/TimelineResourceLoader.gd
+++ b/addons/dialogic/Resources/TimelineResourceLoader.gd
@@ -26,11 +26,11 @@ func _handles_type(typename: StringName) -> bool:
 
 # parse the file and return a resource
 func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int):
-	print('[Dialogic] Reimporting timeline "' , path, '"')
+#	print('[Dialogic] Reimporting timeline "' , path, '"')
 	if FileAccess.file_exists(path):
 		var file := FileAccess.open(path, FileAccess.READ)
-		var res = DialogicTimeline.new()
-		var text = file.get_as_text()
+		var res := DialogicTimeline.new()
+		var text : String = file.get_as_text()
 		
 		# Parse the lines as seperate events and insert them in an array, so they can be converted to DialogicEvent's when processed later
 		var prev_indent := ""
@@ -43,40 +43,8 @@ func _load(path: String, original_path: String, use_sub_threads: bool, cache_mod
 			idx += 1
 			var line :String = lines[idx]
 			var line_stripped :String = line.strip_edges(true, true)
-			if line_stripped.is_empty():
-				continue
 			events.append(line)
-
-
+		
 		res.events = events
 		res.events_processed = false
 		return res
-
-
-func _get_dependencies(path:String, add_type:bool):
-	var depends_on : PackedStringArray
-	var timeline:DialogicTimeline = load(path)
-	for event in timeline.events:
-		for property in event.get_shortcode_parameters().values():
-			if event.get(property['property']) is DialogicTimeline:
-				depends_on.append(event.get(property['property']).resource_path)
-			elif event.get(property['property']) is DialogicCharacter:
-				depends_on.append(event.get(property['property']).resource_path)
-			elif typeof(event.get(property['property'])) == TYPE_STRING and event.get(property['property']).begins_with('res://'):
-				depends_on.append(event.get(property['property']))
-	return depends_on
-
-func _rename_dependencies(path: String, renames: Dictionary):
-	var timeline:DialogicTimeline = load(path)
-	for event in timeline.events:
-		for property in event.get_shortcode_parameters().values():
-			if event.get(property['property']) is DialogicTimeline:
-				if event.get(property['property']).resource_path in renames:
-					event.set(property['property'], load(renames[event.get(property['property']).resource_path]))
-			elif event.get(property['property']) is DialogicCharacter:
-				if event.get(property['property']).resource_path in renames:
-					event.set(property['property'], load(renames[event.get(property['property']).resource_path]))
-			elif typeof(event.get(property['property'])) == TYPE_STRING and event.get(property['property']) in renames:
-				event.set(property['property'], renames[event.get(property['property'])])
-	ResourceSaver.save(timeline, path)
-	return OK

--- a/addons/dialogic/Resources/TimelineResourceSaver.gd
+++ b/addons/dialogic/Resources/TimelineResourceSaver.gd
@@ -7,7 +7,7 @@ func _get_recognized_extensions(resource: Resource) -> PackedStringArray:
 	return PackedStringArray(["dtl"])
 
 
-# Return true if this resource should be loaded as a DialogicCharacter 
+# Return true if this resource should be loaded as a DialogicTimeline 
 func _recognize(resource: Resource) -> bool:
 	# Cast instead of using "is" keyword in case is a subclass
 	resource = resource as DialogicTimeline
@@ -24,75 +24,73 @@ func _save(resource: Resource, path: String = '', flags: int = 0) -> int:
 		if len(resource.events) == 0:
 			printerr("[Dialogic] Timeline save was called, but there are no events. Timeline will not be saved, to prevent accidental data loss. Please delete the timeline file if you are trying to clear all of the events.")
 			return ERR_INVALID_DATA
-		# Do not do this if the timeline's not in a ready state, so it doesn't accidentally save it blank
-		elif !resource.events_processed:
-			print('[Dialogic] Beginning saving timeline. Safety checks will be performed before writing, and temporary file will be created and removed if saving is successful...')
+		
+#		print('[Dialogic] Beginning saving timeline. Safety checks will be performed before writing, and temporary file will be created and removed if saving is successful...')
+		
+		#prepare everything before writing, we will only open the file if it's successfuly prepared, as that will clear the file contents
+		
+		var timeline_as_text :String = ""
+		# if events are resources, create text
+		if resource.events_processed:
 			
-			#prepare everything before writing, we will only open the file if it's successfuly prepared, as that will clear the file contents
-			#var result = events_to_text(resource.events)
-			var result := ""
 			var indent := 0
-
 			for idx in range(0, len(resource.events)):
-				var event = resource.events[idx]
-
-
-				if event['event_name'] == 'End Branch':
+				var event :DialogicEvent= resource.events[idx]
+				if event.event_name == 'End Branch':
 					indent -=1
 					continue
-
+				
+				for i in event.empty_lines_above:
+					timeline_as_text += '\t'.repeat(indent) + '\n'
+					
 				if event != null:
-					result += "\t".repeat(indent)+ event['event_node_as_text'] + "\n"
+					timeline_as_text += "\t".repeat(indent)+ event.event_node_as_text + "\n"
 				if event.can_contain_events:
 					indent += 1
 				if indent < 0: 
 					indent = 0
-				#result += "\t".repeat(indent)+"\n"
-				result += "\n"
-				
-			if (len(result) > 0):
-				var file := FileAccess.open(path.replace(".dtl", ".tmp"), FileAccess.WRITE)
-				file.store_string(result)
-				file = null
-				
-				var dir = DirAccess.open("res://")
-				if  dir.file_exists(path.replace(".dtl", ".tmp")):
-					file = FileAccess.open(path.replace(".dtl", ".tmp"), FileAccess.READ)
-					var check_length = file.get_length()
-					if check_length > 0:
-						var check_result = file.get_as_text()
-						file = null
-						if result == check_result:
-							dir.copy(path.replace(".dtl", ".tmp"), path)
-							file = FileAccess.open(path, FileAccess.READ)
-							var check_result2 = file.get_as_text()
-							if result == check_result2:
-								print('[Dialogic] Completed saving timeline "' , path, '"')
-								dir.remove(path.replace(".dtl", ".tmp"))
-							else:
-								printerr("[Dialogic] " + path + ": Overwriting .dtl file failed! Temporary file was saved as .tmp extension, please check to see if it matches your timeline, and rename to .dtl manually.")
-								return ERR_INVALID_DATA
+		
+		# if events are string lines, just save them
+		else:
+			for event in resource.events:
+				timeline_as_text += event + "\n"
+		
+		# Now do the actual saving
+		if (len(timeline_as_text) > 0):
+			var file := FileAccess.open(path.replace(".dtl", ".tmp"), FileAccess.WRITE)
+			file.store_string(timeline_as_text)
+			file = null
+			
+			var dir = DirAccess.open("res://")
+			if  dir.file_exists(path.replace(".dtl", ".tmp")):
+				file = FileAccess.open(path.replace(".dtl", ".tmp"), FileAccess.READ)
+				var check_length = file.get_length()
+				if check_length > 0:
+					var check_result = file.get_as_text()
+					file = null
+					if timeline_as_text == check_result:
+						dir.copy(path.replace(".dtl", ".tmp"), path)
+						file = FileAccess.open(path, FileAccess.READ)
+						var check_result2 = file.get_as_text()
+						if timeline_as_text == check_result2:
+#							print('[Dialogic] Completed saving timeline "' , path, '"')
+							dir.remove(path.replace(".dtl", ".tmp"))
 						else:
-							printerr("[Dialogic] " + path + ": Temporary timeline file contents do not match what was written! Temporary file was saved as .tmp extension, please check to see if it matches your timeline, and rename to .dtl manually.")
+							printerr("[Dialogic] " + path + ": Overwriting .dtl file failed! Temporary file was saved as .tmp extension, please check to see if it matches your timeline, and rename to .dtl manually.")
 							return ERR_INVALID_DATA
 					else:
-						printerr("[Dialogic] " + path + ": Temporary timeline file is empty! Timeline was not saved!")
-						dir.remove(path.replace(".dtl", ".tmp"))
+						printerr("[Dialogic] " + path + ": Temporary timeline file contents do not match what was written! Temporary file was saved as .tmp extension, please check to see if it matches your timeline, and rename to .dtl manually.")
 						return ERR_INVALID_DATA
 				else:
-					printerr("[Dialogic] " + path + ": Temporary timeline file failed to create! Timeline was not saved!")
+					printerr("[Dialogic] " + path + ": Temporary timeline file is empty! Timeline was not saved!")
+					dir.remove(path.replace(".dtl", ".tmp"))
 					return ERR_INVALID_DATA
-				
-				
-				
-			else: 
-				printerr("[Dialogic] " + path + ": Timeline failed to convert to text for saving! Timeline was not saved!")
+			else:
+				printerr("[Dialogic] " + path + ": Temporary timeline file failed to create! Timeline was not saved!")
 				return ERR_INVALID_DATA
-				
-
-			return OK
+			
 		else: 
-			printerr("[Dialogic] " + path + ": Timeline was not in ready state for saving! Timeline was not saved!")
+			printerr("[Dialogic] " + path + ": Timeline failed to convert to text for saving! Timeline was not saved!")
 			return ERR_INVALID_DATA
-	else:
-		return OK
+	
+	return OK

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -47,6 +47,8 @@ var continue_at_end:bool = true
 var event_node_as_text: String = ""
 ## Flags if the event has been processed or is only stored as text
 var event_node_ready: bool = false
+## How many empty lines are before this event
+var empty_lines_above:int = 0
 
 
 ### Editor UI Properties ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# Saving simplifications
The timeline saving logic has been simplified.
The TimelineResourceSaver now accepts both Timelines with text arrays as well as event arrays. If an event_array is present, it will convert it to text.

The visual timeline editor saves with a event array, while the text editor saves with a text array.

# Empty lines
The number of empty lines is now stored in the next event (in the events.empty_lines_above property). This allows to save them even when events are resources.

# Label fix
The name field of the label event wasn't working