### PR TITLE
Character Editor Update

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -432,7 +432,11 @@ func update_preview() -> void:
 		var scale:float = current_portrait_data.get('scale', 1) * current_resource.scale
 		var offset:Vector2 =current_portrait_data.get('offset', Vector2()) + current_resource.offset
 		
-		if current_previewed_scene != null and current_previewed_scene.get_meta('path', null) == current_portrait_data.get('scene') and current_previewed_scene.has_method('_should_do_portrait_update') and current_previewed_scene._should_do_portrait_update(current_resource, selected_item.get_text(0)):
+		if current_previewed_scene != null \
+			and current_previewed_scene.get_meta('path', null) == current_portrait_data.get('scene') \
+			and current_previewed_scene.has_method('_should_do_portrait_update') \
+			and is_instance_valid(current_previewed_scene.get_script()) \
+			and current_previewed_scene._should_do_portrait_update(current_resource, selected_item.get_text(0)):
 			pass # we keep the same scene
 		else:
 			for node in %RealPreviewPivot.get_children():

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -43,7 +43,7 @@ func _register() -> void:
 # Called when a character is opened somehow
 func _open_resource(resource:Resource) -> void:
 	# update resource
-	current_resource = resource
+	current_resource = (resource as DialogicCharacter)
 	
 	# make sure changes in the ui won't trigger saving
 	loading = true
@@ -62,6 +62,9 @@ func _open_resource(resource:Resource) -> void:
 	# Portrait section
 	%PortraitSearch.text = ""
 	load_portrait_tree()
+	
+	if resource.portraits.is_empty():
+		update_preview()
 	
 	loading = false
 	character_loaded.emit(resource.resource_path)

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=3 uid="uid://dxt0c6mx24nxo"]
+[gd_scene load_steps=14 format=3 uid="uid://dxt0c6mx24nxo"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="2_01va3"]
@@ -6,8 +6,9 @@
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_scene.gd" id="4_6tltp"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/FilePicker.tscn" id="4_a4bcu"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_layout.gd" id="5_eicvp"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_exports.gd" id="7_4enie"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_83hxt"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hdqef"]
 content_margin_left = 10.0
 content_margin_top = 4.0
 content_margin_right = 10.0
@@ -17,7 +18,7 @@ border_width_top = 2
 border_color = Color(1, 1, 1, 0.75)
 corner_detail = 1
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1cl71"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jc1xk"]
 content_margin_left = 7.5
 content_margin_top = 7.5
 content_margin_right = 7.5
@@ -28,7 +29,7 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="Image" id="Image_6yblc"]
+[sub_resource type="Image" id="Image_dqs53"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -37,10 +38,23 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_osvex"]
-image = SubResource("Image_6yblc")
+[sub_resource type="ImageTexture" id="ImageTexture_ckfua"]
+image = SubResource("Image_dqs53")
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_4xgdx"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sf73i"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(1, 0.365, 0.365, 1)
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+corner_detail = 1
 
 [node name="CharacterEditor" type="MarginContainer"]
 self_modulate = Color(0, 0, 0, 1)
@@ -77,18 +91,17 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
-theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
+theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
 
 [node name="PortraitListSection" type="TabContainer" parent="Split/Editor"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
-theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
+theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
 
 [node name="Portraits" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
-visible = false
 layout_mode = 2
 
 [node name="PortraitListTools" type="HBoxContainer" parent="Split/Editor/PortraitListSection/Portraits"]
@@ -97,12 +110,12 @@ layout_mode = 2
 [node name="AddPortraitButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_osvex")
+icon = SubResource("ImageTexture_ckfua")
 
 [node name="ImportPortraitsButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_osvex")
+icon = SubResource("ImageTexture_ckfua")
 
 [node name="PortraitSearch" type="LineEdit" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
@@ -112,7 +125,7 @@ size_flags_vertical = 4
 placeholder_text = "Search"
 expand_to_text_length = true
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_osvex")
+right_icon = SubResource("ImageTexture_ckfua")
 caret_blink = true
 caret_blink_interval = 0.5
 
@@ -129,6 +142,7 @@ hide_folding = true
 hide_root = true
 
 [node name="P Settings" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
+visible = false
 layout_mode = 2
 
 [node name="DefaultPortrait" type="HBoxContainer" parent="Split/Editor/PortraitListSection/P Settings"]
@@ -207,7 +221,7 @@ clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
+theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
 
 [node name="Node2D" type="Node2D" parent="Split/RightSection/PortraitPreviewSection"]
 position = Vector2(13, 17)
@@ -215,7 +229,7 @@ position = Vector2(13, 17)
 [node name="RealPreviewPivot" type="Sprite2D" parent="Split/RightSection/PortraitPreviewSection/Node2D"]
 unique_name_in_owner = true
 position = Vector2(289, 362)
-texture = SubResource("ImageTexture_osvex")
+texture = SubResource("ImageTexture_ckfua")
 
 [node name="ScenePreviewWarning" type="Label" parent="Split/RightSection/PortraitPreviewSection"]
 unique_name_in_owner = true
@@ -282,7 +296,7 @@ unique_name_in_owner = true
 layout_mode = 0
 offset_right = 40.0
 offset_bottom = 23.0
-text = "Preview"
+text = "No portrait to preview."
 
 [node name="PreviewMode" type="OptionButton" parent="Split/RightSection/PortraitPreviewSection"]
 unique_name_in_owner = true
@@ -315,10 +329,11 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
-theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
+theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
 
 [node name="Image" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
+visible = false
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 horizontal_scroll_mode = 0
@@ -344,7 +359,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 file_filter = "*.png, *.svg"
-resource_icon = SubResource("ImageTexture_osvex")
+resource_icon = SubResource("ImageTexture_ckfua")
 
 [node name="Scene" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
 visible = false
@@ -375,7 +390,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 file_filter = "*.tscn"
 placeholder = "Default scene"
-resource_icon = SubResource("ImageTexture_osvex")
+resource_icon = SubResource("ImageTexture_ckfua")
 
 [node name="Label2" type="Label" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer"]
 layout_mode = 2
@@ -442,6 +457,20 @@ text = "Mirror:"
 [node name="PortraitMirror" type="CheckBox" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/MirrorOption"]
 unique_name_in_owner = true
 layout_mode = 2
+
+[node name="Exports" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
+custom_minimum_size = Vector2(0, 35)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_sf73i")
+horizontal_scroll_mode = 0
+script = ExtResource("7_4enie")
+
+[node name="Grid" type="GridContainer" parent="Split/RightSection/PortraitSettingsSection/Exports"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/h_separation = 10
+columns = 2
 
 [connection signal="button_clicked" from="Split/Editor/PortraitListSection/Portraits/Panel/PortraitTree" to="." method="_on_portrait_tree_button_clicked"]
 [connection signal="resized" from="Split/RightSection/PortraitPreviewSection/FullPreviewAvailableRect" to="." method="_on_full_preview_available_rect_resized"]

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
@@ -1,14 +1,15 @@
-[gd_scene load_steps=14 format=3 uid="uid://dxt0c6mx24nxo"]
+[gd_scene load_steps=15 format=3 uid="uid://dlskc36c5hrwv"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="2_01va3"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_image.gd" id="2_cusvj"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd" id="2_vad0i"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_scene.gd" id="4_6tltp"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/FilePicker.tscn" id="4_a4bcu"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_layout.gd" id="5_eicvp"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_exports.gd" id="7_4enie"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hdqef"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kxihh"]
 content_margin_left = 10.0
 content_margin_top = 4.0
 content_margin_right = 10.0
@@ -18,7 +19,7 @@ border_width_top = 2
 border_color = Color(1, 1, 1, 0.75)
 corner_detail = 1
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_jc1xk"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1pdx5"]
 content_margin_left = 7.5
 content_margin_top = 7.5
 content_margin_right = 7.5
@@ -29,7 +30,7 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="Image" id="Image_dqs53"]
+[sub_resource type="Image" id="Image_8q5e2"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -38,12 +39,12 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_ckfua"]
-image = SubResource("Image_dqs53")
+[sub_resource type="ImageTexture" id="ImageTexture_uf4x7"]
+image = SubResource("Image_8q5e2")
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_4xgdx"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_sf73i"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_81xk6"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
@@ -91,15 +92,15 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
-theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_kxihh")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1pdx5")
 
 [node name="PortraitListSection" type="TabContainer" parent="Split/Editor"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
-theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_kxihh")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1pdx5")
 
 [node name="Portraits" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
 layout_mode = 2
@@ -110,12 +111,20 @@ layout_mode = 2
 [node name="AddPortraitButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_ckfua")
+tooltip_text = "Add portrait"
+icon = SubResource("ImageTexture_uf4x7")
+
+[node name="AddPortraitGroupButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Add Group"
+icon = SubResource("ImageTexture_uf4x7")
 
 [node name="ImportPortraitsButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-icon = SubResource("ImageTexture_ckfua")
+tooltip_text = "Import images from folder"
+icon = SubResource("ImageTexture_uf4x7")
 
 [node name="PortraitSearch" type="LineEdit" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
@@ -125,7 +134,7 @@ size_flags_vertical = 4
 placeholder_text = "Search"
 expand_to_text_length = true
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_ckfua")
+right_icon = SubResource("ImageTexture_uf4x7")
 caret_blink = true
 caret_blink_interval = 0.5
 
@@ -138,8 +147,9 @@ theme_override_styles/panel = SubResource("StyleBoxEmpty_4xgdx")
 unique_name_in_owner = true
 layout_mode = 2
 allow_rmb_select = true
-hide_folding = true
 hide_root = true
+drop_mode_flags = 1
+script = ExtResource("2_vad0i")
 
 [node name="P Settings" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
 visible = false
@@ -221,15 +231,15 @@ clip_contents = true
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1pdx5")
 
 [node name="Node2D" type="Node2D" parent="Split/RightSection/PortraitPreviewSection"]
 position = Vector2(13, 17)
 
 [node name="RealPreviewPivot" type="Sprite2D" parent="Split/RightSection/PortraitPreviewSection/Node2D"]
 unique_name_in_owner = true
-position = Vector2(289, 362)
-texture = SubResource("ImageTexture_ckfua")
+position = Vector2(330, 405)
+texture = SubResource("ImageTexture_uf4x7")
 
 [node name="ScenePreviewWarning" type="Label" parent="Split/RightSection/PortraitPreviewSection"]
 unique_name_in_owner = true
@@ -329,11 +339,10 @@ layout_mode = 2
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_hdqef")
-theme_override_styles/panel = SubResource("StyleBoxFlat_jc1xk")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_kxihh")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1pdx5")
 
 [node name="Image" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
-visible = false
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
 horizontal_scroll_mode = 0
@@ -359,7 +368,7 @@ unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 file_filter = "*.png, *.svg"
-resource_icon = SubResource("ImageTexture_ckfua")
+resource_icon = SubResource("ImageTexture_uf4x7")
 
 [node name="Scene" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
 visible = false
@@ -390,7 +399,7 @@ layout_mode = 2
 size_flags_horizontal = 3
 file_filter = "*.tscn"
 placeholder = "Default scene"
-resource_icon = SubResource("ImageTexture_ckfua")
+resource_icon = SubResource("ImageTexture_uf4x7")
 
 [node name="Label2" type="Label" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer"]
 layout_mode = 2
@@ -459,9 +468,10 @@ unique_name_in_owner = true
 layout_mode = 2
 
 [node name="Exports" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
+visible = false
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_sf73i")
+theme_override_styles/panel = SubResource("StyleBoxFlat_81xk6")
 horizontal_scroll_mode = 0
 script = ExtResource("7_4enie")
 

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=11 format=3 uid="uid://dxt0c6mx24nxo"]
+[gd_scene load_steps=12 format=3 uid="uid://dxt0c6mx24nxo"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor.gd" id="2"]
+[ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="2_01va3"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_image.gd" id="2_cusvj"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_scene.gd" id="4_6tltp"]
 [ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/FilePicker.tscn" id="4_a4bcu"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_ptab_layout.gd" id="5_eicvp"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_cf78c"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_83hxt"]
 content_margin_left = 10.0
 content_margin_top = 4.0
 content_margin_right = 10.0
@@ -16,7 +17,7 @@ border_width_top = 2
 border_color = Color(1, 1, 1, 0.75)
 corner_detail = 1
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_l8t00"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1cl71"]
 content_margin_left = 7.5
 content_margin_top = 7.5
 content_margin_right = 7.5
@@ -27,7 +28,7 @@ corner_radius_top_right = 3
 corner_radius_bottom_right = 3
 corner_radius_bottom_left = 3
 
-[sub_resource type="Image" id="Image_fyuk7"]
+[sub_resource type="Image" id="Image_6yblc"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -36,13 +37,12 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_asiy6"]
-image = SubResource("Image_fyuk7")
+[sub_resource type="ImageTexture" id="ImageTexture_osvex"]
+image = SubResource("Image_6yblc")
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_4xgdx"]
 
 [node name="CharacterEditor" type="MarginContainer"]
-visible = false
 self_modulate = Color(0, 0, 0, 1)
 anchors_preset = 15
 anchor_right = 1.0
@@ -57,24 +57,16 @@ script = ExtResource("2")
 
 [node name="Split" type="HSplitContainer" parent="."]
 layout_mode = 2
-offset_right = 1152.0
-offset_bottom = 648.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="Editor" type="VSplitContainer" parent="Split"]
 layout_mode = 2
-offset_right = 454.0
-offset_bottom = 648.0
-grow_horizontal = 2
-grow_vertical = 2
 size_flags_horizontal = 3
 size_flags_vertical = 11
 
 [node name="EditorScroll" type="ScrollContainer" parent="Split/Editor"]
 layout_mode = 2
-offset_right = 454.0
-offset_bottom = 54.0
 size_flags_horizontal = 3
 size_flags_stretch_ratio = 0.0
 vertical_scroll_mode = 0
@@ -82,93 +74,129 @@ vertical_scroll_mode = 0
 [node name="MainEditTabs" type="TabContainer" parent="Split/Editor/EditorScroll"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 454.0
-offset_bottom = 54.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_cf78c")
-theme_override_styles/panel = SubResource("StyleBoxFlat_l8t00")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
 
 [node name="PortraitListSection" type="TabContainer" parent="Split/Editor"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 66.0
-offset_right = 454.0
-offset_bottom = 648.0
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_cf78c")
-theme_override_styles/panel = SubResource("StyleBoxFlat_l8t00")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
 
 [node name="Portraits" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
+visible = false
 layout_mode = 2
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 7.5
-offset_top = 38.5
-offset_right = -7.5
-offset_bottom = -7.5
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="PortraitListTools" type="HBoxContainer" parent="Split/Editor/PortraitListSection/Portraits"]
 layout_mode = 2
-offset_right = 439.0
-offset_bottom = 31.0
 
 [node name="AddPortraitButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 24.0
-offset_bottom = 31.0
-icon = SubResource("ImageTexture_asiy6")
+icon = SubResource("ImageTexture_osvex")
 
 [node name="ImportPortraitsButton" type="Button" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 28.0
-offset_right = 52.0
-offset_bottom = 31.0
-icon = SubResource("ImageTexture_asiy6")
+icon = SubResource("ImageTexture_osvex")
 
 [node name="PortraitSearch" type="LineEdit" parent="Split/Editor/PortraitListSection/Portraits/PortraitListTools"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 56.0
-offset_right = 439.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
 size_flags_vertical = 4
 placeholder_text = "Search"
 expand_to_text_length = true
 clear_button_enabled = true
-right_icon = SubResource("ImageTexture_asiy6")
+right_icon = SubResource("ImageTexture_osvex")
 caret_blink = true
 caret_blink_interval = 0.5
 
 [node name="Panel" type="PanelContainer" parent="Split/Editor/PortraitListSection/Portraits"]
 layout_mode = 2
-offset_top = 35.0
-offset_right = 439.0
-offset_bottom = 314.0
 size_flags_vertical = 3
 theme_override_styles/panel = SubResource("StyleBoxEmpty_4xgdx")
 
 [node name="PortraitTree" type="Tree" parent="Split/Editor/PortraitListSection/Portraits/Panel"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 439.0
-offset_bottom = 279.0
 allow_rmb_select = true
 hide_folding = true
 hide_root = true
 
+[node name="P Settings" type="VBoxContainer" parent="Split/Editor/PortraitListSection"]
+layout_mode = 2
+
+[node name="DefaultPortrait" type="HBoxContainer" parent="Split/Editor/PortraitListSection/P Settings"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label5" type="Label" parent="Split/Editor/PortraitListSection/P Settings/DefaultPortrait"]
+layout_mode = 2
+text = "Default:"
+
+[node name="DefaultPortraitPicker" parent="Split/Editor/PortraitListSection/P Settings/DefaultPortrait" instance=ExtResource("2_01va3")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+placeholder_text = "Select Portrait"
+
+[node name="HSeparator" type="HSeparator" parent="Split/Editor/PortraitListSection/P Settings"]
+layout_mode = 2
+
+[node name="PortraitMainSettings" type="HFlowContainer" parent="Split/Editor/PortraitListSection/P Settings"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings"]
+layout_mode = 2
+text = "Scale"
+
+[node name="MainScale" type="SpinBox" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings"]
+unique_name_in_owner = true
+layout_mode = 2
+value = 100.0
+allow_greater = true
+suffix = "%"
+
+[node name="Offset" type="HBoxContainer" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings"]
+layout_mode = 2
+
+[node name="Label2" type="Label" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings/Offset"]
+layout_mode = 2
+text = "Offset"
+
+[node name="MainOffsetX" type="SpinBox" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings/Offset"]
+unique_name_in_owner = true
+layout_mode = 2
+allow_greater = true
+allow_lesser = true
+suffix = "X"
+
+[node name="MainOffsetY" type="SpinBox" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings/Offset"]
+unique_name_in_owner = true
+layout_mode = 2
+allow_greater = true
+allow_lesser = true
+suffix = "Y"
+
+[node name="MirrorOption" type="HBoxContainer" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings/MirrorOption"]
+layout_mode = 2
+text = "Mirror"
+
+[node name="MainMirror" type="CheckBox" parent="Split/Editor/PortraitListSection/P Settings/PortraitMainSettings/MirrorOption"]
+unique_name_in_owner = true
+layout_mode = 2
+
 [node name="RightSection" type="VSplitContainer" parent="Split"]
 layout_mode = 2
-offset_left = 466.0
-offset_right = 1152.0
-offset_bottom = 648.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 size_flags_stretch_ratio = 1.5
@@ -177,11 +205,9 @@ size_flags_stretch_ratio = 1.5
 unique_name_in_owner = true
 clip_contents = true
 layout_mode = 2
-offset_right = 686.0
-offset_bottom = 492.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_l8t00")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
 
 [node name="Node2D" type="Node2D" parent="Split/RightSection/PortraitPreviewSection"]
 position = Vector2(13, 17)
@@ -189,7 +215,7 @@ position = Vector2(13, 17)
 [node name="RealPreviewPivot" type="Sprite2D" parent="Split/RightSection/PortraitPreviewSection/Node2D"]
 unique_name_in_owner = true
 position = Vector2(289, 362)
-texture = SubResource("ImageTexture_asiy6")
+texture = SubResource("ImageTexture_osvex")
 
 [node name="ScenePreviewWarning" type="Label" parent="Split/RightSection/PortraitPreviewSection"]
 unique_name_in_owner = true
@@ -229,11 +255,6 @@ metadata/_edit_layout_mode = 1
 
 [node name="Control" type="Control" parent="Split/RightSection/PortraitPreviewSection/PreviewReal"]
 layout_mode = 2
-anchors_preset = 0
-offset_left = 302.0
-offset_top = 69.0
-offset_right = 302.0
-offset_bottom = 69.0
 
 [node name="RealSizeRemotePivotTransform" type="RemoteTransform2D" parent="Split/RightSection/PortraitPreviewSection/PreviewReal/Control"]
 unique_name_in_owner = true
@@ -291,188 +312,115 @@ offset_bottom = -12.0
 [node name="PortraitSettingsSection" type="TabContainer" parent="Split/RightSection"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_top = 504.0
-offset_right = 686.0
-offset_bottom = 648.0
 size_flags_vertical = 3
 size_flags_stretch_ratio = 0.3
 theme_override_constants/side_margin = 5
-theme_override_styles/tab_selected = SubResource("StyleBoxFlat_cf78c")
-theme_override_styles/panel = SubResource("StyleBoxFlat_l8t00")
+theme_override_styles/tab_selected = SubResource("StyleBoxFlat_83hxt")
+theme_override_styles/panel = SubResource("StyleBoxFlat_1cl71")
 
 [node name="Image" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 7.5
-offset_top = 38.5
-offset_right = -7.5
-offset_bottom = -7.5
-grow_horizontal = 2
-grow_vertical = 2
 horizontal_scroll_mode = 0
 script = ExtResource("2_cusvj")
 
 [node name="Flow" type="HFlowContainer" parent="Split/RightSection/PortraitSettingsSection/Image"]
 layout_mode = 2
-offset_right = 671.0
-offset_bottom = 98.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="Split/RightSection/PortraitSettingsSection/Image/Flow"]
 layout_mode = 2
-offset_right = 671.0
-offset_bottom = 38.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
 
 [node name="Label" type="Label" parent="Split/RightSection/PortraitSettingsSection/Image/Flow/GridContainer"]
 layout_mode = 2
-offset_top = 6.0
-offset_right = 57.0
-offset_bottom = 32.0
 text = "Image: "
 
 [node name="ImagePicker" parent="Split/RightSection/PortraitSettingsSection/Image/Flow/GridContainer" instance=ExtResource("4_a4bcu")]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 61.0
-offset_right = 671.0
-offset_bottom = 38.0
 size_flags_horizontal = 3
 file_filter = "*.png, *.svg"
-resource_icon = SubResource("ImageTexture_asiy6")
+resource_icon = SubResource("ImageTexture_osvex")
 
 [node name="Scene" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
 visible = false
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = 10.0
-offset_top = 41.0
-offset_right = -10.0
-offset_bottom = -10.0
-grow_horizontal = 2
-grow_vertical = 2
 horizontal_scroll_mode = 0
 script = ExtResource("4_6tltp")
 
 [node name="Flow" type="HFlowContainer" parent="Split/RightSection/PortraitSettingsSection/Scene"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 666.0
-offset_bottom = 93.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="GridContainer" type="GridContainer" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow"]
 layout_mode = 2
-offset_right = 584.0
-offset_bottom = 63.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 columns = 2
 
 [node name="Label" type="Label" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer"]
 layout_mode = 2
-offset_top = 3.0
-offset_right = 102.0
-offset_bottom = 29.0
 text = "Scene: "
 
 [node name="ScenePicker" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer" instance=ExtResource("4_a4bcu")]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 106.0
-offset_right = 584.0
-offset_bottom = 33.0
 size_flags_horizontal = 3
 file_filter = "*.tscn"
 placeholder = "Default scene"
-resource_icon = SubResource("ImageTexture_asiy6")
+resource_icon = SubResource("ImageTexture_osvex")
 
 [node name="Label2" type="Label" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer"]
 layout_mode = 2
-offset_top = 37.0
-offset_right = 102.0
-offset_bottom = 63.0
 text = "Ignore scale: "
 
 [node name="IgnoreScale" type="CheckBox" parent="Split/RightSection/PortraitSettingsSection/Scene/Flow/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 106.0
-offset_top = 37.0
-offset_right = 584.0
-offset_bottom = 63.0
 
 [node name="Layout" type="ScrollContainer" parent="Split/RightSection/PortraitSettingsSection"]
 visible = false
 custom_minimum_size = Vector2(0, 35)
 layout_mode = 2
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_top = 31.0
-grow_horizontal = 2
-grow_vertical = 2
 horizontal_scroll_mode = 0
 script = ExtResource("5_eicvp")
 
 [node name="Flow" type="HFlowContainer" parent="Split/RightSection/PortraitSettingsSection/Layout"]
 layout_mode = 2
-offset_right = 686.0
-offset_bottom = 113.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow"]
 layout_mode = 2
-offset_right = 150.0
-offset_bottom = 33.0
 
 [node name="Label" type="Label" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/HBoxContainer"]
 layout_mode = 2
-offset_top = 3.0
-offset_right = 40.0
-offset_bottom = 29.0
 text = "Scale:"
 
 [node name="PortraitScale" type="SpinBox" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/HBoxContainer"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 44.0
-offset_right = 150.0
-offset_bottom = 33.0
 value = 100.0
 allow_greater = true
 suffix = "%"
 
 [node name="HBoxContainer2" type="HBoxContainer" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow"]
 layout_mode = 2
-offset_top = 37.0
-offset_right = 268.0
-offset_bottom = 70.0
 
 [node name="Label2" type="Label" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/HBoxContainer2"]
 layout_mode = 2
-offset_top = 3.0
-offset_right = 48.0
-offset_bottom = 29.0
 text = "Offset:"
 
 [node name="PortraitOffsetX" type="SpinBox" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 52.0
-offset_right = 158.0
-offset_bottom = 33.0
 allow_greater = true
 allow_lesser = true
 suffix = "X"
@@ -480,33 +428,20 @@ suffix = "X"
 [node name="PortraitOffsetY" type="SpinBox" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/HBoxContainer2"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 162.0
-offset_right = 268.0
-offset_bottom = 33.0
 allow_greater = true
 allow_lesser = true
 suffix = "Y"
 
 [node name="MirrorOption" type="HBoxContainer" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow"]
 layout_mode = 2
-offset_left = 272.0
-offset_top = 37.0
-offset_right = 350.0
-offset_bottom = 70.0
 
 [node name="Label" type="Label" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/MirrorOption"]
 layout_mode = 2
-offset_top = 3.0
-offset_right = 50.0
-offset_bottom = 29.0
 text = "Mirror:"
 
 [node name="PortraitMirror" type="CheckBox" parent="Split/RightSection/PortraitSettingsSection/Layout/Flow/MirrorOption"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_left = 54.0
-offset_right = 78.0
-offset_bottom = 33.0
 
 [connection signal="button_clicked" from="Split/Editor/PortraitListSection/Portraits/Panel/PortraitTree" to="." method="_on_portrait_tree_button_clicked"]
 [connection signal="resized" from="Split/RightSection/PortraitPreviewSection/FullPreviewAvailableRect" to="." method="_on_full_preview_available_rect_resized"]

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_settings_tab.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_settings_tab.gd
@@ -12,5 +12,5 @@ var character_editor:Control
 
 var selected_item :TreeItem = null
 
-func _load_portrait(data:Dictionary) -> void:
+func _load_portrait_data(data:Dictionary) -> void:
 	pass

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_portrait_tree.gd
@@ -1,0 +1,115 @@
+@tool
+extends Tree
+
+## Tree that displays the portrait list as a hirarchy
+
+var editor := find_parent('Character Editor')
+var current_group_nodes := {}
+
+
+func clear_tree() -> void:
+	clear()
+	current_group_nodes = {}
+
+
+func add_portrait_item(portrait_name:String, portrait_data:Dictionary, parent_item:TreeItem) -> TreeItem:
+	var item :TreeItem = %PortraitTree.create_item(parent_item)
+	item.set_text(0, portrait_name)
+	item.set_metadata(0, portrait_data)
+	if portrait_name == editor.current_resource.default_portrait:
+		item.add_button(0, get_theme_icon('Favorites', 'EditorIcons'), 2, true, 'Default')
+	item.add_button(0, get_theme_icon('Duplicate', 'EditorIcons'), 3, false, 'Duplicate')
+	item.add_button(0, get_theme_icon('Remove', 'EditorIcons'), 1, false, 'Remove')
+	return item
+
+
+func add_portrait_group(goup_name:String = "Group", parent_item:TreeItem = get_root()):
+	var item :TreeItem = %PortraitTree.create_item(parent_item)
+	item.set_icon(0, get_theme_icon("Groups", "EditorIcons"))
+	item.set_text(0, goup_name)
+	item.set_metadata(0, {'group':true})
+	item.add_button(0, get_theme_icon('Remove', 'EditorIcons'), 1, false, 'Remove')
+	return item
+
+
+func get_full_item_name(item:TreeItem) -> String:
+	var item_name := item.get_text(0)
+	while item.get_parent() != get_root() and item != get_root():
+		item_name = item.get_parent().get_text(0)+"/"+item_name
+		item = item.get_parent()
+	return item_name
+
+
+# Will create all not yet existing folders in the given path.
+# Returns the last folder (the parent of the portrait item of this path). 
+func create_necessary_group_items(path:String) -> void:
+	var last_item := get_root()
+	var item_path := ""
+	
+	for i in Array(path.split('/')).slice(0, -1):
+		item_path += "/"+i
+		item_path = item_path.trim_prefix('/')
+		if current_group_nodes.has(item_path+"/"+i):
+			last_item = current_group_nodes[item_path+"/"+i]
+		else:
+			var new_item := add_portrait_group(i, last_item)
+			current_group_nodes[item_path+"/"+i] = new_item
+			last_item = new_item
+	return last_item
+
+
+################################################################################
+##					DRAG AND DROP
+################################################################################
+
+func _get_drag_data(position:Vector2) -> Variant:
+	set_drop_mode_flags(DROP_MODE_ON_ITEM)
+	
+	var preview := Label.new()
+	preview.text = "     "+get_selected().get_text(0)
+	preview.add_theme_stylebox_override('normal', get_theme_stylebox("Background", "EditorStyles"))
+	set_drag_preview(preview)
+	
+	return get_selected()
+
+
+func _can_drop_data(position:Vector2, data:Variant) -> bool:
+	return data is TreeItem
+
+
+func _drop_data(position:Vector2, item:Variant) -> void:
+	var to_item := get_item_at_position(position)
+	if to_item:
+		var test_item:= to_item
+		while true:
+			if test_item == item:
+				return
+			test_item = test_item.get_parent()
+			if test_item == get_root():
+				break
+	
+	var parent := get_root()
+	if to_item:
+		parent = to_item.get_parent()
+	
+	if to_item and to_item.get_metadata(0).has('group'):
+		parent = to_item
+	
+	var new_item := copy_branch_or_item(item, parent)
+	
+	if to_item and !to_item.get_metadata(0).has('group'):
+		new_item.move_after(to_item)
+	
+	item.free()
+
+
+func copy_branch_or_item(item:TreeItem, new_parent:TreeItem) -> TreeItem:
+	var new_item :TreeItem = null
+	if item.get_metadata(0).has('group'):
+		new_item = add_portrait_group(item.get_text(0), new_parent)
+	else:
+		new_item = add_portrait_item(item.get_text(0), item.get_metadata(0), new_parent)
+	
+	for child in item.get_children():
+		copy_branch_or_item(child, new_item)
+	return new_item

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_ptab_exports.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_ptab_exports.gd
@@ -1,0 +1,102 @@
+@tool
+extends DialogicCharacterEditorPortraitSettingsTab
+
+## Tab that allows setting values of exported scene variables
+## for custom portrait scenes
+
+var current_portrait_data := {}
+
+func _ready() -> void:
+	get_parent().set_tab_icon(get_index(), get_theme_icon("EditInternal", "EditorIcons"))
+	add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
+
+func _load_portrait_data(data:Dictionary) -> void:
+	if data.get('scene', '').is_empty():
+		get_parent().set_tab_hidden(get_index(), true)
+	else:
+		get_parent().set_tab_hidden(get_index(), false)
+	
+		current_portrait_data = data
+		load_portrait_scene_export_variables()
+
+func load_portrait_scene_export_variables():
+	var scene = null
+	if !current_portrait_data.get('scene', '').is_empty():
+		scene = load(current_portrait_data.get('scene'))
+	
+	if !scene:
+		return
+	
+	for child in $Grid.get_children(): 
+		child.queue_free()
+	
+	scene = scene.instantiate()
+	for i in scene.script.get_script_property_list():
+		if i['usage'] & PROPERTY_USAGE_EDITOR:
+			var label = Label.new()
+			label.text = i['name']
+			label.add_theme_stylebox_override('normal', get_theme_stylebox("CanvasItemInfoOverlay", "EditorStyles"))
+			label.size_flags_horizontal = SIZE_EXPAND_FILL
+			$Grid.add_child(label)
+			
+			
+			var input = null
+			var current_value :String = ""
+			if current_portrait_data.has('export_overrides') and current_portrait_data['export_overrides'].has(i['name']):
+				current_value = current_portrait_data['export_overrides'][i['name']]
+			match typeof(scene.get(i['name'])):
+				TYPE_BOOL:
+					input = CheckBox.new()
+					if current_value:
+						input.button_pressed = current_value == "true"
+					input.toggled.connect(_on_export_bool_submitted.bind(i['name']))
+				TYPE_COLOR:
+					input = ColorPickerButton.new()
+					if current_value:
+						input.color = str_to_var(current_value)
+					input.color_changed.connect(_on_export_color_submitted.bind(i['name']))
+					input.custom_minimum_size.x = DialogicUtil.get_editor_scale()*50
+				TYPE_INT:
+					if i['hint'] & PROPERTY_HINT_ENUM:
+						input = OptionButton.new()
+						for x in i['hint_string'].split(','):
+							input.add_item(x)
+						input.item_selected.connect(_on_export_int_enum_submitted.bind(i['name']))
+				_:
+					input = LineEdit.new()
+					if current_value:
+						input.text = current_value
+					input.text_submitted.connect(_on_export_input_text_submitted.bind(i['name']))
+			input.size_flags_horizontal = SIZE_EXPAND_FILL
+			$Grid.add_child(input)
+		if i['usage'] & PROPERTY_USAGE_GROUP:
+			var title := Label.new()
+			title.text = i['name']
+			title.add_theme_stylebox_override('normal', get_theme_stylebox("ContextualToolbar", "EditorStyles"))
+			$Grid.add_child(title)
+			$Grid.add_child(Control.new())
+
+func set_export_override(property_name:String, value:String = "") -> void:
+	var data:Dictionary = selected_item.get_metadata(0)
+	if !data.has('export_overrides'):
+		data['export_overrides'] = {}
+	
+	if !value.is_empty():
+		data['export_overrides'][property_name] = value
+	else:
+		data['export_overrides'].erase(property_name)
+	
+	changed.emit()
+	update_preview.emit()
+
+func _on_export_input_text_submitted(text:String, property_name:String) -> void:
+	set_export_override(property_name, var_to_str(text))
+
+func _on_export_bool_submitted(value:bool, property_name:String) -> void:
+	set_export_override(property_name, var_to_str(value))
+
+func _on_export_color_submitted(color:Color, property_name:String) -> void:
+	set_export_override(property_name, var_to_str(color))
+
+func _on_export_int_enum_submitted(item:int, property_name:String) -> void:
+	set_export_override(property_name, var_to_str(item))

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_ptab_image.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_ptab_image.gd
@@ -13,12 +13,7 @@ func _ready() -> void:
 func _load_portrait_data(data:Dictionary) -> void:
 	# hides/shows this tab based on the scene value of this portrait
 	# (only shown if the default scene is used) 
-	if !data.get('scene', '').is_empty():
-		get_parent().set_tab_hidden(get_index(), true)
-		while get_parent().is_tab_hidden(get_parent().current_tab):
-			get_parent().current_tab = (get_parent().current_tab+1)%get_parent().get_tab_count()
-	else:
-		get_parent().set_tab_hidden(get_index(), false)
+	get_parent().set_tab_hidden(get_index(), !data.get('scene', '').is_empty())
 	
 	%ImagePicker.set_value(data.get('image', ''))
 

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.gd
@@ -10,16 +10,6 @@ func _ready() -> void:
 	%DisplayNameLineEdit.text_changed.connect(character_editor.something_changed)
 	%NicknameLineEdit.text_changed.connect(character_editor.something_changed)
 	%DescriptionTextEdit.text_changed.connect(character_editor.something_changed)
-	%DefaultPortraitPicker.value_changed.connect(default_portrait_changed)
-	%MainScale.value_changed.connect(main_portrait_settings_update)
-	%MainOffsetX.value_changed.connect(main_portrait_settings_update)
-	%MainOffsetY.value_changed.connect(main_portrait_settings_update)
-	%MainMirror.toggled.connect(main_portrait_settings_update)
-	
-	# Setting up Default Portrait Picker
-	%DefaultPortraitPicker.resource_icon = load("res://addons/dialogic/Editor/Images/Resources/portrait.svg")
-	%DefaultPortraitPicker.get_suggestions_func = suggest_portraits
-	%DefaultPortraitPicker.set_left_text("")
 
 
 func _load_character(resource:DialogicCharacter) -> void:
@@ -32,12 +22,6 @@ func _load_character(resource:DialogicCharacter) -> void:
 	%NicknameLineEdit.text = %NicknameLineEdit.text.trim_suffix(', ')
 	
 	%DescriptionTextEdit.text = resource.description
-	%DefaultPortraitPicker.set_value(resource.default_portrait)
-	
-	%MainScale.value = 100*resource.scale
-	%MainOffsetX.value = resource.offset.x
-	%MainOffsetY.value = resource.offset.y
-	%MainMirror.button_pressed = resource.mirror
 
 
 func _save_changes(resource:DialogicCharacter) -> DialogicCharacter:
@@ -49,37 +33,4 @@ func _save_changes(resource:DialogicCharacter) -> DialogicCharacter:
 	resource.nicknames = nicknames
 	resource.description = %DescriptionTextEdit.text
 	
-	if $'%DefaultPortraitPicker'.current_value in resource.portraits.keys():
-		resource.default_portrait = $'%DefaultPortraitPicker'.current_value
-	elif !resource.portraits.is_empty():
-		resource.default_portrait = resource.portraits.keys()[0]
-	else:
-		resource.default_portrait = ""
-	
-	resource.scale = %MainScale.value/100.0
-	resource.offset = Vector2(%MainOffsetX.value, %MainOffsetY.value) 
-	resource.mirror = %MainMirror.button_pressed
-	
 	return resource
-
-
-# Get suggestions for DefaultPortraitPicker
-func suggest_portraits(search:String) -> Dictionary:
-	var suggestions := {}
-	for portrait in character_editor.get_updated_portrait_dict().keys():
-		suggestions[portrait] = {'value':portrait}
-	return suggestions
-
-
-# Make sure preview get's updated when portrait settings change
-func main_portrait_settings_update(value = null) -> void:
-	character_editor.current_resource.scale = %MainScale.value/100.0
-	character_editor.current_resource.offset = Vector2(%MainOffsetX.value, %MainOffsetY.value) 
-	character_editor.current_resource.mirror = %MainMirror.button_pressed
-	character_editor.update_preview()
-	character_editor.something_changed()
-
-func default_portrait_changed(property:String, value:String) -> void:
-	character_editor.current_resource.default_portrait = value
-	character_editor.update_default_portrait_star(value)
-	

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.tscn
@@ -19,7 +19,6 @@ script = ExtResource("1_3e1i1")
 
 [node name="Label2" type="Label" parent="."]
 layout_mode = 2
-tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable: {Player.name}"
 text = "Display Name: "
 
 [node name="DisplayName" type="HBoxContainer" parent="."]
@@ -29,7 +28,7 @@ size_flags_horizontal = 3
 [node name="DisplayNameLineEdit" type="LineEdit" parent="DisplayName"]
 unique_name_in_owner = true
 layout_mode = 2
-tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable: {Player.name}"
+tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable. E.g. :{Player.name}"
 expand_to_text_length = true
 caret_blink = true
 caret_blink_interval = 0.5
@@ -44,7 +43,6 @@ edit_alpha = false
 
 [node name="Label3" type="Label" parent="."]
 layout_mode = 2
-tooltip_text = "If autocolor names is enabled, these will be colored in the characters color as well."
 text = "Nicknames:"
 
 [node name="NicknameLineEdit" type="LineEdit" parent="."]
@@ -58,7 +56,6 @@ caret_blink_interval = 0.5
 [node name="Label4" type="Label" parent="."]
 layout_mode = 2
 size_flags_vertical = 0
-tooltip_text = "No effect, just for you."
 text = "Description:"
 
 [node name="DescriptionTextEdit" type="TextEdit" parent="."]

--- a/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.tscn
@@ -1,6 +1,5 @@
-[gd_scene load_steps=3 format=3 uid="uid://de5kj4vd0we1w"]
+[gd_scene load_steps=2 format=3 uid="uid://de5kj4vd0we1w"]
 
-[ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="1_3b04d"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/character_editor_tab_general.gd" id="1_3e1i1"]
 
 [node name="General" type="GridContainer"]
@@ -20,27 +19,17 @@ script = ExtResource("1_3e1i1")
 
 [node name="Label2" type="Label" parent="."]
 layout_mode = 2
-offset_right = 131.0
-offset_bottom = 26.0
-size_flags_vertical = 0
+tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable: {Player.name}"
 text = "Display Name: "
 
 [node name="DisplayName" type="HBoxContainer" parent="."]
 layout_mode = 2
-offset_left = 132.0
-offset_right = 1137.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
-
-[node name="CheckBox" type="CheckBox" parent="DisplayName"]
-visible = false
-layout_mode = 2
 
 [node name="DisplayNameLineEdit" type="LineEdit" parent="DisplayName"]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 67.0
-offset_bottom = 31.0
+tooltip_text = "This name will be displayed on the name label. You can use a dialogic variable: {Player.name}"
 expand_to_text_length = true
 caret_blink = true
 caret_blink_interval = 0.5
@@ -49,173 +38,33 @@ caret_blink_interval = 0.5
 unique_name_in_owner = true
 custom_minimum_size = Vector2(30, 0)
 layout_mode = 2
-offset_left = 71.0
-offset_right = 101.0
-offset_bottom = 31.0
+tooltip_text = "This color can be used on the name label and for occurences of the characters name in text (autocolor names)."
 color = Color(1, 1, 1, 1)
 edit_alpha = false
 
 [node name="Label3" type="Label" parent="."]
 layout_mode = 2
-offset_top = 37.0
-offset_right = 131.0
-offset_bottom = 63.0
-size_flags_vertical = 0
+tooltip_text = "If autocolor names is enabled, these will be colored in the characters color as well."
 text = "Nicknames:"
 
-[node name="DisplayNickname" type="HBoxContainer" parent="."]
-layout_mode = 2
-offset_left = 132.0
-offset_top = 37.0
-offset_right = 1137.0
-offset_bottom = 68.0
-size_flags_horizontal = 3
-
-[node name="NicknameLineEdit" type="LineEdit" parent="DisplayNickname"]
+[node name="NicknameLineEdit" type="LineEdit" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 1005.0
-offset_bottom = 31.0
 size_flags_horizontal = 3
+tooltip_text = "If autocolor names is enabled, these will be colored in the characters color as well."
 caret_blink = true
 caret_blink_interval = 0.5
 
 [node name="Label4" type="Label" parent="."]
 layout_mode = 2
-offset_top = 74.0
-offset_right = 131.0
-offset_bottom = 100.0
 size_flags_vertical = 0
+tooltip_text = "No effect, just for you."
 text = "Description:"
 
-[node name="Description" type="HBoxContainer" parent="."]
-layout_mode = 2
-offset_left = 132.0
-offset_top = 74.0
-offset_right = 1137.0
-offset_bottom = 109.0
-size_flags_horizontal = 3
-
-[node name="DescriptionTextEdit" type="TextEdit" parent="Description"]
+[node name="DescriptionTextEdit" type="TextEdit" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
-offset_right = 1005.0
-offset_bottom = 35.0
 size_flags_horizontal = 3
+tooltip_text = "No effect, just for you."
 wrap_mode = 1
 scroll_fit_content_height = true
-
-[node name="Label5" type="Label" parent="."]
-layout_mode = 2
-offset_top = 115.0
-offset_right = 131.0
-offset_bottom = 141.0
-size_flags_vertical = 0
-text = "Default Portrait:"
-
-[node name="DefaultPortrait" type="HBoxContainer" parent="."]
-layout_mode = 2
-offset_left = 132.0
-offset_top = 115.0
-offset_right = 1137.0
-offset_bottom = 150.0
-size_flags_horizontal = 3
-
-[node name="DefaultPortraitPicker" parent="DefaultPortrait" instance=ExtResource("1_3b04d")]
-unique_name_in_owner = true
-layout_mode = 2
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
-offset_left = 0.0
-offset_top = 0.0
-offset_right = 180.0
-offset_bottom = 35.0
-grow_horizontal = 1
-grow_vertical = 1
-
-[node name="Label6" type="Label" parent="."]
-layout_mode = 2
-offset_top = 156.0
-offset_right = 131.0
-offset_bottom = 182.0
-size_flags_vertical = 0
-text = "Portrait Settings:"
-
-[node name="PortraitMainSettings" type="HFlowContainer" parent="."]
-layout_mode = 2
-offset_left = 132.0
-offset_top = 156.0
-offset_right = 1137.0
-offset_bottom = 187.0
-size_flags_horizontal = 3
-
-[node name="Label" type="Label" parent="PortraitMainSettings"]
-layout_mode = 2
-offset_top = 2.0
-offset_right = 40.0
-offset_bottom = 28.0
-text = "Scale"
-
-[node name="MainScale" type="SpinBox" parent="PortraitMainSettings"]
-unique_name_in_owner = true
-layout_mode = 2
-offset_left = 44.0
-offset_right = 127.0
-offset_bottom = 31.0
-value = 100.0
-allow_greater = true
-suffix = "%"
-
-[node name="Offset" type="HBoxContainer" parent="PortraitMainSettings"]
-layout_mode = 2
-offset_left = 131.0
-offset_right = 353.0
-offset_bottom = 31.0
-
-[node name="Label2" type="Label" parent="PortraitMainSettings/Offset"]
-layout_mode = 2
-offset_top = 2.0
-offset_right = 48.0
-offset_bottom = 28.0
-text = "Offset"
-
-[node name="MainOffsetX" type="SpinBox" parent="PortraitMainSettings/Offset"]
-unique_name_in_owner = true
-layout_mode = 2
-offset_left = 52.0
-offset_right = 135.0
-offset_bottom = 31.0
-allow_greater = true
-allow_lesser = true
-suffix = "X"
-
-[node name="MainOffsetY" type="SpinBox" parent="PortraitMainSettings/Offset"]
-unique_name_in_owner = true
-layout_mode = 2
-offset_left = 139.0
-offset_right = 222.0
-offset_bottom = 31.0
-allow_greater = true
-allow_lesser = true
-suffix = "Y"
-
-[node name="MirrorOption" type="HBoxContainer" parent="PortraitMainSettings"]
-layout_mode = 2
-offset_left = 357.0
-offset_right = 435.0
-offset_bottom = 31.0
-
-[node name="Label" type="Label" parent="PortraitMainSettings/MirrorOption"]
-layout_mode = 2
-offset_top = 2.0
-offset_right = 50.0
-offset_bottom = 28.0
-text = "Mirror"
-
-[node name="MainMirror" type="CheckBox" parent="PortraitMainSettings/MirrorOption"]
-unique_name_in_owner = true
-layout_mode = 2
-offset_left = 54.0
-offset_right = 78.0
-offset_bottom = 31.0

--- a/addons/dialogic/Events/Character/default_portrait.gd
+++ b/addons/dialogic/Events/Character/default_portrait.gd
@@ -43,4 +43,6 @@ func _set_mirror(mirror:bool) -> void:
 
 ## If implemented, this is used by the editor for the "full view" mode
 func _get_covered_rect() -> Rect2:
+	if $Portrait.texture == null: 
+		return Rect2()
 	return Rect2($Portrait.position, $Portrait.get_rect().size)

--- a/addons/dialogic/Events/Character/default_portrait.gd
+++ b/addons/dialogic/Events/Character/default_portrait.gd
@@ -22,7 +22,7 @@ func _should_do_portrait_update(character:DialogicCharacter, portrait:String) ->
 
 ## If the custom portrait accepts a change, then accept it here
 func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
-	if passed_portrait == "":
+	if passed_portrait == "" or not passed_portrait in passed_character.portraits.keys():
 		passed_portrait = passed_character['default_portrait']
 	portrait = passed_portrait
 	if passed_character != null:

--- a/addons/dialogic/Events/Character/default_portrait.tscn
+++ b/addons/dialogic/Events/Character/default_portrait.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=3 format=3 uid="uid://c4yp65n7ju1br"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Events/Character/default_portrait.gd" id="1_wn77n"]
 

--- a/addons/dialogic/Events/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Events/Character/subsystem_portraits.gd
@@ -130,6 +130,10 @@ func change_portrait(character:DialogicCharacter, portrait:String, mirrored:bool
 			portrait_node.scale = Vector2(1,1)*character.scale * character.portraits[portrait].get('scale', 1)
 		else:
 			portrait_node.scale = Vector2(1,1)*character.portraits[portrait].get('scale', 1)
+		
+		for property in character.portraits[portrait].get('export_overrides', {}).keys():
+			portrait_node.set(property, str_to_var(character.portraits[portrait]['export_overrides'][property]))
+		
 		if portrait_node.has_method('_update_portrait'):
 			portrait_node._update_portrait(character, portrait)
 		if portrait_node.has_method('_set_mirror'):

--- a/addons/dialogic/Events/Text/character_settings/ui_mood_item.tscn
+++ b/addons/dialogic/Events/Text/character_settings/ui_mood_item.tscn
@@ -1,14 +1,14 @@
-[gd_scene load_steps=6 format=3]
+[gd_scene load_steps=6 format=3 uid="uid://x8alx74fnm10"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Events/Text/character_settings/ui_mood_item.gd" id="2"]
 [ext_resource type="Script" path="res://addons/dialogic/Events/Text/node_type_sound.gd" id="3"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_h1p4u"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rsmy0"]
 content_margin_left = 4.0
 content_margin_top = 4.0
 content_margin_right = 4.0
 content_margin_bottom = 4.0
-bg_color = Color(0.147, 0.168, 0.203, 1)
+bg_color = Color(1, 0.365, 0.365, 1)
 draw_center = false
 border_width_left = 2
 border_width_top = 2
@@ -16,7 +16,7 @@ border_width_right = 2
 border_width_bottom = 2
 corner_detail = 1
 
-[sub_resource type="Image" id="Image_7wswg"]
+[sub_resource type="Image" id="Image_uegt4"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -25,163 +25,123 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_o5mle"]
-image = SubResource("Image_7wswg")
+[sub_resource type="ImageTexture" id="ImageTexture_osvex"]
+image = SubResource("Image_uegt4")
 
 [node name="MoodItem" type="PanelContainer"]
 size_flags_horizontal = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_h1p4u")
+theme_override_styles/panel = SubResource("StyleBoxFlat_rsmy0")
 script = ExtResource("2")
 
 [node name="VBox" type="VBoxContainer" parent="."]
-offset_left = 4.0
-offset_top = 4.0
-offset_right = 241.0
-offset_bottom = 135.0
+layout_mode = 2
 
 [node name="General" type="HBoxContainer" parent="VBox"]
-offset_right = 237.0
-offset_bottom = 31.0
+layout_mode = 2
 
 [node name="Name" type="LineEdit" parent="VBox/General"]
 unique_name_in_owner = true
-offset_right = 125.0
-offset_bottom = 31.0
+layout_mode = 2
 size_flags_horizontal = 3
-hint_tooltip = "Mood name"
+tooltip_text = "Mood name"
 caret_blink = true
-caret_blink_speed = 0.5
 
 [node name="Play" type="Button" parent="VBox/General"]
 unique_name_in_owner = true
-offset_left = 129.0
-offset_right = 153.0
-offset_bottom = 31.0
-hint_tooltip = "Preview"
-icon = SubResource("ImageTexture_o5mle")
+layout_mode = 2
+tooltip_text = "Preview"
+icon = SubResource("ImageTexture_osvex")
 
 [node name="Duplicate" type="Button" parent="VBox/General"]
 unique_name_in_owner = true
-offset_left = 157.0
-offset_right = 181.0
-offset_bottom = 31.0
-hint_tooltip = "Duplicate"
-icon = SubResource("ImageTexture_o5mle")
+layout_mode = 2
+tooltip_text = "Duplicate"
+icon = SubResource("ImageTexture_osvex")
 
 [node name="Delete" type="Button" parent="VBox/General"]
 unique_name_in_owner = true
-offset_left = 185.0
-offset_right = 209.0
-offset_bottom = 31.0
-hint_tooltip = "Delete"
-icon = SubResource("ImageTexture_o5mle")
+layout_mode = 2
+tooltip_text = "Delete"
+icon = SubResource("ImageTexture_osvex")
 
 [node name="Fold" type="Button" parent="VBox/General"]
 unique_name_in_owner = true
-offset_left = 213.0
-offset_right = 237.0
-offset_bottom = 31.0
-hint_tooltip = "Fold/Unfold"
+layout_mode = 2
+tooltip_text = "Fold/Unfold"
 toggle_mode = true
 button_pressed = true
-icon = SubResource("ImageTexture_o5mle")
+icon = SubResource("ImageTexture_osvex")
 
 [node name="Content" type="HBoxContainer" parent="VBox"]
 unique_name_in_owner = true
-offset_top = 35.0
-offset_right = 237.0
-offset_bottom = 131.0
+visible = false
+layout_mode = 2
 
 [node name="Control" type="Control" parent="VBox/Content"]
-offset_bottom = 96.0
+layout_mode = 2
 
 [node name="Content" type="VBoxContainer" parent="VBox/Content"]
-offset_left = 4.0
-offset_right = 237.0
-offset_bottom = 96.0
+layout_mode = 2
 size_flags_horizontal = 3
 
 [node name="SoundFolderSect" type="HBoxContainer" parent="VBox/Content/Content"]
-offset_right = 233.0
-offset_bottom = 26.0
+layout_mode = 2
 
 [node name="Label" type="Label" parent="VBox/Content/Content/SoundFolderSect"]
-offset_right = 107.0
-offset_bottom = 26.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Sounds folder"
 
 [node name="SoundFolder" type="Label" parent="VBox/Content/Content/SoundFolderSect"]
 unique_name_in_owner = true
-offset_left = 111.0
-offset_top = 1.0
-offset_right = 205.0
-offset_bottom = 24.0
+layout_mode = 2
 size_flags_horizontal = 3
 horizontal_alignment = 2
 
 [node name="ChangeSoundFolderButton" type="Button" parent="VBox/Content/Content/SoundFolderSect"]
 unique_name_in_owner = true
-offset_left = 209.0
-offset_right = 233.0
-offset_bottom = 26.0
-hint_tooltip = "Change sounds folder"
-icon = SubResource("ImageTexture_o5mle")
+layout_mode = 2
+tooltip_text = "Change sounds folder"
+icon = SubResource("ImageTexture_osvex")
 
 [node name="Pitch" type="HBoxContainer" parent="VBox/Content/Content"]
-offset_top = 30.0
-offset_right = 233.0
-offset_bottom = 61.0
+layout_mode = 2
 
 [node name="Label2" type="Label" parent="VBox/Content/Content/Pitch"]
-offset_top = 2.0
-offset_right = 59.0
-offset_bottom = 28.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Pitch"
 
 [node name="PitchBase" type="SpinBox" parent="VBox/Content/Content/Pitch"]
 unique_name_in_owner = true
-offset_left = 63.0
-offset_right = 146.0
-offset_bottom = 31.0
+layout_mode = 2
 step = 0.001
 value = 1.0
 
 [node name="PitchVariance" type="SpinBox" parent="VBox/Content/Content/Pitch"]
 unique_name_in_owner = true
-offset_left = 150.0
-offset_right = 233.0
-offset_bottom = 31.0
+layout_mode = 2
 step = 0.001
 prefix = "+/-"
 
 [node name="Volume" type="HBoxContainer" parent="VBox/Content/Content"]
-offset_top = 65.0
-offset_right = 233.0
-offset_bottom = 96.0
+layout_mode = 2
 
 [node name="Label3" type="Label" parent="VBox/Content/Content/Volume"]
-offset_top = 2.0
-offset_right = 59.0
-offset_bottom = 28.0
+layout_mode = 2
 size_flags_horizontal = 3
 text = "Volume"
 
 [node name="VolumeBase" type="SpinBox" parent="VBox/Content/Content/Volume"]
 unique_name_in_owner = true
-offset_left = 63.0
-offset_right = 146.0
-offset_bottom = 31.0
+layout_mode = 2
 min_value = -80.0
 step = 0.001
 suffix = "db"
 
 [node name="VolumeVariance" type="SpinBox" parent="VBox/Content/Content/Volume"]
 unique_name_in_owner = true
-offset_left = 150.0
-offset_right = 233.0
-offset_bottom = 31.0
+layout_mode = 2
 step = 0.001
 prefix = "+/-"
 

--- a/addons/dialogic/Events/Text/node_type_sound.gd
+++ b/addons/dialogic/Events/Text/node_type_sound.gd
@@ -76,7 +76,7 @@ func _on_continued_revealing_text(new_character) -> void:
 	stream = current_overwrite_data.get('sounds', sounds)[RNG.randi_range(0, sounds.size() - 1)]
 	
 	#choose a random pitch and volume
-	pitch_scale = current_overwrite_data.get('pitch_base', base_pitch) + current_overwrite_data.get('pitch_variance', pitch_variance) * RNG.randf_range(-1.0, 1.0)
+	pitch_scale = max(0, current_overwrite_data.get('pitch_base', base_pitch) + current_overwrite_data.get('pitch_variance', pitch_variance) * RNG.randf_range(-1.0, 1.0))
 	volume_db = current_overwrite_data.get('volume_base', base_volume) + current_overwrite_data.get('volume_variance',volume_variance) * RNG.randf_range(-1.0, 1.0)
 	
 	#play the sound

--- a/addons/dialogic/plugin.gd
+++ b/addons/dialogic/plugin.gd
@@ -14,8 +14,8 @@ const MainPanel := preload("res://addons/dialogic/Editor/editor_main.tscn")
 var editor_view: Control
 
 # multiple editor compononents/helper classes
-var _parts_inspector : EditorInspectorPlugin
-var _export_plugin : EditorExportPlugin
+#var _parts_inspector : EditorInspectorPlugin # TODO remove
+#var _export_plugin : EditorExportPlugin # TODO remove
 var editor_interface : EditorInterface
 
 # emitted if godot wants us to save
@@ -56,8 +56,8 @@ func _exit_tree() -> void:
 	if editor_view:
 		remove_control_from_bottom_panel(editor_view)
 		editor_view.queue_free()
-	remove_inspector_plugin(_parts_inspector)
-	remove_export_plugin(_export_plugin)
+#	remove_inspector_plugin(_parts_inspector)
+#	remove_export_plugin(_export_plugin)
 
 
 func _has_main_screen() -> bool:


### PR DESCRIPTION
# Big features
## Groups for portrait list
- #1047, #666

![grafik](https://user-images.githubusercontent.com/42868150/209653107-d7bdd6ac-154a-4368-be8e-d810d81d12b0.png)

The portrait list now allows to add groups. These are not actually saved. If a portrait is in a group it will be saved as it's full path (with / e.g.: "Group/Subgroup/Portrait").
You can now also drag and drop to reorder/reparent portrait items.


## Custom exports
- #820

Custom portrait scenes now have a Export tab in the portrait settings section. If the scenes script has some exported variables, they will be listed there. 

For scenes that are in @tool mode, updates can be shown in editor (even with transitions if _should_do_portrait_update() returns true).

These "export_overrides" are saved in the portrait data and applied on change_portrait().
![grafik](https://user-images.githubusercontent.com/42868150/209653479-fc4cc478-37c2-4a01-bc10-0a49cd13776e.png)
![grafik](https://user-images.githubusercontent.com/42868150/209653643-74233346-bdd1-462c-990c-e1c41535ffc2.png)


# Small changes
- Fix some preview updating bugs #1192, #1361, #1360, #1363
--> Note: Most of these were fixed by making the character editor autosave again, as that means the preview can use the character resource to get all information. This instant autosave might not be desired, but isn't to bad for now. In the future, we might want to pass a fake character resource to the preview, not sure.
- move default portrait and main scale, mirror and offset to a new Portrait Settings tab in the portrait list section to make the main tab less crowded 