### PR TITLE
Save system updates

### DIFF
--- a/addons/dialogic/Events/Save/event_save.gd
+++ b/addons/dialogic/Events/Save/event_save.gd
@@ -8,7 +8,8 @@ extends DialogicEvent
 ### Settings
 
 ## The name of the slot to save to. Learn more in the saving subsystem.
-var slot_name: String = "Default"
+## If empty, the event will attempt to save to the latest slot, and otherwise use the default.
+var slot_name: String = ""
 
 
 ################################################################################
@@ -16,7 +17,12 @@ var slot_name: String = "Default"
 ################################################################################
 
 func _execute() -> void:
-	if slot_name:
+	if slot_name.is_empty():
+		if Dialogic.Save.get_latest_slot():
+			dialogic.Save.save(Dialogic.Save.get_latest_slot())
+		else:
+			dialogic.Save.save()
+	else:
 		dialogic.Save.save(slot_name)
 	finish()
 

--- a/addons/dialogic/Events/Save/subsystem_save.gd
+++ b/addons/dialogic/Events/Save/subsystem_save.gd
@@ -2,16 +2,23 @@ extends DialogicSubsystem
 
 ### Subsystem that manages saving and loading data.
 
+
+## Emitted when a save was done. Keys of the info dictionary are "slot_name" and "is_autosave".
+signal saved(info:Dictionary)
+
 ## The directory that will be saved to.
-const SAVE_SLOTS_DIR = "user://dialogic/saves/"
+const SAVE_SLOTS_DIR := "user://dialogic/saves/"
+
 ## Temporarily stores a taken screen capture when using [take_slot_image()].
-var _saved_image = null
+enum THUMBNAIL_MODE {NONE, TAKE_AND_STORE, STORE_ONLY}
+var latest_thumbnail : Image = null
 
 
 ####################################################################################################
 ##					STATE
 ####################################################################################################
 
+## Built-in, called by DialogicGameHandler.
 func clear_game_state():
 	_make_sure_slot_dir_exists()
 
@@ -20,44 +27,62 @@ func clear_game_state():
 ##					MAIN METHODS
 ####################################################################################################
 
-func save(slot_name:String = '', is_autosave:bool = false, create_thumbnail:bool= true, slot_info :Dictionary = {}):
-	# check if to save (if this is a autosave)
+## Saves the current state to the given slot. 
+## If no slot is given the default slot is used (name can be set in the dialogic settings)
+## If you want to change to the current slot use save(Dialogic.Save.get_latest_slot())
+func save(slot_name:String = '', is_autosave:bool = false, thumbnail_mode:THUMBNAIL_MODE=THUMBNAIL_MODE.TAKE_AND_STORE, slot_info :Dictionary = {}):
+	# check if to save (if this is an autosave)
 	if is_autosave and !DialogicUtil.get_project_setting('dialogic/save/autosave', false):
 		return
 	
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty(): return
+	if slot_name.is_empty():
+		slot_name = get_default_slot()
+	
+	set_latest_slot(slot_name)
 	
 	save_file(slot_name, 'state.txt', dialogic.get_full_state())
 	
-	if create_thumbnail:
-		take_slot_image()
-		store_slot_image(slot_name)
+	if thumbnail_mode == THUMBNAIL_MODE.TAKE_AND_STORE:
+		take_thumbnail()
+		save_slot_thumbnail(slot_name)
+	elif thumbnail_mode == THUMBNAIL_MODE.STORE_ONLY:
+		save_slot_thumbnail(slot_name)
+	
 	if slot_info:
 		store_slot_info(slot_name, slot_info)
 	
+	saved.emit({"slot_name":slot_name, "is_autosave": is_autosave})
 	print('[Dialogic] Saved to slot "'+slot_name+'".')
 
 
+## Loads all info from the given slot in the DialogicGameHandler (Dialogic Autoload).
+## If no slot is given, the default slot is used.
+## To check if something is saved in that slot use has_slot(). 
+## If the slot does not exist, this method will fail. 
 func load(slot_name:String):
+	if slot_name.is_empty(): slot_name = get_default_slot()
+	
+	if !has_slot(slot_name):
+		printerr("[Dialogic Error] Tried loading from invalid save slot '"+slot_name+"'.")
+		return
 	set_latest_slot(slot_name)
 	dialogic.load_full_state(load_file(slot_name, 'state.txt', {}))
 
 
-func save_file(slot_name:String, file_name:String, data) -> void:
-	slot_name = this_or_current_slot(slot_name)
+# Saves a variable to a file in the given slot.
+func save_file(slot_name:String, file_name:String, data:Variant) -> void:
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	if not slot_name.is_empty():
-		if slot_name.is_empty() in get_slot_names():
+		if !has_slot(slot_name):
 			add_empty_slot(slot_name)
 		
 		var file = FileAccess.open(SAVE_SLOTS_DIR.path_join(slot_name).path_join(file_name), FileAccess.WRITE)
 		file.store_var(data, true)
 
 
-func load_file(slot_name:String, file_name:String, default):
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty():
-		return
+## Loads a file from a given list and returns the contained info as a variable.
+func load_file(slot_name:String, file_name:String, default:Variant) -> Variant:
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	
 	var path := get_slot_path(slot_name).path_join(file_name)
 	
@@ -67,9 +92,29 @@ func load_file(slot_name:String, file_name:String, default):
 	return default
 
 
+
+func set_global_info(key:String, value:Variant) -> void:
+	var global_info := ConfigFile.new()
+	if global_info.load(SAVE_SLOTS_DIR.path_join('global_info.txt')) == OK:
+		global_info.set_value('main', key, value)
+		global_info.save(SAVE_SLOTS_DIR.path_join('global_info.txt'))
+	else:
+		printerr("[Dialogic Error]: Couldn't access global saved info file.")
+
+
+func get_global_info(key:String, default:Variant) -> Variant:
+	var global_info := ConfigFile.new()
+	if global_info.load(SAVE_SLOTS_DIR.path_join('global_info.txt')) == OK:
+		return global_info.get_value('main', key, default)
+	printerr("[Dialogic Error]: Couldn't access global saved info file.")
+	return default
+
+
 ####################################################################################################
 ##					SLOT HELPERS
 ####################################################################################################
+## Returns a list of all available slots. Usefull for iterating over all slots 
+## (for example to build a UI list). 
 func get_slot_names() -> Array:
 	var save_folders := []
 
@@ -82,15 +127,17 @@ func get_slot_names() -> Array:
 				save_folders.append(file_name)
 			file_name = directory.get_next()
 		return save_folders
-	
 	return []
 
 
+## Returns true if the given slot exists.
 func has_slot(slot_name:String) -> bool:
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	return slot_name in get_slot_names()
 
 
-func remove_slot(slot_name:String) -> void:
+## Removes all the given slot along with all it's info/files.
+func delete_slot(slot_name:String) -> void:
 	var path := SAVE_SLOTS_DIR.path_join(slot_name)
 	
 	if DirAccess.dir_exists_absolute(path):
@@ -104,42 +151,54 @@ func remove_slot(slot_name:String) -> void:
 		directory.remove(SAVE_SLOTS_DIR.path_join(slot_name))
 
 
-# this adds a new save folder with the given name
+## this adds a new save folder with the given name
+##
 func add_empty_slot(slot_name: String) -> void:
 	if DirAccess.dir_exists_absolute(SAVE_SLOTS_DIR):
 		var directory := DirAccess.open(SAVE_SLOTS_DIR)
 		directory.make_dir(slot_name)
 
 
-# reset the state of the given save folder (or default)
+## reset the state of the given save folder (or default)
 func reset_slot(slot_name: String = '') -> void:
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty(): return
+	if slot_name.is_empty(): slot_name = get_default_slot()
 
 	save_file(slot_name, 'state.txt', {})
 
 
+## Returns the full path to the given slot folder
 func get_slot_path(slot_name:String) -> String:
 	return SAVE_SLOTS_DIR.path_join(slot_name)
 
 
+## Returns the default slot name defined in the dialogic settings
+func get_default_slot() -> String:
+	return DialogicUtil.get_project_setting('dialogic/save/default_slot', 'Default')
+
+
+## Returns the latest slot or empty if nothing was saved yet
 func get_latest_slot() -> String:
-	return DialogicUtil.get_project_setting('dialogic/save/latest_save', DialogicUtil.get_project_setting('dialogic/save/default_slot', 'Default'))
+	var latest_slot :String = ""
+	if Engine.get_main_loop().has_meta('dialogic_latest_saved_slot'):
+		latest_slot = Engine.get_main_loop().get_meta('dialogic_latest_saved_slot', '')
+	else:
+		latest_slot = get_global_info('latest_save_slot', '')
+		Engine.get_main_loop().set_meta('dialogic_latest_saved_slot', latest_slot)
+	if !has_slot(latest_slot):
+		return ''
+	return latest_slot
 
 
 func set_latest_slot(slot_name:String) -> void:
-	ProjectSettings.set_setting('dialogic/save/latest_save', slot_name)
-	ProjectSettings.save()
+	Engine.get_main_loop().set_meta('dialogic_latest_saved_slot', slot_name)
+	set_global_info('latest_save_slot', slot_name)
 
 
 func _make_sure_slot_dir_exists() -> void:
 	if not DirAccess.dir_exists_absolute(SAVE_SLOTS_DIR):
 		DirAccess.make_dir_recursive_absolute(SAVE_SLOTS_DIR)
-
-
-func this_or_current_slot(slot_name:String) -> String:
-	if slot_name: set_latest_slot(slot_name)
-	return slot_name if slot_name.is_empty() else get_latest_slot()
+	if not FileAccess.file_exists(SAVE_SLOTS_DIR.path_join('global_info.txt')):
+		FileAccess.open(SAVE_SLOTS_DIR.path_join('global_info.txt'), FileAccess.WRITE)
 
 
 ####################################################################################################
@@ -147,14 +206,12 @@ func this_or_current_slot(slot_name:String) -> String:
 ####################################################################################################
 
 func store_slot_info(slot_name:String, info: Dictionary) -> void:
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty(): return
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	save_file(slot_name, 'info.txt', info)
 
 
 func get_slot_info(slot_name:String = '') -> Dictionary:
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty(): return {}
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	return load_file(slot_name, 'info.txt', {})
 
 
@@ -162,31 +219,24 @@ func get_slot_info(slot_name:String = '') -> Dictionary:
 ##					SLOT IMAGE
 ####################################################################################################
 
-func take_slot_image() -> void:
-	_saved_image = get_viewport().get_texture().get_image()
-	_saved_image.flip_y()
+## Can be called manually to create a thumbnail. Then call save() with THUMBNAIL_MODE.STORE_ONLY
+func take_thumbnail() -> void:
+	latest_thumbnail = get_viewport().get_texture().get_image()
 
 
-func store_slot_image(slot_name:String) -> void:
-	if _saved_image:
-		_saved_image.save_png(get_slot_path(slot_name).path_join('thumbnail.png'))
+## No need to call from outside. Used to store the latest thumbnail to the given slot.
+func save_slot_thumbnail(slot_name:String) -> void:
+	if latest_thumbnail:
+		latest_thumbnail.save_png(get_slot_path(slot_name).path_join('thumbnail.png'))
 
 
-func get_slot_image(slot_name:String) -> ImageTexture:
-	slot_name = this_or_current_slot(slot_name)
-	if slot_name.is_empty(): return null
+## Returns an ImageTexture containing the thumbnail of that slot.
+func get_slot_thumbnail(slot_name:String) -> ImageTexture:
+	if slot_name.is_empty(): slot_name = get_default_slot()
 	
 	var path := get_slot_path(slot_name).path_join('thumbnail.png')
 	if FileAccess.file_exists(path):
-		var file := FileAccess.open(path, FileAccess.READ)
-		var buffer = file.get_buffer(file.get_len())
-
-		var image = Image.new()
-		image.load_png_from_buffer(buffer)
-
-		var image_texture = ImageTexture.new()
-		image_texture.create_from_image(image)
-		return image_texture
+		return ImageTexture.create_from_image(Image.load_from_file(path))
 	return null
 
 

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -12,13 +12,13 @@ signal speaking_character(argument)
 ##					STATE
 ####################################################################################################
 func clear_game_state() -> void:
-	update_dialog_text('')
+	update_dialog_text('', true)
 	update_name_label(null)
 	dialogic.current_state_info['character'] = null
 	dialogic.current_state_info['text'] = ''
 
 func load_game_state() -> void:
-	update_dialog_text(dialogic.current_state_info.get('text', ''))
+	update_dialog_text(dialogic.current_state_info.get('text', ''), true)
 	var character:DialogicCharacter = null
 	if dialogic.current_state_info.get('character', null):
 		character = load(dialogic.current_state_info.get('character', null))
@@ -40,15 +40,20 @@ func resume() -> void:
 ##					MAIN METHODS
 ####################################################################################################
 
-func update_dialog_text(text:String) -> void:
-	dialogic.current_state = dialogic.states.SHOWING_TEXT
+## Shows the given text on all visible DialogText nodes. 
+## Instant can be used to skip all reveiling (effects won't work).
+func update_dialog_text(text:String, instant:bool= false) -> void:
+	if !instant: dialogic.current_state = dialogic.states.SHOWING_TEXT
 	dialogic.current_state_info['text'] = text
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		if text_node.is_visible_in_tree():
-			text_node.reveal_text(text)
-			if !text_node.finished_revealing_text.is_connected(_on_dialog_text_finished):
-				text_node.finished_revealing_text.connect(_on_dialog_text_finished)
-
+			if instant:
+				text_node.text = text
+			else:
+				text_node.reveal_text(text)
+				if !text_node.finished_revealing_text.is_connected(_on_dialog_text_finished):
+					text_node.finished_revealing_text.connect(_on_dialog_text_finished)
+		
 func _on_dialog_text_finished():
 	text_finished.emit()
 


### PR DESCRIPTION
# Save event
The save event will now handle an empty name differently. If slot_name is empty it will attempt to save to the latest loaded slot, otherwise use the default slot (from the dialogic settings).

# Save subsystem
- added saved signal
- refactored/fixed thumbnail making.
- added lot's of documentation

Importrant: All slot methods will now use the default slot if slot_name is empty.

Only load() and save() will update the latest_slot. This means calling reset(), save_file(), load_file() will all NOT change the "current slot".

- the latest slot is now saved in a custom global_info file. Using the project settings turned out to be SUPER annoying, because godot would start to complain about the project file having changed. 

- made sure attempting to load from non-existent slot would produce error, but not failure

- added methods to save global info (slot-independend) 
- renamed remove_slot() to delete_slot()

# Other
- The text subsystem kept annoyingly changing the GameHandler state wrong when loading, so update_text() has now an instant flag that will skip revealing and not change the state.