### PR TITLE
Improve jump logic & bugfix

### DIFF
--- a/addons/dialogic/Events/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Events/Character/subsystem_portraits.gd
@@ -57,7 +57,7 @@ func add_portrait(character:DialogicCharacter, portrait:String,  position_idx:in
 		print_debug('[DialogicError] Cannot call add_portrait() with null character.')
 		return null
 	if not portrait in character.portraits:
-		print_debug("[DialogicError] Tried joining ",character.display_name, " wit not-existing portrait '", portrait, "'. Will use default portrait instead.")
+		print_debug("[DialogicError] Tried joining ",character.display_name, " with not-existing portrait '", portrait, "'. Will use default portrait instead.")
 		portrait = character.default_portrait
 		if portrait.is_empty():
 			print_debug("[DialogicError] Character ",character.display_name, " has no default portrait to use.")

--- a/addons/dialogic/Events/Jump/event_jump.gd
+++ b/addons/dialogic/Events/Jump/event_jump.gd
@@ -8,7 +8,15 @@ extends DialogicEvent
 ### Settings
 
 ## The timeline to jump to, if null then it's the current one. This setting should be a dialogic timeline resource.
-var timeline :DialogicTimeline = null
+var timeline :DialogicTimeline = null:
+	get:
+		if timeline == null:
+			if !_timeline_file.is_empty():
+				if _timeline_file.contains("res://"):
+					return load(_timeline_file)
+				else: 
+					return load(Dialogic.find_timeline(_timeline_file))
+		return timeline
 ## If not empty, the event will try to find a Label event with this set as name. Empty by default..
 var label_name : String = ""
 ## If true when the timeline this event jumps to finishes, dialogic will continue this one from here.
@@ -28,24 +36,16 @@ var _timeline_loaded: bool = false
 ################################################################################
 
 func _execute() -> void:
-	if timeline: # TODO: Question, why is this always done, even if return_after  is false?
-		dialogic.push_to_jump_stack()
+	if return_after:
+		dialogic.Jump.push_to_jump_stack()
 	if timeline and timeline != dialogic.current_timeline:
 		dialogic.start_timeline(timeline, label_name)
-	elif _timeline_file != "":
-		if _timeline_file.contains("res://"):
-			dialogic.start_timeline(_timeline_file, label_name)
-		else: 
-			dialogic.start_timeline(Dialogic.find_timeline(_timeline_file), label_name)
-	dialogic.jump_to_label(label_name)
-
-
-# TODO: Question what this is supposed to do. Can't see it being used anywhere. Is it for use from outside?
-func load_timeline() -> void:
-	if timeline == null:
-		if _timeline_file != "":
-			timeline = Dialogic.preload_timeline(_timeline_file)
-			_timeline_loaded = true
+	else:
+		if label_name:
+			dialogic.Jump.jump_to_label(label_name)
+			finish()
+		else:
+			dialogic.start_timeline(dialogic.current_timeline)
 
 
 ################################################################################
@@ -62,6 +62,7 @@ func _init() -> void:
 
 func _get_icon() -> Resource:
 	return load(self.get_script().get_path().get_base_dir().path_join('icon_jump.png'))
+
 
 ################################################################################
 ## 						SAVING/LOADING

--- a/addons/dialogic/Events/Jump/index.gd
+++ b/addons/dialogic/Events/Jump/index.gd
@@ -4,3 +4,6 @@ extends DialogicIndexer
 
 func _get_events() -> Array:
 	return [this_folder.path_join('event_jump.gd'), this_folder.path_join('event_label.gd')]
+
+func _get_subsystems() -> Array:
+	return [{'name':'Jump', 'script':this_folder.path_join('subsystem_jump.gd')}]

--- a/addons/dialogic/Events/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Events/Jump/subsystem_jump.gd
@@ -38,11 +38,9 @@ func jump_to_label(label:String) -> void:
 
 func push_to_jump_stack() -> void:
 	dialogic.current_state_info['jump_stack'].push_back({'timeline':dialogic.current_timeline, 'index':dialogic.current_event_idx})
-	print("pusehd" , dialogic.current_state_info['jump_stack'])
 
 
 func resume_from_latst_jump() -> void:
-	print("resume" , dialogic.current_state_info['jump_stack'])
 	dialogic.start_timeline(
 		dialogic.current_state_info['jump_stack'][-1].timeline, 
 		dialogic.current_state_info['jump_stack'][-1].index+1)

--- a/addons/dialogic/Events/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Events/Jump/subsystem_jump.gd
@@ -1,0 +1,53 @@
+extends DialogicSubsystem
+
+## Subsystem that holds methods for jumping to specific labels, or return to the previous jump.
+
+
+####################################################################################################
+##					STATE
+####################################################################################################
+
+func clear_game_state():
+	dialogic.current_state_info['jump_stack'] = []
+
+
+func load_game_state():
+	if not 'jump_stack' in dialogic.current_state_info:
+		dialogic.current_state_info['jump_stack'] = []
+
+
+####################################################################################################
+##					MAIN METHODS
+####################################################################################################
+
+func jump_to_label(label:String) -> void:
+	if label.is_empty():
+		dialogic.current_event_idx = 0
+		return
+	var idx: int = -1
+	while true:
+		idx += 1
+		var event: Variant = dialogic.current_timeline.get_event(idx)
+		if not event:
+			idx = dialogic.current_event_idx
+			break
+		if event is DialogicLabelEvent and event.name == label:
+			break
+	dialogic.current_event_idx = idx
+
+
+func push_to_jump_stack() -> void:
+	dialogic.current_state_info['jump_stack'].push_back({'timeline':dialogic.current_timeline, 'index':dialogic.current_event_idx})
+	print("pusehd" , dialogic.current_state_info['jump_stack'])
+
+
+func resume_from_latst_jump() -> void:
+	print("resume" , dialogic.current_state_info['jump_stack'])
+	dialogic.start_timeline(
+		dialogic.current_state_info['jump_stack'][-1].timeline, 
+		dialogic.current_state_info['jump_stack'][-1].index+1)
+	dialogic.current_state_info['jump_stack'].pop_back()
+
+
+func is_jump_stack_empty():
+	return len(dialogic.current_state_info['jump_stack']) < 1

--- a/addons/dialogic/Events/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Events/Variable/subsystem_variables.gd
@@ -70,7 +70,7 @@ func set_variable(variable_name: String, value: String) -> bool:
 		# if none is found, try getting it from the dialogic variables
 		_set_value_in_dictionary(variable_name, dialogic.current_state_info['variables'], value) 
 	
-	if variable_name in dialogic.current_state_info['variables'].keys():
+	elif variable_name in dialogic.current_state_info['variables'].keys():
 		if typeof(dialogic.current_state_info['variables'][variable_name]) == TYPE_STRING:
 			dialogic.current_state_info['variables'][variable_name] = value
 			return true

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -4,7 +4,6 @@ enum states {IDLE, SHOWING_TEXT, ANIMATING, AWAITING_CHOICE, WAITING}
 
 var current_timeline: Variant = null
 var current_timeline_events: Array = []
-var timeline_jump_stack: Array = []
 var character_directory: Dictionary = {}
 var timeline_directory: Dictionary = {}
 var _event_script_cache: Array[DialogicEvent] = []
@@ -77,7 +76,8 @@ func start_timeline(timeline_resource:Variant, label_or_idx:Variant = "") -> voi
 	
 	if typeof(label_or_idx) == TYPE_STRING:
 		if label_or_idx:
-			jump_to_label(label_or_idx)
+			if has_subsystem('Jump'):
+				self.Jump.jump_to_label(label_or_idx)
 	elif typeof(label_or_idx) == TYPE_INT:
 		if label_or_idx >-1:
 			current_event_idx = label_or_idx -1
@@ -121,9 +121,9 @@ func handle_event(event_index:int) -> void:
 		await dialogic_resumed
 	
 	if event_index >= len(current_timeline_events):
-		if timeline_jump_stack.size() > 0:
-			pop_from_jump_stack()
-			event_index = current_event_idx+1
+		if has_subsystem('Jump') and !self.Jump.is_jump_stack_empty():
+			self.Jump.resume_from_latst_jump()
+			return
 		else:
 			end_timeline()
 			return
@@ -148,33 +148,6 @@ func handle_event(event_index:int) -> void:
 	emit_signal('event_handled', current_timeline_events[event_index])
 
 
-func jump_to_label(label:String) -> void:
-	if label.is_empty():
-		current_event_idx = 0
-		return
-	var idx: int = -1
-	while true:
-		idx += 1
-		var event: Variant = current_timeline.get_event(idx)
-		if not event:
-			idx = current_event_idx
-			break
-		if event is DialogicLabelEvent and event.name == label:
-			break
-	current_event_idx = idx
-
-func push_to_jump_stack() -> void:
-	var current_point:Dictionary = {}
-	current_point['timeline'] = current_timeline 
-	current_point['index'] = current_event_idx
-	timeline_jump_stack.push_front(current_point)
-
-func pop_from_jump_stack() -> void:
-	var stack_point:Dictionary = timeline_jump_stack.pop_front()
-	current_timeline = stack_point['timeline']
-	current_timeline_events = current_timeline.get_events()
-	current_event_idx = stack_point['index']
-	
 
 func clear() -> bool:
 	for subsystem in get_children():


### PR DESCRIPTION
The main point of this PR is improving the jump logic by

- making a dedicated jump subsystem, thus separating the jump logic from the DGH. #1394
- making the jump stack part of the save data, thus allowing to resume to a working stack
- making sure empty jumps go to the start of the current timeline #1318
- making sure jumps in the same timeline don't need any input to continue. #1358

## Other:
- make sure set_variable() doesn't print unnecessary error # 1381