### PR TITLE
Fix a few editor startup errors

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/FilePicker.gd
+++ b/addons/dialogic/Editor/Events/Fields/FilePicker.gd
@@ -31,7 +31,7 @@ func _ready():
 	%ClearButton.icon = get_theme_icon("Reload", "EditorIcons")
 	%OpenButton.button_down.connect(_on_OpenButton_pressed)
 	%ClearButton.button_up.connect(clear_path)
-	%Field.set_drag_forwarding(self)
+	%Field.set_drag_forwarding(Callable(), self._can_drop_data_fw, self._drop_data_fw)
 	%Field.placeholder_text = placeholder
 
 func set_right_text(value:String):
@@ -62,7 +62,7 @@ func clear_path():
 	emit_signal("value_changed", property_name, "")
 	set_value("")
 
-func _can_drop_data_fw(position, data, from_control):
+func _can_drop_data_fw(at_position: Vector2, data: Variant) -> bool:
 	if typeof(data) == TYPE_DICTIONARY and data.has('files') and len(data.files) == 1:
 		if file_filter:
 			if '*.'+data.files[0].get_extension() in file_filter:
@@ -70,5 +70,5 @@ func _can_drop_data_fw(position, data, from_control):
 		else: return true
 	return false
 
-func _drop_data_fw(position, data, from_control):
+func _drop_data_fw(at_position: Vector2, data: Variant) -> void:
 	_on_file_dialog_selected(data.files[0])

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -235,7 +235,6 @@ func create_drag_and_drop_event(resource) -> void:
 	moving_piece = piece
 	piece_was_dragged = true
 	select_item(piece)
-	return piece
 
 
 func drop_event() -> void:

--- a/addons/dialogic/Example Assets/default_event.gd
+++ b/addons/dialogic/Example Assets/default_event.gd
@@ -18,7 +18,7 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Default"
 	event_color = Color("#ffffff")
-	event_category = Category.MAIN
+	event_category = Category.Main
 	event_sorting_index = 0
 	
 


### PR DESCRIPTION
Fix a few SCRIPT ERRORs at startup:

- Don't return value from create_drag_and_drop_event, which returns void
- Fix Category enum value MAIN -> Main
- Update set_drag_forwarding and associated signatures: There were some changes to set_drag_forwarding in Godot 4:
  - `Control.set_drag_forwarding` takes three callables instead of an object
  - `_can_drop_data_fw`, `_drop_data_fw` don't have a `from_control` argument anymore