### PR TITLE
Make text effects and modifiers modular

### DIFF
--- a/addons/dialogic/Events/Character/index.gd
+++ b/addons/dialogic/Events/Character/index.gd
@@ -12,3 +12,6 @@ func _get_subsystems() -> Array:
 
 func _get_settings_pages() -> Array:
 	return [this_folder.path_join('settings_portraits.tscn')]
+
+func _get_text_effects() -> Array[Dictionary]:
+	return [{'command':'portrait', 'subsystem':'Portraits', 'method':'text_effect_portrait'}]

--- a/addons/dialogic/Events/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Events/Character/subsystem_portraits.gd
@@ -184,7 +184,7 @@ func move_portrait(character:DialogicCharacter, position_idx:int, z_index:int = 
 		char_node.z_index = z_index
 	
 	char_node.set_meta('position', position_idx)
-
+	
 	if time == 0.0:
 		char_node.position = current_positions[position_idx]
 	else:
@@ -214,9 +214,11 @@ func add_portrait_position(position_number: int, position:Vector2) -> void:
 		_default_positions[position_number] = position
 		current_positions[position_number] = position
 
+
 func reset_portrait_positions(time:float = 0.0) -> void:
 	for position in current_positions:
 		move_portrait_position(position, _default_positions[position], false, time)
+
 
 func reset_portrait_position(position:int, time:float = 0.0) -> void:
 	move_portrait_position(position, _default_positions[position], false, time)
@@ -253,11 +255,13 @@ func move_portrait_position(position_number: int, vector:Vector2, relative:bool 
 func is_character_joined(character:DialogicCharacter) -> bool:
 	return character.resource_path in dialogic.current_state_info['portraits']
 
+
 func get_joined_characters() -> Array:
 	var chars = []
 	for char_path in dialogic.current_state_info.get('portraits', {}).keys():
 		chars.append(load(char_path))
 	return chars
+
 
 func update_rpg_portrait_mode(character:DialogicCharacter = null, portrait:String = "") -> void:
 	if DialogicUtil.get_project_setting('dialogic/portrait_mode', 0) == DialogicCharacterEvent.PortraitModes.RPG:
@@ -291,6 +295,7 @@ func update_rpg_portrait_mode(character:DialogicCharacter = null, portrait:Strin
 			add_portrait(character, portrait, 1, false)
 			var anim = animate_portrait(character, AnimationName, AnimationLength)
 
+
 # makes sure positions are listed and can be accessed
 func check_positions_and_holder() -> void:
 	if _portrait_holder_reference == null and len(get_tree().get_nodes_in_group('dialogic_portrait_holder')) == 0:
@@ -304,3 +309,9 @@ func check_positions_and_holder() -> void:
 	
 	if current_positions.size() == 0:
 		current_positions = _default_positions.duplicate()
+
+
+func text_effect_portrait(text_node:Control, skipped:bool, argument:String) -> void:
+	if argument:
+		if Dialogic.current_state_info.get('character', null):
+			Dialogic.Portraits.change_portrait(load(Dialogic.current_state_info.character), argument)

--- a/addons/dialogic/Events/Text/event_text.gd
+++ b/addons/dialogic/Events/Text/event_text.gd
@@ -78,7 +78,7 @@ func _execute() -> void:
 		if dialogic.has_subsystem('Glossary'):
 			final_text = dialogic.Glossary.parse_glossary(final_text)
 		
-		dialogic.Text.update_dialog_text(dialogic.Text.color_names(final_text))
+		dialogic.Text.update_dialog_text(final_text)
 		
 		#Plays the audio region for the current line.
 		if dialogic.has_subsystem('Voice') and dialogic.Voice.is_voiced(dialogic.current_event_idx):

--- a/addons/dialogic/Events/Text/index.gd
+++ b/addons/dialogic/Events/Text/index.gd
@@ -16,3 +16,19 @@ func _get_settings_pages() -> Array:
 
 func _get_character_editor_tabs() -> Array:
 	return [this_folder.path_join('character_settings/character_settings_text.tscn')]
+
+
+func _get_text_effects() -> Array[Dictionary]:
+	return [
+		{'command':'speed', 'subsystem':'Text', 'method':'effect_speed'},
+		{'command':'pause', 'subsystem':'Text', 'method':'effect_pause'},
+		{'command':'signal', 'subsystem':'Text', 'method':'effect_signal'},
+		{'command':'mood', 'subsystem':'Text', 'method':'effect_mood'},
+	]
+
+
+func _get_text_modifiers() -> Array[Dictionary]:
+	return [
+		{'subsystem':'Text', 'method':'modifier_random_selection'},
+		{'subsystem':'Text', 'method':"modifier_break"},
+	]

--- a/addons/dialogic/Events/Text/node_dialog_text.gd
+++ b/addons/dialogic/Events/Text/node_dialog_text.gd
@@ -2,23 +2,18 @@ extends RichTextLabel
 
 class_name DialogicNode_DialogText
 
+## Dialogic node that can reveal text at a given (changeable speed). 
 
+signal started_revealing_text()
+signal continued_revealing_text(new_character)
+signal finished_revealing_text()
 enum ALIGNMENT {LEFT, CENTER, RIGHT}
 
 @export var Align : ALIGNMENT = ALIGNMENT.LEFT
 @onready var timer :Timer = null
 
-var effect_regex = RegEx.new()
-var modifier_words_select_regex = RegEx.new()
-var effects:Array = []
 
 var speed:float = 0.01
-
-signal started_revealing_text()
-
-signal continued_revealing_text(new_character)
-
-signal finished_revealing_text()
 
 func _ready() -> void:
 	# add to necessary
@@ -34,17 +29,12 @@ func _ready() -> void:
 	timer.one_shot = true
 	DialogicUtil.update_timer_process_callback(timer)
 	timer.timeout.connect(continue_reveal)
-	
-	# compile effects regex
-	effect_regex.compile("(?<!\\\\)\\[\\s*(?<command>mood|portrait|speed|signal|pause)\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
-	
-	# compule modifier regexs
-	modifier_words_select_regex.compile("(?<!\\\\)\\[[^\\[\\]]+(,[^\\]]*)\\]")
-	
+
+
 # this is called by the DialogicGameHandler to set text
 func reveal_text(_text:String) -> void:
 	speed = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
-	text = parse_effects(parse_modifiers(_text))
+	text = _text
 	if Align == ALIGNMENT.CENTER:
 		text = '[center]'+text
 	elif Align == ALIGNMENT.RIGHT:
@@ -61,7 +51,7 @@ func continue_reveal() -> void:
 	if visible_characters < get_total_character_count():
 		visible_characters += 1
 		emit_signal("continued_revealing_text", text[visible_characters-1])
-		execute_effects()
+		await Dialogic.Text.execute_effects(visible_characters, self, false)
 		if timer.is_stopped():
 			if speed <= 0:
 				continue_reveal()
@@ -75,70 +65,11 @@ func continue_reveal() -> void:
 # called by this thing itself or the DialogicGameHandler
 func finish_text() -> void:
 	visible_ratio = 1
-	execute_effects(true)
+	Dialogic.Text.execute_effects(-1, self, true)
 	timer.stop()
 	Dialogic.current_state = Dialogic.states.IDLE
 	emit_signal("finished_revealing_text")
 
-
-func parse_effects(_text:String) -> String:
-	effects.clear()
-	var position_correction = 0
-	for effect_match in effect_regex.search_all(_text):
-		# append [index, command, value] to effects array
-		effects.append([effect_match.get_start()-position_correction, effect_match.get_string('command'), effect_match.get_string('value').strip_edges()])
-		
-		## TODO MIGHT BE BROKEN, because I had to replace string.erase for godot 4
-		_text = _text.substr(0,effect_match.get_start()-position_correction)+_text.substr(effect_match.get_start()-position_correction+len(effect_match.get_string()))
-		
-		position_correction += len(effect_match.get_string())
-	_text = _text.replace('\\[', '[')
-	return _text
-
-func execute_effects(skip :bool= false) -> void:
-	# might have to execute multiple effects
-	while effects and (visible_characters >= effects.front()[0] or visible_characters== -1):
-		var effect = effects.pop_front()
-		match effect[1]:
-			'pause':
-				if skip:
-					continue
-				if effect[2].is_valid_float():
-					timer.start(effect[2].to_float())
-				else:
-					timer.start(1)
-			'speed':
-				if skip:
-					continue
-				if effect[2].is_valid_float():
-					speed = effect[2].to_float()
-				else:
-					speed = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
-			'signal':
-				Dialogic.emit_signal("text_signal", effect[2])
-			'portrait':
-				if effect[2]:
-					if Dialogic.current_state_info.get('character', null):
-						Dialogic.Portraits.change_portrait(load(Dialogic.current_state_info.character), effect[2])
-			'mood':
-				if effect[2]:
-					if Dialogic.current_state_info.get('character', null):
-						var Character = load(Dialogic.current_state_info.character)
-						Dialogic.Text.update_typing_sound_mood(Character.custom_info.get('sound_moods', {}).get(effect[2], {}))
-
-func parse_modifiers(_text:String) -> String:
-	# [word, select] effect
-	for replace_mod_match in modifier_words_select_regex.search_all(_text):
-		var string = replace_mod_match.get_string().trim_prefix("[").trim_suffix("]")
-		string = string.replace('\\,', '<comma>')
-		var list = string.split(',')
-		var item = list[randi()%len(list)]
-		item = item.replace('<comma>', ',')
-		_text = _text.replace(replace_mod_match.get_string(), item.strip_edges())
-	
-	# [br] effect
-	_text = _text.replace('[br]', '\n')
-	return _text
 
 func pause() -> void: 
 	timer.stop()

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -1,21 +1,32 @@
 extends DialogicSubsystem
 
+## Subsystem that handles showing of dialog text (+text effects & modifiers), name label, and next indicator
+
+
+signal text_finished
+signal speaking_character(argument)
+
 # used to color names without searching for all characters each time
 var character_colors := {}
 var color_regex := RegEx.new()
 var text_already_read:bool = false
 
-signal text_finished
-signal speaking_character(argument)
+var text_effects := {}
+var parsed_text_effect_info := []
+var text_effects_regex := RegEx.new()
+var text_modifiers := []
+
 
 ####################################################################################################
 ##					STATE
 ####################################################################################################
+
 func clear_game_state() -> void:
 	update_dialog_text('', true)
 	update_name_label(null)
 	dialogic.current_state_info['character'] = null
 	dialogic.current_state_info['text'] = ''
+
 
 func load_game_state() -> void:
 	update_dialog_text(dialogic.current_state_info.get('text', ''), true)
@@ -26,23 +37,30 @@ func load_game_state() -> void:
 	if character:
 		update_name_label(character)
 
+
 func pause() -> void:
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		if text_node.is_visible_in_tree():
 			text_node.pause()
 
+
 func resume() -> void:
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		if text_node.is_visible_in_tree():
 			text_node.resume()
-	
+
+
 ####################################################################################################
 ##					MAIN METHODS
 ####################################################################################################
 
-## Shows the given text on all visible DialogText nodes. 
-## Instant can be used to skip all reveiling (effects won't work).
+## Shows the given text on all visible DialogText nodes.
+## Instant can be used to skip all reveiling.
 func update_dialog_text(text:String, instant:bool= false) -> void:
+	text = parse_text_effects(text)
+	text = parse_text_modifiers(text)
+	text = color_names(text)
+	
 	if !instant: dialogic.current_state = dialogic.states.SHOWING_TEXT
 	dialogic.current_state_info['text'] = text
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
@@ -53,9 +71,11 @@ func update_dialog_text(text:String, instant:bool= false) -> void:
 				text_node.reveal_text(text)
 				if !text_node.finished_revealing_text.is_connected(_on_dialog_text_finished):
 					text_node.finished_revealing_text.connect(_on_dialog_text_finished)
-		
+
+
 func _on_dialog_text_finished():
 	text_finished.emit()
+
 
 func update_name_label(character:DialogicCharacter) -> void:
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
@@ -74,25 +94,30 @@ func update_name_label(character:DialogicCharacter) -> void:
 			name_label.self_modulate = Color(1,1,1,1)
 			speaking_character.emit("(Nobody)")
 
+
 func update_typing_sound_mood(mood:Dictionary = {}) -> void:
 	for typing_sound in get_tree().get_nodes_in_group('dialogic_type_sounds'):
 		typing_sound.load_overwrite(mood)
-		
+
+
 func hide_text_boxes() -> void:
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
 		name_label.text = ""
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		text_node.get_parent().visible = false
-		
+
+
 func show_text_boxes() -> void:
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		text_node.get_parent().visible = true
+
 
 func show_next_indicators(question=false, autocontinue=false) -> void:
 	for next_indicator in get_tree().get_nodes_in_group('dialogic_next_indicator'):
 		if (question and 'show_on_questions' in next_indicator and next_indicator.show_on_questions) or \
 			(autocontinue and 'show_on_autocontinue' in next_indicator and next_indicator.show_on_autocontinue) or (!question and !autocontinue):
 			next_indicator.show()
+
 
 func hide_next_indicators(fake_arg=null) -> void:
 	for next_indicator in get_tree().get_nodes_in_group('dialogic_next_indicator'):
@@ -101,6 +126,66 @@ func hide_next_indicators(fake_arg=null) -> void:
 ####################################################################################################
 ##					HELPERS
 ####################################################################################################
+
+func collect_text_effects() -> void:
+	var text_effect_names := ""
+	text_effects.clear()
+	for indexer in DialogicUtil.get_indexers(true):
+		for effect in indexer._get_text_effects():
+			text_effects[effect.command] = {}
+			if effect.has('subsystem') and effect.has('method'):
+				text_effects[effect.command]['callable'] = Callable(Dialogic.get_subsystem(effect.subsystem), effect.method)
+			elif effect.has('node_path') and effect.has('method'):
+				text_effects[effect.command]['callable'] = Callable(get_node(effect.node_path), effect.method)
+			else:
+				continue
+			text_effect_names += effect.command +"|"
+	text_effects_regex.compile("(?<!\\\\)\\[\\s*(?<command>"+text_effect_names.trim_suffix("|")+")\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
+
+
+## Returns the string with all text effects removed
+## Use get_parsed_text_effects() after calling this to get all effect information
+func parse_text_effects(text:String) -> String:
+	parsed_text_effect_info.clear()
+	var position_correction := 0
+	for effect_match in text_effects_regex.search_all(text):
+		# append [index] = [command, value] to effects dict
+		parsed_text_effect_info.append({'index':effect_match.get_start()-position_correction, 'execution_info':text_effects[effect_match.get_string('command')], 'value': effect_match.get_string('value').strip_edges()})
+		
+		## TODO MIGHT BE BROKEN, because I had to replace string.erase for godot 4
+		text = text.substr(0,effect_match.get_start()-position_correction)+text.substr(effect_match.get_start()-position_correction+len(effect_match.get_string()))
+		
+		position_correction += len(effect_match.get_string())
+	text = text.replace('\\[', '[')
+	return text
+
+func execute_effects(current_index:int, text_node:Control, skipping:bool= false) -> void:
+	# might have to execute multiple effects
+	while true:
+		if parsed_text_effect_info.is_empty():
+			return
+		if current_index == -1 or current_index < parsed_text_effect_info[0]['index']:
+			return
+		var effect :=  parsed_text_effect_info.pop_front()
+		await (effect['execution_info']['callable'] as Callable).call(text_node, skipping, effect['value'])
+
+
+func collect_text_modifiers() -> void:
+	text_modifiers.clear()
+	for indexer in DialogicUtil.get_indexers(true):
+		for modifier in indexer._get_text_modifiers():
+			if modifier.has('subsystem') and modifier.has('method'):
+				text_modifiers.append(Callable(Dialogic.get_subsystem(modifier.subsystem), modifier.method))
+			elif modifier.has('node_path') and modifier.has('method'):
+				text_modifiers.append(Callable(get_node(modifier.node_path), modifier.method))
+
+
+func parse_text_modifiers(text:String) -> String:
+	for mod_method in text_modifiers:
+		text = mod_method.call(text) 
+	return text
+
+
 func skip_text_animation() -> void:
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		if text_node.is_visible_in_tree():
@@ -108,20 +193,23 @@ func skip_text_animation() -> void:
 	if dialogic.has_subsystem('Voice'):
 		dialogic.Voice.stop_audio()
 
+
 func get_current_speaker() -> DialogicCharacter:
 	return (load(dialogic.current_state_info['character']) as DialogicCharacter)
 
 
 func _ready():
-	update_character_names()
+	collect_character_names()
+	collect_text_effects()
+	collect_text_modifiers()
 	Dialogic.event_handled.connect(hide_next_indicators)
 
 
 func color_names(text:String) -> String:
 	if !DialogicUtil.get_project_setting('dialogic/text/autocolor_names', false):
 		return text
-
-	var counter = 0
+	
+	var counter := 0
 	for result in color_regex.search_all(text):
 		text = text.insert(result.get_start("name")+((9+8+8)*counter), '[color=#' + character_colors[result.get_string('name')].to_html() + ']')
 		text = text.insert(result.get_end("name")+9+8+((9+8+8)*counter), '[/color]')
@@ -129,7 +217,8 @@ func color_names(text:String) -> String:
 	
 	return text
 
-func update_character_names() -> void:
+
+func collect_character_names() -> void:
 	#don't do this at all if we're not using autocolor names to begin with
 	if !DialogicUtil.get_project_setting('dialogic/text/autocolor_names', false):
 		return 
@@ -146,3 +235,54 @@ func update_character_names() -> void:
 				character_colors[nickname.strip_edges()] = dch.color
 	
 	color_regex.compile('(?<=\\W|^)(?<name>'+str(character_colors.keys()).trim_prefix('["').trim_suffix('"]').replace('", "', '|')+')(?=\\W|$)')
+
+
+################################################################################
+## 				DEFAULT TEXT EFFECTS & MODIFIERS
+################################################################################
+
+func effect_pause(text_node:Control, skipped:bool, argument:String) -> void:
+	if skipped:
+		return
+	if argument:
+		await get_tree().create_timer(float(argument)).timeout
+	else:
+		await get_tree().create_timer(0.5).timeout
+
+
+func effect_speed(text_node:Control, skipped:bool, argument:String) -> void:
+	if skipped:
+		return
+	if argument:
+		text_node.speed = float(argument)
+	else:
+		text_node.speed = DialogicUtil.get_project_setting('dialogic/text/speed', 0.01)
+
+
+func effect_signal(text_node:Control, skipped:bool, argument:String) -> void:
+	Dialogic.text_signal.emit(argument)
+
+
+func effect_mood(text_node:Control, skipped:bool, argument:String) -> void:
+	if argument.is_empty(): return
+	if Dialogic.current_state_info.get('character', null):
+		update_typing_sound_mood(
+			load(Dialogic.current_state_info.character).custom_info.get('sound_moods', {}).get(argument, {}))
+
+
+var modifier_words_select_regex := RegEx.create_from_string("(?<!\\\\)\\[[^\\[\\]]+(\\/[^\\]]*)\\]")
+func modifier_random_selection(text:String) -> String:
+	print("\n seraching through '",text,"'")
+	for replace_mod_match in modifier_words_select_regex.search_all(text):
+		print("found ", replace_mod_match)
+		var string :String= replace_mod_match.get_string().trim_prefix("[").trim_suffix("]")
+		string = string.replace('//', '<slash>')
+		var list :PackedStringArray= string.split('/')
+		var item :String= list[randi()%len(list)]
+		item = item.replace('<slash>', '/')
+		text = text.replace(replace_mod_match.get_string(), item.strip_edges())
+	return text
+
+
+func modifier_break(text:String) -> String:
+	return text.replace('[br]', '\n')

--- a/addons/dialogic/Other/index_class.gd
+++ b/addons/dialogic/Other/index_class.gd
@@ -15,7 +15,7 @@ func _get_events() -> Array:
 	return []
 
 
-func _get_subsystems() -> Array:
+func _get_subsystems() -> Array[Dictionary]:
 	return []
 
 
@@ -24,4 +24,16 @@ func _get_settings_pages() -> Array:
 
 
 func _get_character_editor_tabs() -> Array:
+	return []
+
+
+## Should return array of dictionaries with the following keys:
+## "command" 	-> the text e.g. "speed"
+## "node_path" or "subsystem" -> whichever contains your effect method
+## "method" 	-> name of the effect method
+func _get_text_effects() -> Array[Dictionary]:
+	return []
+
+
+func _get_text_modifiers() -> Array:
 	return []


### PR DESCRIPTION
Removes the text effect and modifier logic from the DialogText node.

The index.gd file can now register text effects and modifiers.
These are effectively just methods. The text subsystem collects them and applies/reads them to/from the text before sending it to the DialogText node. Then the DialogText node calls execute_effects on every letter advance. 

Text modifiers are also methods, these are only called once before the text is shown.

The text effect methods have access to the calling dialog_text node, the skipping boolean and the argument string. 

All effects/modifiers have been moved to the text subsystem except portrait which is now part of the portrait subsystem.

Additionally the syntax for random selection has been changed from [option1, option2] to [option1/option2].

This PR improves little to nothing for the average user, but makes it easier
- to maintain existing text effects/modifiers in the future
- to add text effects/modifiers both in core and in additions
- to create a custom dialog node implementation (because less functionality is in the default one)
