### PR TITLE
Fix default layout path

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -14,45 +14,31 @@ func _ready() -> void:
 		'background': Color(0.545098, 0.545098, 0.545098, 0.211765)
 	})
 	%ExtensionsFolderPicker.resource_icon = get_theme_icon("Folder", "EditorIcons")
-	
+
 	# Signals
 	%ExtensionsFolderPicker.value_changed.connect(_on_ExtensionsFolder_value_changed)
 	%PhysicsTimerButton.pressed.connect(_on_physics_timer_button_toggled)
-	
+
 	# Colors
 	%ResetColorsButton.button_up.connect(_on_reset_colors_button)
-	
+
 	for n in $"%Colors".get_children():
 		n.color_changed.connect(_on_color_change.bind(n))
-	
+
 	# Extension creator
 	%ExtensionCreator.hide()
 
 func refresh() -> void:
 	%PhysicsTimerButton.button_pressed = DialogicUtil.is_physics_timer()
-	
+
 	%ExtensionsFolderPicker.set_value(DialogicUtil.get_project_setting('dialogic/extensions_folder', 'res://addons/dialogic_additions'))
-	
+
 	# Color Palett
 	color_palette = DialogicUtil.get_color_palette()
 	var _scale := DialogicUtil.get_editor_scale()
 	for n in %Colors.get_children():
 		n.custom_minimum_size = Vector2(50 ,50)*scale
 		n.color = color_palette[n.name]
-
-
-func _on_TestingScene_value_changed(property:String, value:String) -> void:
-	if value == null or value.is_empty():
-		value = "res://addons/dialogic/Example Assets/example-scenes/DialogicDefaultScene.tscn"
-	ProjectSettings.set_setting('dialogic/editor/test_dialog_scene', value)
-	ProjectSettings.save()
-
-
-func _on_DefaultScene_value_changed(property:String, value:String) -> void:
-	if value == null or value.is_empty():
-		value = "res://addons/dialogic/Example Assets/example-scenes/DialogicDefaultScene.tscn"
-	ProjectSettings.set_setting('dialogic/default_dialog_scene', value)
-	ProjectSettings.save()
 
 
 func _on_color_change(color: Color, who) -> void:
@@ -66,8 +52,8 @@ func _on_reset_colors_button() -> void:
 	for n in %Colors.get_children():
 		n.color = color_palette[n.name]
 		# There is a bug when trying to remove existing values, so we have to
-		# set/create new entries for all the colors used. 
-		# If you manage to make it work using the ProjectSettings.clear() 
+		# set/create new entries for all the colors used.
+		# If you manage to make it work using the ProjectSettings.clear()
 		# feel free to open a PR!
 		ProjectSettings.set_setting('dialogic/editor/' + str(n.name), color_palette[n.name])
 	ProjectSettings.save()
@@ -92,7 +78,7 @@ func _on_ExtensionsFolder_value_changed(property:String, value:String) -> void:
 func _on_create_extension_button_pressed() -> void:
 	%CreateExtensionButton.hide()
 	%ExtensionCreator.show()
-	
+
 	%NameEdit.text = ""
 	%NameEdit.grab_focus()
 
@@ -100,13 +86,13 @@ func _on_create_extension_button_pressed() -> void:
 func _on_submit_extension_button_pressed() -> void:
 	if %NameEdit.text.is_empty():
 		return
-	
+
 	var extensions_folder :String = DialogicUtil.get_project_setting('dialogic/extensions_folder', 'res://addons/dialogic_additions')
-	
+
 	extensions_folder = extensions_folder.path_join(%NameEdit.text.to_pascal_case())
 	DirAccess.make_dir_recursive_absolute(extensions_folder)
 	var mode :int= %ExtensionMode.selected
-	
+
 	var file : FileAccess
 	var indexer_content := "@tool\nextends DialogicIndexer\n\n"
 	if mode != 1: # don't add event in Subsystem Only mode
@@ -186,8 +172,8 @@ func load_game_state():
 """)
 	file = FileAccess.open(extensions_folder.path_join('index.gd'), FileAccess.WRITE)
 	file.store_string(indexer_content)
-	
+
 	%ExtensionCreator.hide()
 	%CreateExtensionButton.show()
-	
+
 	find_parent('EditorView').plugin_reference.editor_interface.get_resource_filesystem().scan_sources()

--- a/addons/dialogic/Editor/Settings/settings_layouts.gd
+++ b/addons/dialogic/Editor/Settings/settings_layouts.gd
@@ -11,7 +11,7 @@ func _ready() -> void:
 	for indexer in DialogicUtil.get_indexers():
 		for layout in indexer._get_layout_scenes():
 			layouts_info[layout['path']] = layout
-	
+
 	%PresetSceneLabel.add_theme_color_override("font_color", get_theme_color("success_color", "Editor"))
 	%ClearCustomization.icon = get_theme_icon("Remove", "EditorIcons")
 	%PresetSelectionButton.icon = get_theme_icon("ListSelect", "EditorIcons")
@@ -25,7 +25,7 @@ func _ready() -> void:
 	get_theme_icon("CreateNewSceneFrom", "EditorIcons")
 	get_theme_icon("Load", "EditorIcons")
 	get_theme_icon("New", "EditorIcons")
-	
+
 	get_theme_icon("NodeInfo", "EditorIcons")
 	get_theme_icon("Unlinked", "EditorIcons")
 
@@ -81,8 +81,11 @@ func _on_preset_selection_pressed() -> void:
 
 func update_presets_list() -> void:
 	%LayoutItemList.clear()
-	
-	var current_path :String = DialogicUtil.get_project_setting('dialogic/layout_scene', "res://addons/dialogic/Example Assets/example-scenes/DialogicDefaultScene.tscn")
+
+	var current_path :String = DialogicUtil.get_project_setting(
+	    'dialogic/layout_scene',
+	    DialogicUtil.get_default_layout()
+	)
 	var index := 0
 	for indexer in DialogicUtil.get_indexers():
 		for layout in indexer._get_layout_scenes():
@@ -96,7 +99,7 @@ func update_presets_list() -> void:
 				%LayoutItemList.set_item_custom_fg_color(index, get_theme_color("accent_color", "Editor"))
 				%LayoutItemList.select(index)
 			%LayoutItemList.set_item_metadata(index, layout)
-			
+
 			index += 1
 	await get_tree().process_frame
 	if %LayoutItemList.get_selected_items().is_empty():
@@ -140,7 +143,7 @@ func _on_close_preset_selection_pressed():
 
 
 ################################################################################
-##				CREATE CUSTOM COPY FROM PRESET 
+##				CREATE CUSTOM COPY FROM PRESET
 ################################################################################
 func _on_make_custom_button_pressed() -> void:
 	%PresetSelection.hide()
@@ -158,7 +161,7 @@ func _on_close_make_custom_button_pressed() -> void:
 
 func _on_create_custom_copy_pressed() -> void:
 	find_parent("EditorView").godot_file_dialog(
-		create_custom_copy, "*", 
+		create_custom_copy, "*",
 		EditorFileDialog.FILE_MODE_OPEN_DIR)
 
 
@@ -205,24 +208,24 @@ func load_layout_scene_customization(custom_scene_path:String = "") -> void:
 		scene = load(ProjectSettings.get_setting('dialogic/layout_scene', DialogicUtil.get_default_layout())).instantiate()
 	if !scene:
 		return
-	
-	for child in %ExportsTabs.get_children(): 
+
+	for child in %ExportsTabs.get_children():
 		child.queue_free()
-	
+
 	var export_overrides :Dictionary = DialogicUtil.get_project_setting('dialogic/layout/export_overrides', {})
 	var current_grid :GridContainer
 	var current_hbox :HBoxContainer
-	
+
 	var label_bg_style = get_theme_stylebox("CanvasItemInfoOverlay", "EditorStyles").duplicate()
 	label_bg_style.content_margin_left = 5
 	label_bg_style.content_margin_right = 5
 	label_bg_style.content_margin_top = 5
-	
+
 	customization_editor_info = {}
 	for i in scene.script.get_script_property_list():
 		if i['usage'] & PROPERTY_USAGE_CATEGORY:
 			continue
-		
+
 		if i['usage'] & PROPERTY_USAGE_GROUP or current_hbox == null:
 			var main_scroll = ScrollContainer.new()
 			main_scroll.vertical_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
@@ -239,7 +242,7 @@ func load_layout_scene_customization(custom_scene_path:String = "") -> void:
 				continue
 			else:
 				%ExportsTabs.set_tab_title(main_scroll.get_index(), 'General')
-		
+
 		if i['usage'] & PROPERTY_USAGE_SUBGROUP:
 			var v_scroll := ScrollContainer.new()
 			v_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
@@ -257,7 +260,7 @@ func load_layout_scene_customization(custom_scene_path:String = "") -> void:
 			current_grid = GridContainer.new()
 			current_grid.columns = 3
 			v_box.add_child(current_grid, true)
-		
+
 		if current_grid == null:
 			var v_scroll := ScrollContainer.new()
 			v_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
@@ -265,28 +268,28 @@ func load_layout_scene_customization(custom_scene_path:String = "") -> void:
 			current_grid = GridContainer.new()
 			current_grid.columns = 3
 			v_scroll.add_child(current_grid, true)
-		
+
 		if i['usage'] & PROPERTY_USAGE_EDITOR:
 			var label := Label.new()
 			label.text = str(i['name']).capitalize()
 			current_grid.add_child(label, true)
-			
+
 			var current_value = scene.get(i['name'])
 			customization_editor_info[i['name']] = {}
 			customization_editor_info[i['name']]['orig'] = current_value
-			
+
 			if export_overrides.has(i['name']):
 				current_value = str_to_var(export_overrides[i['name']])
-			
-			var input :Node = DialogicUtil.setup_script_property_edit_node( 
-				i, current_value, 
+
+			var input :Node = DialogicUtil.setup_script_property_edit_node(
+				i, current_value,
 				{'bool':_on_export_bool_submitted, 'color':_on_export_color_submitted, 'enum':_on_export_int_enum_submitted,
 				'int':_on_export_number_submitted, 'float':_on_export_number_submitted, 'file':_on_export_file_submitted,
 				'string':_on_export_input_text_submitted, "string_enum": _on_export_string_enum_submitted})
-			
+
 			input.size_flags_horizontal = SIZE_EXPAND_FILL
 			customization_editor_info[i['name']]['node'] = input
-			
+
 			var reset := Button.new()
 			reset.flat = true
 			reset.icon = get_theme_icon('Clear', 'EditorIcons')
@@ -307,7 +310,7 @@ func set_export_override(property_name:String, value:String = "") -> void:
 	else:
 		export_overrides.erase(property_name)
 		customization_editor_info[property_name]['reset'].disabled = true
-	
+
 	ProjectSettings.set_setting('dialogic/layout/export_overrides', export_overrides)
 
 func _on_export_override_reset(property_name:String) -> void:

--- a/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
+++ b/addons/dialogic/Editor/TimelineEditor/test_timeline_scene.gd
@@ -6,7 +6,9 @@ func _ready() -> void:
 		print("Testing locale is: ", ProjectSettings.get_setting('internationalization/locale/test'))
 	$PauseIndictator.hide()
 	var dialog_scene_path: String = DialogicUtil.get_project_setting(
-		'dialogic/editor/custom_testing_layout', "res://addons/dialogic/Example Assets/example-scenes/DialogicDefaultScene.tscn")
+		'dialogic/editor/custom_testing_layout',
+		DialogicUtil.get_default_layout()
+	)
 	var scene: Node = load(dialog_scene_path).instantiate()
 	DialogicUtil.apply_scene_export_overrides(scene, ProjectSettings.get_setting('dialogic/layout/export_overrides', {}))
 	add_child(scene)
@@ -15,7 +17,7 @@ func _ready() -> void:
 			scene.position = get_viewport_rect().size/2.0
 		if scene is Node2D:
 			scene.position = get_viewport_rect().size/2.0
-	
+
 	randomize()
 	var current_timeline: String = ProjectSettings.get_setting('dialogic/editor/current_timeline_path')
 	Dialogic.start_timeline(current_timeline)
@@ -28,7 +30,7 @@ func recieve_event_signal(argument:String) -> void:
 
 func recieve_text_signal(argument:String) -> void:
 	print("[Dialogic] Encountered a signal in text: ", argument)
-	
+
 func _input(event:InputEvent) -> void:
 	if event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
 		Dialogic.paused = !Dialogic.paused


### PR DESCRIPTION
In https://github.com/coppolaemilio/dialogic/pull/1421 `DialogicDefaultLayout` (formerly `DialogicDefaultScene`) was moved and renamed, however paths pointing to its location were not updated, because GDScript is a very good language and refactoring code written in it is always a pleasure.

There are some occasional formatting fixes to dilute the atmosphere of inevitable hardcoded doom.