### PR TITLE
Change how text speed works (to allow faster text speeds)

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -67,7 +67,7 @@ func _init():
 	for idx in DialogicUtil.get_indexers():
 		for effect in idx._get_text_effects():
 			text_effects+= effect['command']+'|'
-	text_effects += "b|i|u|s|code|p|center|left|right|fill|indent|url|img|font|font_size|opentype_features|color|bg_color|fg_color|outline_size|outline_color|table|cell|ul|ol|lb|rb"
+	text_effects += "b|i|u|s|code|p|center|left|right|fill|indent|url|img|font|font_size|opentype_features|color|bg_color|fg_color|outline_size|outline_color|table|cell|ul|ol|lb|rb|br"
 	text_effects_regex.compile("(?<!\\\\)\\[\\s*/?(?<command>"+text_effects+")\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
 	character_event_regex.compile("(?<type>Join|Update|Leave)\\s*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?(\\s*(?<position>\\d))?(\\s*\\[(?<shortcode>.*)\\])?")
 

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/AddEventButton.gd
@@ -17,7 +17,6 @@ extends Button
 
 
 func _ready() -> void:
-#	toggle_name()
 	tooltip_text = visible_name
 	
 	custom_minimum_size = Vector2(get_theme_font("font", 'Label').get_string_size(text).x+35,30)* DialogicUtil.get_editor_scale()

--- a/addons/dialogic/Events/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Events/Character/subsystem_portraits.gd
@@ -318,7 +318,7 @@ func is_character_joined(character:DialogicCharacter) -> bool:
 
 
 func get_joined_characters() -> Array[DialogicCharacter]:
-	var chars := []
+	var chars :Array[DialogicCharacter]= []
 	for char_path in dialogic.current_state_info.get('portraits', {}).keys():
 		chars.append(load(char_path))
 	return chars

--- a/addons/dialogic/Events/Text/node_dialog_text.gd
+++ b/addons/dialogic/Events/Text/node_dialog_text.gd
@@ -39,13 +39,13 @@ func reveal_text(_text:String) -> void:
 # called by the timer -> reveals more text
 func continue_reveal() -> void:
 	if visible_characters < get_total_character_count():
-		visible_characters += 1
-		emit_signal("continued_revealing_text", text[visible_characters-1])
 		revealing = false
 		await Dialogic.Text.execute_effects(visible_characters, self, false)
 		revealing = true
+		visible_characters += 1
+		print("revealed ", get_parsed_text()[visible_characters-1])
+		emit_signal("continued_revealing_text", get_parsed_text()[visible_characters-1])
 	else:
-		
 		finish_text()
 
 # shows all the text imidiatly
@@ -63,6 +63,7 @@ func _process(delta:float) -> void:
 	if !revealing or Dialogic.paused:
 		return
 	speed_counter += delta
-	while speed_counter > 0 and revealing and !Dialogic.paused:
+	print("new frame ", speed_counter)
+	while speed_counter > speed and revealing and !Dialogic.paused:
 		speed_counter -= speed
 		continue_reveal()

--- a/addons/dialogic/Events/Text/node_dialog_text.gd
+++ b/addons/dialogic/Events/Text/node_dialog_text.gd
@@ -9,10 +9,10 @@ signal finished_revealing_text()
 enum ALIGNMENT {LEFT, CENTER, RIGHT}
 
 @export var alignment : ALIGNMENT = ALIGNMENT.LEFT
-@onready var timer :Timer = null
 
-
+var revealing := false
 var speed:float = 0.01
+var speed_counter:float = 0
 
 func _ready() -> void:
 	# add to necessary
@@ -20,14 +20,7 @@ func _ready() -> void:
 	
 	bbcode_enabled = true
 	text = ""
-	
-	# setup my timer
-	timer = Timer.new()
-	add_child(timer)
-	timer.wait_time = 0.01
-	timer.one_shot = true
-	DialogicUtil.update_timer_process_callback(timer)
-	timer.timeout.connect(continue_reveal)
+
 
 
 # this is called by the DialogicGameHandler to set text
@@ -39,10 +32,8 @@ func reveal_text(_text:String) -> void:
 	elif alignment == ALIGNMENT.RIGHT:
 		text = '[right]'+text
 	visible_characters = 0
-	if speed <= 0:
-		timer.start(0.01)
-	else:
-		timer.start(speed) 
+	revealing = true
+	speed_counter = 0
 	emit_signal('started_revealing_text')
 
 # called by the timer -> reveals more text
@@ -50,12 +41,9 @@ func continue_reveal() -> void:
 	if visible_characters < get_total_character_count():
 		visible_characters += 1
 		emit_signal("continued_revealing_text", text[visible_characters-1])
+		revealing = false
 		await Dialogic.Text.execute_effects(visible_characters, self, false)
-		if timer.is_stopped():
-			if speed <= 0:
-				continue_reveal()
-			else:
-				timer.start(speed)
+		revealing = true
 	else:
 		
 		finish_text()
@@ -65,13 +53,16 @@ func continue_reveal() -> void:
 func finish_text() -> void:
 	visible_ratio = 1
 	Dialogic.Text.execute_effects(-1, self, true)
-	timer.stop()
+	revealing = false
 	Dialogic.current_state = Dialogic.states.IDLE
 	emit_signal("finished_revealing_text")
 
 
-func pause() -> void: 
-	timer.stop()
-
-func resume() -> void:
-	continue_reveal()
+# Calls continue_reveal. Used instead of a timer to allow multiple reveals per frame.
+func _process(delta:float) -> void:
+	if !revealing or Dialogic.paused:
+		return
+	speed_counter += delta
+	while speed_counter > 0 and revealing and !Dialogic.paused:
+		speed_counter -= speed
+		continue_reveal()

--- a/addons/dialogic/Events/Text/node_dialog_text.gd
+++ b/addons/dialogic/Events/Text/node_dialog_text.gd
@@ -43,7 +43,6 @@ func continue_reveal() -> void:
 		await Dialogic.Text.execute_effects(visible_characters, self, false)
 		revealing = true
 		visible_characters += 1
-		print("revealed ", get_parsed_text()[visible_characters-1])
 		emit_signal("continued_revealing_text", get_parsed_text()[visible_characters-1])
 	else:
 		finish_text()
@@ -63,7 +62,6 @@ func _process(delta:float) -> void:
 	if !revealing or Dialogic.paused:
 		return
 	speed_counter += delta
-	print("new frame ", speed_counter)
 	while speed_counter > speed and revealing and !Dialogic.paused:
 		speed_counter -= speed
 		continue_reveal()

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -156,7 +156,6 @@ func execute_effects(current_index:int, text_node:Control, skipping:bool= false)
 		if current_index == -1 or current_index < parsed_text_effect_info[0]['index']:
 			return
 		var effect :Dictionary=  parsed_text_effect_info.pop_front()
-		print(effect)
 		await (effect['execution_info']['callable'] as Callable).call(text_node, skipping, effect['value'])
 
 

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -39,19 +39,6 @@ func load_game_state() -> void:
 	if character:
 		update_name_label(character)
 
-
-func pause() -> void:
-	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
-		if text_node.is_visible_in_tree():
-			text_node.pause()
-
-
-func resume() -> void:
-	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
-		if text_node.is_visible_in_tree():
-			text_node.resume()
-
-
 ####################################################################################################
 ##					MAIN METHODS
 ####################################################################################################
@@ -59,8 +46,8 @@ func resume() -> void:
 ## Shows the given text on all visible DialogText nodes.
 ## Instant can be used to skip all reveiling.
 func update_dialog_text(text:String, instant:bool= false) -> void:
-	text = parse_text_effects(text)
 	text = parse_text_modifiers(text)
+	text = parse_text_effects(text)
 	text = color_names(text)
 	
 	if !instant: dialogic.current_state = dialogic.states.SHOWING_TEXT
@@ -169,6 +156,7 @@ func execute_effects(current_index:int, text_node:Control, skipping:bool= false)
 		if current_index == -1 or current_index < parsed_text_effect_info[0]['index']:
 			return
 		var effect :Dictionary=  parsed_text_effect_info.pop_front()
+		print(effect)
 		await (effect['execution_info']['callable'] as Callable).call(text_node, skipping, effect['value'])
 
 

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -207,9 +207,6 @@ func get_full_state() -> Dictionary:
 	else:
 		current_state_info['current_event_idx'] = -1
 		current_state_info['current_timeline'] = null
-	if has_subsystem('Portraits'):
-		current_state_info['current_portrait_positions'] = self.Portraits.current_positions
-		current_state_info['default_portrait_positions'] = self.Portraits._default_positions
 	if has_subsystem('History'):
 		if self.History.full_history_enabled:
 			self.History.strip_events_from_full_history()
@@ -226,10 +223,6 @@ func load_full_state(state_info:Dictionary) -> void:
 	current_state_info = state_info
 	if current_state_info.get('current_timeline', null):
 		start_timeline(current_state_info.current_timeline, current_state_info.get('current_event_idx', 0))
-	if has_subsystem('Portraits'):
-		if current_state_info.get('current_portrait_positions', null):
-			self.Portraits.current_positions = current_state_info['current_portrait_positions']
-			self.Portraits._default_positions = current_state_info['default_portrait_positions']
 	if has_subsystem('History'):
 		if self.History.full_history_enabled:
 			self.History.full_history = current_state_info['full_history'] 


### PR DESCRIPTION
Revealing new letters is now done in _process() instead of with a timer to allow revealing multiple characters in the same frame. 

- also removes leftover character_positions stuff in get_full_state()
- also fixes static typing in portrait subsystem get_joined_characters()
- add [br] syntax highlighting

- fixes #1412 