### PR TITLE
Add [aa] and [ns] commands plus more advance and skipping functionality

### DIFF
--- a/addons/dialogic/Events/DefaultLayouts/Default/DialogicDefaultLayout.tscn
+++ b/addons/dialogic/Events/DefaultLayouts/Default/DialogicDefaultLayout.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=3 uid="uid://r8jg1cax6dui"]
+[gd_scene load_steps=26 format=3 uid="uid://r8jg1cax6dui"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Events/DefaultLayouts/Default/DialogicDefaultLayout.gd" id="1"]
 [ext_resource type="Script" path="res://addons/dialogic/Events/Text/node_dialog_text.gd" id="2"]
@@ -11,6 +11,7 @@
 [ext_resource type="Script" path="res://addons/dialogic/Events/Style/node_style.gd" id="12"]
 [ext_resource type="AudioStream" uid="uid://dwcre3fjf3cj8" path="res://addons/dialogic/Example Assets/sound-effects/typing5.wav" id="13"]
 [ext_resource type="AudioStream" uid="uid://b6c1p14bc20p1" path="res://addons/dialogic/Example Assets/sound-effects/typing1.wav" id="14"]
+[ext_resource type="Script" path="res://addons/dialogic/Events/DefaultLayouts/Default/autoadvance_indicator.gd" id="15_ptoy3"]
 [ext_resource type="Script" path="res://addons/dialogic/Events/Choice/node_button_sound.gd" id="18"]
 [ext_resource type="Script" path="res://addons/dialogic/Events/Text/node_next_indicator.gd" id="20_ljcq2"]
 [ext_resource type="Script" path="res://addons/dialogic/Events/DefaultLayouts/Default/ExampleGlossaryPopup.gd" id="20_vmnp2"]
@@ -294,6 +295,17 @@ size_flags_vertical = 8
 script = ExtResource("20_ljcq2")
 show_on_questions = true
 metadata/_edit_layout_mode = 1
+
+[node name="AutoAdvanceProgressbar" type="ProgressBar" parent="DefaultStyle/DialogTextPanel"]
+modulate = Color(1, 1, 1, 0.188235)
+custom_minimum_size = Vector2(0, 10)
+layout_mode = 2
+size_flags_vertical = 8
+max_value = 1.0
+step = 0.001
+value = 0.5
+show_percentage = false
+script = ExtResource("15_ptoy3")
 
 [node name="DialogicNode_TextInput" type="Control" parent="DefaultStyle"]
 layout_mode = 1

--- a/addons/dialogic/Events/DefaultLayouts/Default/autoadvance_indicator.gd
+++ b/addons/dialogic/Events/DefaultLayouts/Default/autoadvance_indicator.gd
@@ -1,0 +1,8 @@
+extends Range
+
+func _process(delta):
+	if Dialogic.Text.get_autoadvance_progress() < 0:
+		hide()
+	else:
+		show()
+		value = Dialogic.Text.get_autoadvance_progress()

--- a/addons/dialogic/Events/Text/default_input_handler.gd
+++ b/addons/dialogic/Events/Text/default_input_handler.gd
@@ -1,6 +1,8 @@
 @tool
 extends Node
 
+var autoadvance_timer := Timer.new()
+
 ################################################################################
 ## 						INPUT
 ################################################################################
@@ -8,10 +10,37 @@ func _input(event:InputEvent) -> void:
 	if Input.is_action_just_pressed(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action')):
 		if Dialogic.paused: return
 		
-		if Dialogic.current_state == Dialogic.states.IDLE:
+		if Dialogic.current_state == Dialogic.states.IDLE and Dialogic.Text.can_manual_advance():
 			Dialogic.handle_next_event()
-			
+			autoadvance_timer.stop()
 		
 		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT:
-			if DialogicUtil.get_project_setting('dialogic/text/skippable', true):
+			if Dialogic.Text.can_skip():
 				Dialogic.Text.skip_text_animation()
+
+
+####################################################################################################
+##								AUTO-ADVANCING
+####################################################################################################
+func _ready() -> void:
+	Dialogic.Text.text_finished.connect(_on_text_finished)
+	add_child(autoadvance_timer)
+	autoadvance_timer.one_shot = true
+	autoadvance_timer.timeout.connect(_on_autoadvance_timer_timeout)
+
+
+func _on_text_finished() -> void:
+	if Dialogic.Text.should_autoadvance():
+		autoadvance_timer.start(Dialogic.Text.get_autoadvance_time())
+
+
+func _on_autoadvance_timer_timeout() -> void:
+	Dialogic.handle_next_event()
+
+
+func is_autoadvancing() -> bool:
+	return !autoadvance_timer.is_stopped()
+
+
+func get_autoadvance_time_left() -> float:
+	return autoadvance_timer.time_left

--- a/addons/dialogic/Events/Text/event_text.gd
+++ b/addons/dialogic/Events/Text/event_text.gd
@@ -88,15 +88,9 @@ func _execute() -> void:
 		dialogic.Text.show_next_indicators(true)
 		dialogic.Choices.show_current_choices()
 		dialogic.current_state = dialogic.states.AWAITING_CHOICE
-	elif DialogicUtil.get_project_setting('dialogic/text/autocontinue', false):
+	elif Dialogic.Text.should_autoadvance():
 		dialogic.Text.show_next_indicators(false, true)
-		var wait:float = DialogicUtil.get_project_setting('dialogic/text/autocontinue_delay', 1)
-		# if voiced, grab remaining time left on the voiceed line's audio region - KvaGram
-		if dialogic.has_subsystem('Voice') and dialogic.Voice.is_voiced(dialogic.current_event_idx):
-			#autocontinue settings is set as minimal. change or keep this? - Kvagram
-			wait = max(wait, dialogic.Voice.get_remaining_time())
-		await dialogic.get_tree().create_timer(wait, true, DialogicUtil.is_physics_timer()).timeout
-		dialogic.handle_next_event()
+		# In this case continuing is handled by the input script.
 	else:
 		dialogic.Text.show_next_indicators()
 		finish()

--- a/addons/dialogic/Events/Text/index.gd
+++ b/addons/dialogic/Events/Text/index.gd
@@ -24,11 +24,14 @@ func _get_text_effects() -> Array[Dictionary]:
 		{'command':'pause', 'subsystem':'Text', 'method':'effect_pause'},
 		{'command':'signal', 'subsystem':'Text', 'method':'effect_signal'},
 		{'command':'mood', 'subsystem':'Text', 'method':'effect_mood'},
+		{'command':'aa', 'subsystem':'Text', 'method':'effect_autoadvance'},
+		{'command':'ns', 'subsystem':'Text', 'method':'effect_noskip'},
 	]
 
 
 func _get_text_modifiers() -> Array[Dictionary]:
 	return [
 		{'subsystem':'Text', 'method':'modifier_random_selection'},
-		{'subsystem':'Text', 'method':"modifier_break"},
+		{'subsystem':'Text', 'method':"modifier_break", 'command':'br'},
+		
 	]


### PR DESCRIPTION
You can now 
- enable/disable skippable
- enable/disable auto-advance
- enable/disabled manual-advance
using methods of the Text subsystem.  

You can also use the text commands:
- [aa=x] will enable autoadvance, but still allow manual advance and skipping. It supports both [aa=v] as well as [aa=v+x]
-  [ns=x] is kinda full auto mode right now disabling skipping and manual advance and setting an autoadvance (also allows v and v+x)
These are reset before the next text event.

Autoadvance is no handled in the default input handler script instead of the text event. This script uses the new Dialogic.Text.can_skip(), Dialogic.Text.can_manual_advance(), Dialogic.Text.should_autoadvance() and Dialogic.Text.get_autoadvance_time().

A new Dialogic.Text.get_autoadvance_progress() method allows easily implementing an autoadvance indicator. A simple progress bar does this in the default layout scene.

- fixes #1459
- fixes #1280
- fixes #966
- somewhat fixes #134