### PR TITLE
Changed Glossary Category

### DIFF
--- a/addons/dialogic/Events/Glossary/event_glossary.gd
+++ b/addons/dialogic/Events/Glossary/event_glossary.gd
@@ -20,7 +20,7 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Glossary"
 	set_default_color('Color6')
-	event_category = Category.AudioVisual
+	event_category = Category.Other
 	event_sorting_index = 0
 	expand_by_default = false
 


### PR DESCRIPTION
This PR sets `event_category` in `DialogicGlossaryEvent` to `Other` because the previous value, `AudioVisual`, is not found in `DialogicEvent.Category`.

I originally presumed `Other` to be the category, but it could be `Audio` instead. Let me know the intended category, and I'll make a new PR branch.