### PR TITLE
Various smaller fixes

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -68,7 +68,7 @@ func _open_resource(resource:Resource) -> void:
 	character_loaded.emit(resource.resource_path)
 
 
-func _save_resource() -> void:
+func _save() -> void:
 	if ! visible or not current_resource:
 		return
 	

--- a/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
+++ b/addons/dialogic/Editor/TimelineEditor/timeline_editor.gd
@@ -69,7 +69,7 @@ func _open_resource(resource:Resource) -> void:
 
 
 ## If this editor supports editing resources, save them here (overwrite in subclass)
-func _save_resource() -> void:
+func _save() -> void:
 	match current_editor_mode:
 		0:
 			$VisualEditor.save_timeline()
@@ -86,7 +86,7 @@ func _input(event: InputEvent) -> void:
 
 ## Method to play the current timeline. Connected to the button in the sidebar.
 func play_timeline():
-	_save_resource()
+	_save()
 	
 	var dialogic_plugin = DialogicUtil.get_dialogic_plugin()
 	
@@ -128,7 +128,7 @@ func _on_resource_saved():
 
 
 func new_timeline(path:String) -> void:
-	_save_resource()
+	_save()
 	var new_timeline := DialogicTimeline.new()
 	new_timeline.resource_path = path
 	new_timeline.set_meta('timeline_not_saved', true)

--- a/addons/dialogic/Editor/dialogic_editor.gd
+++ b/addons/dialogic/Editor/dialogic_editor.gd
@@ -35,7 +35,7 @@ func _open_resource(resource:Resource) -> void:
 
 
 ## If this editor supports editing resources, save them here (overwrite in subclass)
-func _save_resource() -> void:
+func _save() -> void:
 	pass
 
 

--- a/addons/dialogic/Editor/editors_manager.gd
+++ b/addons/dialogic/Editor/editors_manager.gd
@@ -93,7 +93,7 @@ func _on_editors_tab_changed(tab:int) -> void:
 func edit_resource(resource:Resource, save_previous:bool = true) -> void:
 	if resource:
 		if current_editor and save_previous:
-			current_editor._save_resource()
+			current_editor._save()
 		
 		if !resource.resource_path in used_resources_cache:
 			used_resources_cache.append(resource.resource_path)
@@ -124,7 +124,7 @@ func toggle_editor(editor) -> void:
 func open_editor(editor:DialogicEditor, save_previous: bool = true, extra_info:Variant = null) -> void:
 	
 	if current_editor and save_previous:
-		current_editor._save_resource()
+		current_editor._save()
 	
 	if current_editor:
 		current_editor._close()
@@ -155,7 +155,7 @@ func open_editor(editor:DialogicEditor, save_previous: bool = true, extra_info:V
 ## Rarely used to completely clear a editor.
 func clear_editor(editor:DialogicEditor, save:bool = false) -> void:
 	if save:
-		editor._save_resource()
+		editor._save()
 	
 	editor._clear()
 
@@ -171,10 +171,9 @@ func show_add_resource_dialog(accept_callable:Callable, filter:String = "*", tit
 	)
 
 
-## If the current editor edits a resource, icurrent_editort will try to save
+## Called by the plugin.gd script on CTRL+S or Debug Game start
 func save_current_resource() -> void: 
-	if current_editor and editors[current_editor.name].has('extension'):
-		current_editor._save_resource()
+	current_editor._save()
 
 
 ## Change the resource state

--- a/addons/dialogic/Events/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Events/Character/subsystem_portraits.gd
@@ -324,6 +324,22 @@ func get_joined_characters() -> Array[DialogicCharacter]:
 	return chars
 
 
+func get_character_info(character:DialogicCharacter) -> Dictionary:
+	if is_character_joined(character):
+		var info :Dictionary = dialogic.current_state_info['portraits'][character.resource_path]
+		info ['joined'] = true
+		return info
+	else:
+		return {'joined':false}
+
+
+func get_character_resource(character_name:String) -> DialogicCharacter:
+	var path :String = DialogicUtil.guess_resource('.dch', character_name)
+	if path: 
+		return load(path)
+	return null
+
+
 func update_rpg_portrait_mode(character:DialogicCharacter = null, portrait:String = "") -> void:
 	if DialogicUtil.get_project_setting('dialogic/portrait_mode', 0) == DialogicCharacterEvent.PortraitModes.RPG:
 		if !Dialogic.current_state_info.has('rpg_last_portrait'):

--- a/addons/dialogic/Events/DefaultLayouts/HideWithChild.gd
+++ b/addons/dialogic/Events/DefaultLayouts/HideWithChild.gd
@@ -1,7 +1,8 @@
 extends Control
 
 func _ready():
-	get_child(0).visibility_changed.connect(visiblity_changed)
+	get_child(0).visibility_changed.connect(_on_child_visibility_changed)
+	_on_child_visibility_changed()
 
-func visiblity_changed():
+func _on_child_visibility_changed():
 	visible = get_child(0).visible

--- a/addons/dialogic/Events/Glossary/event_glossary.gd
+++ b/addons/dialogic/Events/Glossary/event_glossary.gd
@@ -20,7 +20,7 @@ func _execute() -> void:
 func _init() -> void:
 	event_name = "Glossary"
 	set_default_color('Color6')
-	event_category = Category.AudioVisual
+	event_category = Category.Other
 	event_sorting_index = 0
 	expand_by_default = false
 

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -94,12 +94,12 @@ func update_name_label(character:DialogicCharacter) -> void:
 				name_label.text = character.display_name
 			if !'use_character_color' in name_label or name_label.use_character_color:
 				name_label.self_modulate = character.color
-			speaking_character.emit(name_label.text)
+			speaking_character.emit(character)
 		else:
 			dialogic.current_state_info['character'] = null
 			name_label.text = ''
 			name_label.self_modulate = Color(1,1,1,1)
-			speaking_character.emit("(Nobody)")
+			speaking_character.emit(null)
 
 
 func set_autoadvance(enabled:=true, wait_time:Variant=1.0, temp:= false) -> void:

--- a/addons/dialogic/Events/Variable/variables_editor/variables_editor.gd
+++ b/addons/dialogic/Events/Variable/variables_editor/variables_editor.gd
@@ -16,7 +16,9 @@ func _open(argument:Variant = null):
 	%MainVariableGroup.update()
 	%MainVariableGroup.load_data('Variables', DialogicUtil.get_project_setting('dialogic/variables', {}))
 
-
-func _close():
+func _save():
 	ProjectSettings.set_setting('dialogic/variables', %MainVariableGroup.get_data())
 	ProjectSettings.save()
+
+func _close():
+	_save()

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -73,7 +73,7 @@ static func guess_resource(extension:String, identifier:String) -> String:
 	for resource_path in resources:
 		if resource_path.get_file().trim_suffix(extension) == identifier:
 			return resource_path
-	return null
+	return ""
 
 
 ## TODO remove this since ProjectSetting.get_setting supports default arg now.

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -28,7 +28,7 @@ static func listdir(path: String, files_only: bool = true, throw_error:bool = tr
 	if DirAccess.dir_exists_absolute(path):
 		var dir := DirAccess.open(path)
 		dir.list_dir_begin()
-		var file_name = dir.get_next()
+		var file_name := dir.get_next()
 		while file_name != "":
 			if not file_name.begins_with("."):
 				if files_only:
@@ -68,15 +68,16 @@ static func scan_folder(path:String, extension:String) -> Array:
 	return list
 
 
-static func guess_resource(extension, identifier):
-	var resources = list_resources_of_type(extension)
+static func guess_resource(extension:String, identifier:String) -> String:
+	var resources := list_resources_of_type(extension)
 	for resource_path in resources:
 		if resource_path.get_file().trim_suffix(extension) == identifier:
 			return resource_path
+	return null
 
 
 ## TODO remove this since ProjectSetting.get_setting supports default arg now.
-static func get_project_setting(setting:String, default = null):
+static func get_project_setting(setting:String, default :Variant= null) -> Variant:
 	return ProjectSettings.get_setting(setting) if ProjectSettings.has_setting(setting) else default
 
 
@@ -103,7 +104,7 @@ static func get_indexers(include_custom := true, force_reload := false) -> Array
 
 
 static func pretty_name(script:String) -> String:
-	var _name = script.get_file().trim_suffix("."+script.get_extension())
+	var _name := script.get_file().trim_suffix("."+script.get_extension())
 	_name = _name.replace('_', ' ')
 	_name = _name.capitalize()
 	return _name
@@ -113,7 +114,7 @@ static func str_to_bool(boolstring:String) -> bool:
 	return true if boolstring == "true" else false
 
 
-static func logical_convert(value):
+static func logical_convert(value:String) -> Variant:
 	if typeof(value) == TYPE_STRING:
 		if value.is_valid_int():
 			return value.to_int()
@@ -134,7 +135,7 @@ static func get_color_palette(default:bool = false) -> Dictionary:
 	#  ./core/rid.h:151 - Condition "!id_map.has(p_rid.get_data())" is true. Returned: nullptr
 	# over and over again.
 	# Might revisit this in Godot 4, but don't have any high hopes for it improving.
-	var colors = [
+	var colors := [
 		Color('#3b8bf2'), # Blue
 		Color('#00b15f'), # Green
 		Color('#9468e8'), # Purple
@@ -142,10 +143,10 @@ static func get_color_palette(default:bool = false) -> Dictionary:
 		Color('#fa952a'), # Orange
 		Color('#7C7C7C')  # Gray
 	]
-	var color_dict = {}
-	var index = 1
+	var color_dict := {}
+	var index := 1
 	for n in colors:
-		var color_name = 'Color' + str(index)
+		var color_name := 'Color' + str(index)
 		color_dict[color_name] = n
 		if !default:
 			if ProjectSettings.has_setting('dialogic/editor/' + color_name):
@@ -156,11 +157,11 @@ static func get_color_palette(default:bool = false) -> Dictionary:
 
 
 static func get_color(value:String) -> Color:
-	var colors = get_color_palette()
+	var colors := get_color_palette()
 	return colors[value]
 
 
-static func is_physics_timer()->bool:
+static func is_physics_timer() -> bool:
 	return get_project_setting('dialogic/timer/process_in_physics', false)
 	
 


### PR DESCRIPTION
Make sure variable editor saves when the editor saves not only when you switch editor. This resulted in a rename of _resource_saved() to just _saved() in the DialogicEditor class and thus the other dialogic Editors.

Added static tpying in a couple of places.

Added handy methods to the portrait subsystem. Also changed what is given with the Dialogic.Text.speaking_character signal (now the character resource).