### PR TITLE
Big signal update

### DIFF
--- a/addons/dialogic/Events/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Events/Audio/subsystem_audio.gd
@@ -2,6 +2,9 @@ extends DialogicSubsystem
 
 ## Subsystem that manages music and sounds.
 
+signal music_started(info:Dictionary)
+signal sound_started(info:Dictionary)
+
 var base_music_player := AudioStreamPlayer.new()
 var base_sound_player := AudioStreamPlayer.new()
 
@@ -43,7 +46,7 @@ func _ready() -> void:
 ## Updates the background music. Will fade out previous music.
 func update_music(path:String = '', volume:float = 0.0, audio_bus:String = "Master", fade_time:float = 0.0, loop:bool = true) -> void:
 	dialogic.current_state_info['music'] = {'path':path, 'volume':volume, 'audio_bus':audio_bus, 'loop':loop}
-	
+	music_started.emit(dialogic.current_state_info['music'])
 	var fader: Tween = null
 	if base_music_player.playing or !path.is_empty():
 		fader = create_tween()
@@ -77,6 +80,7 @@ func update_music(path:String = '', volume:float = 0.0, audio_bus:String = "Mast
 ## Plays a given sound file.
 func play_sound(path:String, volume:float = 0.0, audio_bus:String = "Master", loop :bool= false) -> void:
 	if base_sound_player != null and !path.is_empty():
+		sound_started.emit({'path':path, 'volume':volume, 'audio_bus':audio_bus, 'loop':loop})
 		var new_sound_node := base_sound_player.duplicate()
 		new_sound_node.name = "Sound"
 		new_sound_node.stream = load(path)

--- a/addons/dialogic/Events/Background/subsystem_backgrounds.gd
+++ b/addons/dialogic/Events/Background/subsystem_backgrounds.gd
@@ -2,7 +2,10 @@ extends DialogicSubsystem
 
 ## Subsystem for managing backgrounds. 
 
-var default_background_scene = load(get_script().resource_path.get_base_dir().path_join('default_background.tscn'))
+signal background_changed(info:Dictionary)
+
+
+var default_background_scene :PackedScene = load(get_script().resource_path.get_base_dir().path_join('default_background.tscn'))
 ####################################################################################################
 ##					STATE
 ####################################################################################################
@@ -29,6 +32,7 @@ func load_game_state():
 ## To do so implement [_should_do_background_update()] on the custom background scene.
 ## Then  [_update_background()] will be called directly on that previous scene.
 func update_background(scene:String = '', argument:String = '', fade_time:float = 0.0) -> void:
+	var info := {'scene':scene, 'argument':argument, 'fade_time':fade_time, 'same_scene':false}
 	for node in get_tree().get_nodes_in_group('dialogic_background_holders'):
 		if node.visible:
 			var bg_set: bool = false
@@ -38,6 +42,7 @@ func update_background(scene:String = '', argument:String = '', fade_time:float 
 						if old_bg.has_method('_update_background'):
 							old_bg._update_background(argument, fade_time)
 							bg_set = true
+							info['same_scene'] = true
 			if !bg_set:
 				# remove previous backgrounds
 				for old_bg in node.get_children():
@@ -70,8 +75,9 @@ func update_background(scene:String = '', argument:String = '', fade_time:float 
 					
 					elif "modulate" in new_node:
 						new_node.modulate = Color.TRANSPARENT
-						var tween = new_node.create_tween()
+						var tween := new_node.create_tween()
 						tween.tween_property(new_node, "modulate", Color.WHITE, fade_time)
 	
 	dialogic.current_state_info['background_scene'] = scene
 	dialogic.current_state_info['background_argument'] = argument
+	background_changed.emit(info)

--- a/addons/dialogic/Events/Jump/event_jump.gd
+++ b/addons/dialogic/Events/Jump/event_jump.gd
@@ -39,6 +39,7 @@ func _execute() -> void:
 	if return_after:
 		dialogic.Jump.push_to_jump_stack()
 	if timeline and timeline != dialogic.current_timeline:
+		dialogic.Jump.switched_timeline.emit({'previous_timeline':dialogic.current_timeline, 'timeline':timeline, 'label':label_name})
 		dialogic.start_timeline(timeline, label_name)
 	else:
 		if label_name:

--- a/addons/dialogic/Events/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Events/Jump/subsystem_jump.gd
@@ -2,6 +2,9 @@ extends DialogicSubsystem
 
 ## Subsystem that holds methods for jumping to specific labels, or return to the previous jump.
 
+signal switched_timeline(info:Dictionary)
+signal jumped_to_label(info:Dictionary)
+signal returned_from_jump(info:Dictionary)
 
 ####################################################################################################
 ##					STATE
@@ -34,17 +37,20 @@ func jump_to_label(label:String) -> void:
 		if event is DialogicLabelEvent and event.name == label:
 			break
 	dialogic.current_event_idx = idx
+	jumped_to_label.emit({'timeline':dialogic.current_timeline, 'label':label})
 
 
 func push_to_jump_stack() -> void:
 	dialogic.current_state_info['jump_stack'].push_back({'timeline':dialogic.current_timeline, 'index':dialogic.current_event_idx})
 
 
-func resume_from_latst_jump() -> void:
+func resume_from_last_jump() -> void:
+	var sub_timeline : DialogicTimeline = dialogic.current_timeline
 	dialogic.start_timeline(
 		dialogic.current_state_info['jump_stack'][-1].timeline, 
 		dialogic.current_state_info['jump_stack'][-1].index+1)
 	dialogic.current_state_info['jump_stack'].pop_back()
+	returned_from_jump.emit({'sub_timeline':sub_timeline, 'label':dialogic.current_timeline.get_event(dialogic.current_event_idx-1).name})
 
 
 func is_jump_stack_empty():

--- a/addons/dialogic/Events/Style/subsystem_styles.gd
+++ b/addons/dialogic/Events/Style/subsystem_styles.gd
@@ -2,6 +2,7 @@ extends DialogicSubsystem
 
 ## Subsystem that manages showing and hiding style nodes.
 
+signal style_changed(info:Dictionary)
 
 ####################################################################################################
 ##					STATE
@@ -36,3 +37,4 @@ func change_style(style_name:String) -> void:
 		for style_node in get_tree().get_nodes_in_group('dialogic_styles'):
 			if style_node.style_name == last_style:
 				style_node.show()
+		style_changed.emit({'style_name':style_name})

--- a/addons/dialogic/Events/Text/default_input_handler.gd
+++ b/addons/dialogic/Events/Text/default_input_handler.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 	autoadvance_timer.timeout.connect(_on_autoadvance_timer_timeout)
 
 
-func _on_text_finished() -> void:
+func _on_text_finished(info:Dictionary) -> void:
 	if Dialogic.Text.should_autoadvance():
 		autoadvance_timer.start(Dialogic.Text.get_autoadvance_time())
 

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -3,13 +3,14 @@ extends DialogicSubsystem
 ## Subsystem that handles showing of dialog text (+text effects & modifiers), name label, and next indicator
 
 
-signal text_finished
-signal speaking_character(argument)
+signal text_finished(info:Dictionary)
+signal speaker_updated(character:DialogicCharacter)
+signal textbox_visibility_changed(visible:bool)
 
 # used to color names without searching for all characters each time
 var character_colors := {}
 var color_regex := RegEx.new()
-var text_already_read:bool = false
+var text_already_read := false
 
 var text_effects := {}
 var parsed_text_effect_info : Array[Dictionary]= []
@@ -80,11 +81,14 @@ func update_dialog_text(text:String, instant:bool= false) -> String:
 	set_manualadvance(true, true)
 	return text
 
+
 func _on_dialog_text_finished():
-	text_finished.emit()
+	text_finished.emit({'text':dialogic.current_state_info['text'], 'character':dialogic.current_state_info['character']})
 
 
 func update_name_label(character:DialogicCharacter) -> void:
+	if character.resource_path == dialogic.current_state_info['character']:
+		return
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
 		if character:
 			dialogic.current_state_info['character'] = character.resource_path
@@ -94,12 +98,12 @@ func update_name_label(character:DialogicCharacter) -> void:
 				name_label.text = character.display_name
 			if !'use_character_color' in name_label or name_label.use_character_color:
 				name_label.self_modulate = character.color
-			speaking_character.emit(character)
+			speaker_updated.emit(character)
 		else:
 			dialogic.current_state_info['character'] = null
 			name_label.text = ''
 			name_label.self_modulate = Color(1,1,1,1)
-			speaking_character.emit(null)
+			speaker_updated.emit(null)
 
 
 func set_autoadvance(enabled:=true, wait_time:Variant=1.0, temp:= false) -> void:
@@ -130,7 +134,6 @@ func set_skippable(skippable:= true, temp:=false) -> void:
 		dialogic.current_state_info['skippable']['enabled'] = skippable
 
 
-
 func update_typing_sound_mood(mood:Dictionary = {}) -> void:
 	for typing_sound in get_tree().get_nodes_in_group('dialogic_type_sounds'):
 		typing_sound.load_overwrite(mood)
@@ -141,11 +144,13 @@ func hide_text_boxes() -> void:
 		name_label.text = ""
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		text_node.get_parent().visible = false
+	textbox_visibility_changed.emit(false)
 
 
 func show_text_boxes() -> void:
 	for text_node in get_tree().get_nodes_in_group('dialogic_dialog_text'):
 		text_node.get_parent().visible = true
+	textbox_visibility_changed.emit(true)
 
 
 func show_next_indicators(question=false, autocontinue=false) -> void:
@@ -293,7 +298,7 @@ func collect_character_names() -> void:
 	
 	character_colors = {}
 	for dch_path in DialogicUtil.list_resources_of_type('.dch'):
-		var dch = (load(dch_path) as DialogicCharacter)
+		var dch := (load(dch_path) as DialogicCharacter)
 
 		if dch.display_name:
 			character_colors[dch.display_name] = dch.color
@@ -342,6 +347,7 @@ func effect_noskip(text_node:Control, skipped:bool, argument:String) -> void:
 	set_skippable(false, true)
 	set_manualadvance(false, true)
 	effect_autoadvance(text_node, skipped, argument)
+
 
 func effect_autoadvance(text_node:Control, skipped:bool, argument:String) -> void:
 	if argument.is_empty() or !(argument.is_valid_float() or argument.begins_with('v')):

--- a/addons/dialogic/Events/TextInput/subsystem_text_input.gd
+++ b/addons/dialogic/Events/TextInput/subsystem_text_input.gd
@@ -4,6 +4,7 @@ extends DialogicSubsystem
 
 ## Signal that is fired when a confirmation button was pressed.
 signal input_confirmed(input:String)
+signal input_shown(info:Dictionary)
 
 
 ####################################################################################################
@@ -25,6 +26,7 @@ func show_text_input(text:String = '', default:String = '', placeholder:String =
 		if node.has_method('set_text'): node.set_text(text)
 		if node.has_method('set_default'): node.set_default(default)
 		if node.has_method('set_placeholder'): node.set_placeholder(placeholder)
+	input_shown.emit({'text':text, 'default':default, 'placeholder':placeholder, 'allow_empty':allow_empty})
 
 
 func hide_text_input() -> void:

--- a/addons/dialogic/Events/Variable/event_variable.gd
+++ b/addons/dialogic/Events/Variable/event_variable.gd
@@ -53,8 +53,10 @@ func _execute() -> void:
 						dialogic.VAR.set_variable(name, orig*the_value)
 					Operations.Divide:
 						dialogic.VAR.set_variable(name, orig/the_value)
+				dialogic.VAR.variable_was_set.emit({'variable':name, 'new_value':the_value, 'value':value})
 			elif operation == Operations.Set:
 				dialogic.VAR.set_variable(name, the_value)
+				dialogic.VAR.variable_was_set.emit({'variable':name, 'new_value':the_value, 'value':value})
 			else:
 				printerr("Dialogic: Set Variable event failed because one value wasn't a float! [", orig, ", ",the_value,"]")
 		else:

--- a/addons/dialogic/Events/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Events/Variable/subsystem_variables.gd
@@ -1,5 +1,13 @@
 extends DialogicSubsystem
 
+## Subsystem that manages variables and allows to access them.
+
+# Emitted if a dialogic variable changes
+signal variable_changed(info:Dictionary)
+# Emitted on any set variable event
+signal variable_was_set(info:Dictionary)
+
+
 ####################################################################################################
 ##					STATE
 ####################################################################################################
@@ -68,17 +76,19 @@ func set_variable(variable_name: String, value: Variant) -> bool:
 		
 		# if none is found, try getting it from the dialogic variables
 		_set_value_in_dictionary(variable_name, dialogic.current_state_info['variables'], value) 
+		variable_changed.emit({'variable':variable_name, 'new_value':value})
 	
 	elif variable_name in dialogic.current_state_info['variables'].keys():
 		if typeof(dialogic.current_state_info['variables'][variable_name]) == TYPE_STRING:
 			dialogic.current_state_info['variables'][variable_name] = value
+			variable_changed.emit({'variable':variable_name, 'new_value':value})
 			return true
 	else:
 		printerr("Dialogic: Tried accessing non-existant variable '"+variable_name+"'.")
 	return false
 
 
-func get_variable(variable_path:String, default = null) -> Variant:
+func get_variable(variable_path:String, default :Variant= null) -> Variant:
 	variable_path = variable_path.trim_prefix('{').trim_suffix('}')
 	
 	# Getting all the autoloads

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -122,7 +122,7 @@ func handle_event(event_index:int) -> void:
 	
 	if event_index >= len(current_timeline_events):
 		if has_subsystem('Jump') and !self.Jump.is_jump_stack_empty():
-			self.Jump.resume_from_latst_jump()
+			self.Jump.resume_from_last_jump()
 			return
 		else:
 			end_timeline()


### PR DESCRIPTION
Added many signals to all the subsystems. 
Most of these just give one info dictionary argument. While this is initally not as nice as giving named arguments, it means we can way more easily provide mode information in the future without breaking any code.

Added signals:
- Voice: voiceline_started, voiceline_finished, voiceline_stopped
- Variable: variable_changed, variable_was_set
- TextInput: input_confirmed, input_shown
- Text: text_finished, speaker_updated, textbox_visibility_changed
- Style: style_changed
- Jump: switched_timeline, jumped_to_label, returned_from_jump
- Choices: choice_selected, choices_shown
- Portraits: character_joined, character_left, character_portrait_changed, character_moved, position_changed
- Background: background_changed
- Audio: music_started, sound_started

Also:
- removed the voice timer from the voice subsystem
- fixed typo in Jump.resume_from_last_jump()

Fixes/Helps with:
- #1491 (helps, but doesn't fix)
- #1285 (makes self-implementation easier)
- #1216
- #665
- #384 (helps reacting to certain events)