### PR TITLE
Fix bug where skipping during [pause] doesn't work correctly

### DIFF
--- a/addons/dialogic/Events/Text/node_dialog_text.gd
+++ b/addons/dialogic/Events/Text/node_dialog_text.gd
@@ -41,6 +41,8 @@ func continue_reveal() -> void:
 	if visible_characters < get_total_character_count():
 		revealing = false
 		await Dialogic.Text.execute_effects(visible_characters, self, false)
+		if visible_characters == -1:
+			return
 		revealing = true
 		visible_characters += 1
 		emit_signal("continued_revealing_text", get_parsed_text()[visible_characters-2])


### PR DESCRIPTION
After a pause the text would continue to reveal even if it was skipped during the pause. A new check checks for this ;).