### PR TITLE
Make Sub Directories if Not Already Existed

### DIFF
--- a/addons/dialogic/Events/Converter/settings_converter.gd
+++ b/addons/dialogic/Events/Converter/settings_converter.gd
@@ -250,23 +250,25 @@ func convertTimelines():
 			var fileName = contents["metadata"]["name"]
 			%OutputLog.text += "Name: " + fileName + ", " + str(contents["events"].size()) + " timeline events"
 			
-			
-			if not DirAccess.dir_exists_absolute(conversionRootFolder + "/timelines" + folderPath): 
-				var directory = DirAccess.open(conversionRootFolder + "/timelines")
+			var dir_timelines = conversionRootFolder + "/timelines"
+			if not DirAccess.dir_exists_absolute(dir_timelines + folderPath): 
+				var directory = DirAccess.open(dir_timelines)
+				if not DirAccess.dir_exists_absolute(dir_timelines):
+					DirAccess.make_dir_absolute(dir_timelines)
 				
 				var progresiveDirectory = ""
 				for pathItem in folderPath.split('/'):
-					directory.open(conversionRootFolder + "/timelines" + progresiveDirectory)
+					directory.open(dir_timelines + progresiveDirectory)
 					if pathItem!= "":
 						progresiveDirectory += "/" + pathItem
-					if !directory.dir_exists(conversionRootFolder + "/timelines" + progresiveDirectory):
-						directory.make_dir(conversionRootFolder + "/timelines" + progresiveDirectory)
+					if !directory.dir_exists(dir_timelines + progresiveDirectory):
+						directory.make_dir(dir_timelines + progresiveDirectory)
 				
 			#just double check because sometimes its making double slashes at the final filename
 			if folderPath.right(1) == "/":
 				folderPath = folderPath.left(-1)
 			# we will save it as an intermediary file first, then on second pass cleanup make it the .dtl	
-			var newFilePath = conversionRootFolder + "/timelines" + folderPath + "/" + fileName + ".cnv"	
+			var newFilePath = dir_timelines + folderPath + "/" + fileName + ".cnv"	
 			
 			file = FileAccess.open(newFilePath, FileAccess.WRITE)
 			
@@ -752,17 +754,19 @@ func convertCharacters():
 
 				
 			
-			
-			if not DirAccess.dir_exists_absolute(conversionRootFolder + "/characters" + folderPath): 
-				var directory = DirAccess.open(conversionRootFolder + "/characters")
+			var dir_char = conversionRootFolder + "/characters"
+			if not DirAccess.dir_exists_absolute(dir_char + folderPath):
+				if not DirAccess.dir_exists_absolute(dir_char):
+					DirAccess.make_dir_absolute(dir_char)
+				var directory = DirAccess.open(dir_char)
 				
 				var progresiveDirectory = ""
 				for pathItem in folderPath.split('/'):
-					directory.open(conversionRootFolder + "/characters" + progresiveDirectory)
+					directory.open(dir_char + progresiveDirectory)
 					if pathItem!= "":
 						progresiveDirectory += "/" + pathItem
-					if !directory.dir_exists(conversionRootFolder + "/characters" + progresiveDirectory):
-						directory.make_dir(conversionRootFolder + "/characters" + progresiveDirectory)
+					if !directory.dir_exists(dir_char + progresiveDirectory):
+						directory.make_dir(dir_char + progresiveDirectory)
 			
 			#add the prefix if the prefix option is enabled
 			if prefixCharacters:
@@ -774,7 +778,7 @@ func convertCharacters():
 			# using the resource constructor for this one
 			
 			var current_character = DialogicCharacter.new()
-			current_character.resource_path = conversionRootFolder + "/characters" + folderPath + "/" + fileName + ".dch"
+			current_character.resource_path = dir_char + folderPath + "/" + fileName + ".dch"
 			# Everything needs to be in exact order
 
 			current_character.color = Color(contents["color"].right(6))
@@ -918,7 +922,7 @@ func convertVariables():
 		ProjectSettings.save()
 		
 		#rebuild the data in the other tabs, so it doesnt override it
-		find_parent('SettingsEditor').refresh()
+		refresh()
 		%OutputLog.text += str(convertedVariables) + " variables converted, and saved to project!\r\n"
 	else:
 		%OutputLog.text += "[color=yellow]Variable subsystem is not present! Variables were not converted![/color]\r\n"


### PR DESCRIPTION
This prevent "directory" from being set to null upon calling "DirAccess.make_dir_absolute(dir)".

Also, make "refresh()" to be called on itself rather than its parent.