### PR TITLE
add null check to text update_name_label

### DIFF
--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -87,11 +87,12 @@ func _on_dialog_text_finished():
 
 
 func update_name_label(character:DialogicCharacter) -> void:
-	if character.resource_path == dialogic.current_state_info['character']:
+	var character_path = character.resource_path if character else null
+	if character_path == dialogic.current_state_info.get('character'):
 		return
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
 		if character:
-			dialogic.current_state_info['character'] = character.resource_path
+			dialogic.current_state_info['character'] = character_path
 			if dialogic.has_subsystem('VAR'):
 				name_label.text = dialogic.VAR.parse_variables(character.display_name)
 			else:


### PR DESCRIPTION
There are a few places where we do a `update_name_label(null)`, which makes `character.resource_path` throw an invalid index error. This commit fixes this bug; also a fixes a related bug in the same function where it is possible to access
`dialogic.current_state_info['character']` before it is defined.