### PR TITLE
Check if Keys are Avaiable

### DIFF
--- a/addons/dialogic/Events/Converter/settings_converter.gd
+++ b/addons/dialogic/Events/Converter/settings_converter.gd
@@ -319,7 +319,11 @@ func convertTimelines():
 							# Character event
 							
 							#For some reason this is loading as a float, and the match is failing. so hard casting as string
-							var eventType:String = str(event['type'])
+							var eventType:String
+							if 'type' in event:
+								eventType = str(event['type'])
+							else:
+								eventType = "0"
 							
 							match eventType:
 								"0":
@@ -337,7 +341,7 @@ func convertTimelines():
 										if (event['animation'] != "[Default]" && event['animation'] != "") || ('z_index' in event) || ('mirror_portrait' in event):
 											# Note: due to Anima changes, animations will be converted into a default. Times and wait will be perserved
 											eventLine += " ["
-											if (event['animation'] != "[Default]" && event['animation'] != ""):
+											if ('animation' in event && event['animation'] != "[Default]" && event['animation'] != ""):
 												eventLine += " [animation=\"Instant In Or Out\" "
 												eventLine += "length=\"" +  str(event['animation_length']) + "\""
 												if "animation_wait" in event:


### PR DESCRIPTION
Otherwise, the value would have been taken null and the code won't progress further.

This is a fix to the timeline conversion.