### PR TITLE
Add autopausing-capability

### DIFF
--- a/addons/dialogic/Events/Text/index.gd
+++ b/addons/dialogic/Events/Text/index.gd
@@ -31,7 +31,7 @@ func _get_text_effects() -> Array[Dictionary]:
 
 func _get_text_modifiers() -> Array[Dictionary]:
 	return [
+		{'subsystem':'Text', 'method':'modifier_autopauses'},
 		{'subsystem':'Text', 'method':'modifier_random_selection'},
 		{'subsystem':'Text', 'method':"modifier_break", 'command':'br'},
-		
 	]

--- a/addons/dialogic/Events/Text/settings_text.gd
+++ b/addons/dialogic/Events/Text/settings_text.gd
@@ -12,7 +12,11 @@ func refresh():
 	%InputAction.resource_icon = get_theme_icon("Mouse", "EditorIcons")
 	%InputAction.set_value(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action'))
 	%InputAction.get_suggestions_func = suggest_actions
+	load_autopauses(DialogicUtil.get_project_setting('dialogic/text/autopauses', {}))
 
+
+func _about_to_close():
+	save_autopauses()
 
 func _on_AutocontinueDelay_value_changed(value):
 	ProjectSettings.set_setting('dialogic/text/autocontinue_delay', value)
@@ -38,8 +42,8 @@ func _on_InputAction_value_changed(property_name, value):
 	ProjectSettings.set_setting('dialogic/text/input_action', value)
 	ProjectSettings.save()
 
-func suggest_actions(search):
-	var suggs = {}
+func suggest_actions(search:String) -> Dictionary:
+	var suggs := {}
 	for prop in ProjectSettings.get_property_list():
 		if prop.name.begins_with('input/'):
 			suggs[prop.name.trim_prefix('input/')] = {'value':prop.name.trim_prefix('input/')}
@@ -49,3 +53,41 @@ func suggest_actions(search):
 func _on_AutocolorNames_toggled(button_pressed):
 	ProjectSettings.set_setting('dialogic/text/autocolor_names', button_pressed)
 	ProjectSettings.save()
+
+
+func load_autopauses(dictionary:Dictionary) -> void:
+	for i in %AutoPauseSets.get_children():
+		if i.get_index() != 0:
+			i.queue_free()
+	
+	for i in dictionary.keys():
+		add_autopause_set(i, dictionary[i])
+
+
+func save_autopauses() -> void:
+	var dictionary := {}
+	for i in %AutoPauseSets.get_children():
+		if i.get_index() != 0:
+			if i.get_child(0).text:
+				dictionary[i.get_child(0).text] = i.get_child(1).value
+	ProjectSettings.set_setting('dialogic/text/autopauses', dictionary)
+	ProjectSettings.save()
+
+
+func _on_add_autopauses_set_pressed():
+	add_autopause_set('', 0.1)
+
+
+func add_autopause_set(text:String, time:float) -> void:
+	var hbox := HBoxContainer.new()
+	%AutoPauseSets.add_child(hbox)
+	var line_edit := LineEdit.new()
+	line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	line_edit.placeholder_text = 'e.g. "?!.,;:"'
+	line_edit.text = text
+	hbox.add_child(line_edit)
+	var spin_box := SpinBox.new()
+	spin_box.min_value = 0.1
+	spin_box.step = 0.01
+	spin_box.value = time
+	hbox.add_child(spin_box)

--- a/addons/dialogic/Events/Text/subsystem_text.gd
+++ b/addons/dialogic/Events/Text/subsystem_text.gd
@@ -19,6 +19,7 @@ var text_modifiers := []
 
 var input_handler_node :Node = null
 
+var autopauses := {} 
 
 ####################################################################################################
 ##					STATE
@@ -275,6 +276,11 @@ func _ready():
 	collect_text_modifiers()
 	Dialogic.event_handled.connect(hide_next_indicators)
 	input_handler_node = Node.new()
+	autopauses = {}
+	var autopause_data :Dictionary= ProjectSettings.get_setting('dialogic/text/autopauses', {})
+	for i in autopause_data.keys():
+		autopauses[RegEx.create_from_string('(?<!(\\[|\\{))['+i+'](?![\\w\\s]*[\\]\\}])')] = autopause_data[i]
+		
 	input_handler_node.set_script(load(get_script().resource_path.get_base_dir().path_join('default_input_handler.gd')))
 	add_child(input_handler_node)
 
@@ -371,3 +377,12 @@ func modifier_random_selection(text:String) -> String:
 
 func modifier_break(text:String) -> String:
 	return text.replace('[br]', '\n')
+
+
+func modifier_autopauses(text:String) -> String:
+	for i in autopauses.keys():
+		var offset := 0
+		for result in i.search_all(text):
+			text = text.insert(result.get_end()+offset, '[pause='+str(autopauses[i])+']')
+			offset += len('[pause='+str(autopauses[i])+']')
+	return text


### PR DESCRIPTION
Adds autopausing for certain letters. The sets of letters can be changed in the DialogText settings page.

The autopausing is done as a modifier that adds [pause] effects after these letters. A regex is used so letters inside of [brackets] or {brackets} are not altered. This is mainly important for the dot (.).