### PR TITLE
Fix event issues found by emilio

### DIFF
--- a/addons/dialogic/Events/Background/event_background.gd
+++ b/addons/dialogic/Events/Background/event_background.gd
@@ -62,13 +62,13 @@ func get_shortcode_parameters() -> Dictionary:
 
 func build_event_editor():
 	add_header_edit('argument', ValueType.File, '', '', 
-			{'file_filter':'*.tscn, *.scn, *.jpg, *.jpeg, *.png, *.webp, *.tga, *svg, *.bmp, *.dds, *.exr, *.hdr', 
+			{'file_filter':'*.jpg, *.jpeg, *.png, *.webp, *.tga, *svg, *.bmp, *.dds, *.exr, *.hdr', 
 			'placeholder': "No background", 
 			'editor_icon':["Image", "EditorIcons"]}, 
 			'scene == ""')
 	add_header_edit('argument', ValueType.SinglelineText, 'Argument:', '', {}, 'scene != ""')
-	add_body_edit("fade", ValueType.Float, "fade time: ")
-	add_body_edit("scene", ValueType.File, 'scene:', '', 
+	add_body_edit("fade", ValueType.Float, "Fade Time: ")
+	add_body_edit("scene", ValueType.File, 'Scene:', '', 
 			{'file_filter':'*.tscn, *.scn',
 			'placeholder': "Default scene", 
 			'editor_icon':["PackedScene", "EditorIcons"]})

--- a/addons/dialogic/Events/Variable/event_variable.gd
+++ b/addons/dialogic/Events/Variable/event_variable.gd
@@ -168,7 +168,9 @@ func is_valid_event(string:String) -> bool:
 func build_event_editor():
 	add_header_edit('name', ValueType.ComplexPicker, '', '', 
 			{'suggestions_func' 	: get_var_suggestions, 
-			'editor_icon' 			: ["ClassList", "EditorIcons"]})
+			'editor_icon' 			: ["ClassList", "EditorIcons"],
+			'placeholder'			:'Select Variable'}
+			)
 	add_header_edit('operation', ValueType.FixedOptionSelector, '', '', {
 		'selector_options': [
 			{

--- a/addons/dialogic/Events/Variable/subsystem_variables.gd
+++ b/addons/dialogic/Events/Variable/subsystem_variables.gd
@@ -79,10 +79,9 @@ func set_variable(variable_name: String, value: Variant) -> bool:
 		variable_changed.emit({'variable':variable_name, 'new_value':value})
 	
 	elif variable_name in dialogic.current_state_info['variables'].keys():
-		if typeof(dialogic.current_state_info['variables'][variable_name]) == TYPE_STRING:
-			dialogic.current_state_info['variables'][variable_name] = value
-			variable_changed.emit({'variable':variable_name, 'new_value':value})
-			return true
+		dialogic.current_state_info['variables'][variable_name] = value
+		variable_changed.emit({'variable':variable_name, 'new_value':value})
+		return true
 	else:
 		printerr("Dialogic: Tried accessing non-existant variable '"+variable_name+"'.")
 	return false


### PR DESCRIPTION
- fix for #1521
    -> For some reason first level variables wheren't set if the existing value wasn't a string. I cannot remember any good reason for this, so I removed it. Hope this doesn' result in problems again.

- fix for #1520
     -> Changed placeholder text of the set variable event

- work on #1522
     -> Made sure you cannot select a scene in the image picker of tha background event, also fixed not capitalized texts