### PR TITLE
Add modules manager and first default override ability

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_editor.tscn
+++ b/addons/dialogic/Editor/Settings/settings_editor.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=4 format=3 uid="uid://dganirw26brfb"]
+[gd_scene load_steps=5 format=3 uid="uid://dganirw26brfb"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/Settings/settings_editor.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://b873ho41sklv8" path="res://addons/dialogic/Editor/Settings/settings_general.tscn" id="3"]
 [ext_resource type="PackedScene" uid="uid://chpb1mj03xjxv" path="res://addons/dialogic/Editor/Settings/settings_translation.tscn" id="3_q3qwt"]
+[ext_resource type="PackedScene" uid="uid://o7ljiritpgap" path="res://addons/dialogic/Editor/Settings/settings_modules.tscn" id="4_c4a34"]
 
 [node name="SettingsEditor" type="MarginContainer"]
 offset_right = 1020.0
@@ -22,5 +23,9 @@ size_flags_vertical = 3
 layout_mode = 2
 
 [node name="Translations" parent="Tabs" instance=ExtResource("3_q3qwt")]
+visible = false
+layout_mode = 2
+
+[node name="Modules" parent="Tabs" instance=ExtResource("4_c4a34")]
 visible = false
 layout_mode = 2

--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -28,6 +28,7 @@ func _ready() -> void:
 	# Extension creator
 	%ExtensionCreator.hide()
 
+
 func refresh() -> void:
 	%PhysicsTimerButton.button_pressed = DialogicUtil.is_physics_timer()
 	%LayoutNodeEndBehaviour.select(ProjectSettings.get_setting('dialogic/layout/end_behaviour', 0))

--- a/addons/dialogic/Editor/Settings/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/settings_modules.gd
@@ -255,7 +255,7 @@ func load_event_settings(event:DialogicEvent) -> void:
 				editor_node = LineEdit.new()
 				editor_node.custom_minimum_size.x = 150
 				editor_node.text = str(current_value)
-				editor_node.text_submitted.connect(_on_event_default_string_submitted.bind(params[prop].property))
+				editor_node.text_changed.connect(_on_event_default_string_submitted.bind(params[prop].property))
 			TYPE_INT, TYPE_FLOAT:
 				if params[prop].has('suggestions'):
 					editor_node = OptionButton.new()

--- a/addons/dialogic/Editor/Settings/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/settings_modules.gd
@@ -2,22 +2,6 @@
 extends HSplitContainer
 
 
-# get_theme_icon("Folder", "EditorIcons")
-# get_theme_icon("Favorites", "EditorIcons")
-# get_theme_icon("RichTextEffect", "EditorIcons")
-# get_theme_icon("EditorHandleDisabled", "EditorIcons")
-# get_theme_icon("Callable", "EditorIcons")
-# get_theme_icon("CombineLines", "EditorIcons")
-# get_theme_icon("ScriptCreateDialog", "EditorIcons")
-# get_theme_icon("Search", "EditorIcons")
-# get_theme_icon("GDScript", "EditorIcons")
-# get_theme_icon("MatchCase", "EditorIcons")
-# get_theme_icon("NodeInfo", "EditorIcons")
-# get_theme_icon("PluginScript", "EditorIcons")
-# get_theme_icon("PopupMenu", "EditorIcons")
-
-
-
 func _ready() -> void:
 	%Refresh.icon = get_theme_icon("Loop", "EditorIcons")
 	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
@@ -37,8 +21,7 @@ func _ready() -> void:
 	
 	$Settings/EventDefaultsPanel.add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
 	
-	%ExternalLink.icon = get_theme_icon("ExternalLink", "EditorIcons")
-
+	%ExternalLink.icon = get_theme_icon("Help", "EditorIcons")
 
 
 func refresh() -> void:
@@ -206,7 +189,7 @@ func _on_tree_item_selected() -> void:
 		%ExternalLink.hide()
 		match metadata.type:
 			'Event':
-				%GeneralInfo.text = "Events are can be used in timelines and do all kinds of things. They often interact with subsystems and dialogic nodes."
+				%GeneralInfo.text = "Events can be used in timelines and do all kinds of things. They often interact with subsystems and dialogic nodes."
 				
 				load_event_settings(metadata.event)
 				if %EventDefaults.get_child_count():

--- a/addons/dialogic/Editor/Settings/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/settings_modules.gd
@@ -1,0 +1,316 @@
+@tool
+extends HSplitContainer
+
+
+# get_theme_icon("Folder", "EditorIcons")
+# get_theme_icon("Favorites", "EditorIcons")
+# get_theme_icon("RichTextEffect", "EditorIcons")
+# get_theme_icon("EditorHandleDisabled", "EditorIcons")
+# get_theme_icon("Callable", "EditorIcons")
+# get_theme_icon("CombineLines", "EditorIcons")
+# get_theme_icon("ScriptCreateDialog", "EditorIcons")
+# get_theme_icon("Search", "EditorIcons")
+# get_theme_icon("GDScript", "EditorIcons")
+# get_theme_icon("MatchCase", "EditorIcons")
+# get_theme_icon("NodeInfo", "EditorIcons")
+# get_theme_icon("PluginScript", "EditorIcons")
+# get_theme_icon("PopupMenu", "EditorIcons")
+
+
+
+func _ready() -> void:
+	%Refresh.icon = get_theme_icon("Loop", "EditorIcons")
+	%Search.right_icon = get_theme_icon("Search", "EditorIcons")
+	
+	%Filter_Events.icon = get_theme_icon("Favorites", "EditorIcons")
+	%Filter_Subsystems.icon = get_theme_icon("Callable", "EditorIcons")
+	%Filter_Styles.icon = get_theme_icon("PopupMenu", "EditorIcons")
+	%Filter_EffectsAndModifiers.icon = get_theme_icon("RichTextEffect", "EditorIcons")
+	%Filter_Editors.icon = get_theme_icon("ConfirmationDialog", "EditorIcons")
+	%Filter_Settings.icon = get_theme_icon("PluginScript", "EditorIcons")
+	%Collapse.icon = get_theme_icon("CollapseTree", "EditorIcons")
+	
+	%Title.add_theme_font_size_override('font_size', get_theme_font_size("doc_size", "EditorFonts"))
+	%Title.add_theme_font_override('font', get_theme_font("bold", "EditorFonts"))
+	%GeneralInfo.add_theme_color_override("font_color", get_theme_color("accent_color", "Editor"))
+	%GeneralInfo.add_theme_font_override("font", get_theme_font("doc_italic", "EditorFonts"))
+	
+	$Settings/EventDefaultsPanel.add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
+	
+	%ExternalLink.icon = get_theme_icon("ExternalLink", "EditorIcons")
+
+
+
+func refresh() -> void:
+	load_modules_tree()
+
+
+func _on_refresh_pressed() -> void:
+	load_modules_tree()
+
+
+func filters_updated(fake_arg:Variant) -> void:
+	load_modules_tree()
+
+
+func _on_collapse_toggled(button_pressed:bool) -> void:
+	for item in %Tree.get_root().get_children():
+		item.collapsed = button_pressed
+	
+	if button_pressed:
+		%Collapse.icon = get_theme_icon("ExpandTree", "EditorIcons")
+		%Collapse.tooltip_text = "Expand All"
+	else:
+		%Collapse.icon = get_theme_icon("CollapseTree", "EditorIcons")
+		%Collapse.tooltip_text = "Collapse All"
+
+
+func _on_search_text_changed(new_text:String) -> void:
+	for filter in [%Filter_Events, %Filter_Subsystems, %Filter_Editors, %Filter_EffectsAndModifiers, %Filter_Settings, %Filter_Styles]:
+		filter.text = ""
+		filter.set_meta("counter", 0)
+	
+	
+	for child in %Tree.get_root().get_children():
+		if new_text.to_lower() in child.get_text(0).to_lower() or new_text.is_empty():
+			for sub_child in child.get_children():
+				sub_child.visible = sub_child.get_meta('filter_button').button_pressed
+				sub_child.get_meta('filter_button').set_meta('counter', sub_child.get_meta('filter_button').get_meta('counter')+1)
+				sub_child.get_meta('filter_button').text = str(sub_child.get_meta('filter_button').get_meta('counter'))
+			child.visible = true
+		else:
+			for sub_child in child.get_children():
+				sub_child.visible = sub_child.get_meta('filter_button').button_pressed and new_text.to_lower() in sub_child.get_text(0).to_lower()
+				
+				if new_text.to_lower() in sub_child.get_text(0).to_lower():
+					sub_child.get_meta('filter_button').set_meta('counter', sub_child.get_meta('filter_button').get_meta('counter')+1)
+					sub_child.get_meta('filter_button').text = str(sub_child.get_meta('filter_button').get_meta('counter'))
+		
+		for i in range(child.get_button_count(0)):
+			child.erase_button(0, child.get_button_count(0)-1)
+		var any_visible = false
+		var counter := 0
+		for sub_child in child.get_children():
+			if sub_child.visible:
+				child.add_button(0, sub_child.get_icon(0), counter, false, sub_child.get_text(0))
+				child.set_button_color(0, counter, sub_child.get_icon_modulate(0))
+				counter += 1
+				any_visible = true
+		child.visible = any_visible
+#		child.collapsed = %Collapse.button_pressed
+
+
+
+func load_modules_tree() -> void:
+	%Tree.clear()
+	var root :TreeItem = %Tree.create_item()
+	
+	var cached_events :Array = get_parent().get_parent().editors_manager.resource_helper.event_script_cache
+	var indexers := DialogicUtil.get_indexers()
+	for i in indexers:
+		var module_item :TreeItem = %Tree.create_item(root)
+		module_item.set_text(0, i.get_script().resource_path.trim_suffix('/index.gd').get_file())
+		
+		# Events
+		for ev in i._get_events():
+			var event_item : TreeItem = %Tree.create_item(module_item)
+			event_item.set_icon(0, get_theme_icon("Favorites", "EditorIcons"))
+			for cached_event in cached_events:
+				if cached_event.get_script().resource_path == ev:
+					event_item.set_text(0, cached_event.event_name + " Event")
+					event_item.set_icon_modulate(0, cached_event.event_color)
+					event_item.set_metadata(0, {'type':'Event', 'event':cached_event})
+			event_item.set_meta('filter_button', %Filter_Events)
+			event_item.visible = %Filter_Events.button_pressed
+		
+		# Subsystems
+		for subsys in i._get_subsystems():
+			var subsys_item : TreeItem = %Tree.create_item(module_item)
+			subsys_item.set_icon(0, get_theme_icon("Callable", "EditorIcons"))
+			subsys_item.set_text(0, subsys.name + " Subsystem")
+			subsys_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
+			subsys_item.set_metadata(0, {'type':'Subsystem', 'info':subsys})
+			subsys_item.set_meta('filter_button', %Filter_Subsystems)
+			subsys_item.visible = %Filter_Subsystems.button_pressed
+		
+		# Style scenes
+		for style in i._get_layout_scenes():
+			var style_item : TreeItem = %Tree.create_item(module_item)
+			style_item.set_icon(0, get_theme_icon("PopupMenu", "EditorIcons"))
+			style_item.set_text(0, style.name)
+			style_item.set_icon_modulate(0, get_theme_color("property_color_x", "Editor"))
+			style_item.set_metadata(0, {'type':'Style', 'info':style})
+			style_item.set_meta('filter_button', %Filter_Styles)
+			style_item.visible = %Filter_Styles.button_pressed
+		
+		# Text Effects
+		for effect in i._get_text_effects():
+			var effect_item : TreeItem = %Tree.create_item(module_item)
+			effect_item.set_icon(0, get_theme_icon("RichTextEffect", "EditorIcons"))
+			effect_item.set_text(0, "Text effect ["+effect.command+"]")
+			effect_item.set_icon_modulate(0, get_theme_color("property_color_z", "Editor"))
+			effect_item.set_metadata(0, {'type':'Effect', 'info':effect})
+			effect_item.set_meta('filter_button', %Filter_EffectsAndModifiers)
+			effect_item.visible = %Filter_EffectsAndModifiers.button_pressed
+		
+		# Text Modifiers
+		for mod in i._get_text_modifiers():
+			var mod_item : TreeItem = %Tree.create_item(module_item)
+			mod_item.set_icon(0, get_theme_icon("RichTextEffect", "EditorIcons"))
+			mod_item.set_text(0, mod.method.capitalize())
+			mod_item.set_icon_modulate(0, get_theme_color("property_color_z", "Editor"))
+			mod_item.set_metadata(0, {'type':'Modifier', 'info':mod})
+			mod_item.set_meta('filter_button', %Filter_EffectsAndModifiers)
+			mod_item.visible = %Filter_EffectsAndModifiers.button_pressed
+		
+		# Settings
+		for settings in i._get_settings_pages():
+			var settings_item : TreeItem = %Tree.create_item(module_item)
+			settings_item.set_icon(0, get_theme_icon("PluginScript", "EditorIcons"))
+			settings_item.set_text(0, module_item.get_text(0) + " Settings")
+			settings_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
+			settings_item.set_metadata(0, {'type':'Settings', 'info':settings})
+			settings_item.set_meta('filter_button', %Filter_Settings)
+			settings_item.visible = %Filter_Settings.button_pressed
+		
+		# Editors
+		for editor in i._get_editors():
+			var editor_item : TreeItem = %Tree.create_item(module_item)
+			editor_item.set_icon(0, get_theme_icon("ConfirmationDialog", "EditorIcons"))
+			editor_item.set_text(0, editor.get_file().trim_suffix('.tscn').capitalize())
+			editor_item.set_icon_modulate(0, get_theme_color("readonly_color", "Editor"))
+			editor_item.set_metadata(0, {'type':'Editor', 'info':editor})
+			editor_item.set_meta('filter_button', %Filter_Editors)
+			editor_item.visible = %Filter_Editors.button_pressed
+		
+		module_item.collapsed = %Collapse.button_pressed
+	
+	_on_search_text_changed(%Search.text)
+	if %Tree.get_root().get_child_count(): %Tree.set_selected(%Tree.get_root().get_child(0), 0)
+
+
+func _on_tree_button_clicked(item:TreeItem, column:int, id:int, mouse_button_index:int) -> void:
+	item.collapsed = false
+	%Tree.set_selected(item.get_child(id), 0)
+
+
+func _on_tree_item_selected() -> void:
+	var selected_item :TreeItem = %Tree.get_selected()
+	
+	var metadata :Variant = selected_item.get_metadata(0)
+	
+	if metadata is Dictionary:
+		%Title.text = selected_item.get_text(0)
+		$Settings/EventDefaultsPanel.hide()
+		%ExternalLink.hide()
+		match metadata.type:
+			'Event':
+				%GeneralInfo.text = "Events are can be used in timelines and do all kinds of things. They often interact with subsystems and dialogic nodes."
+				$Settings/EventDefaultsPanel.show()
+				
+				load_event_settings(metadata.event)
+				if metadata.event.help_page_path:
+					%ExternalLink.show()
+					%ExternalLink.set_meta('url', metadata.event.help_page_path)
+				%Icon.texture = metadata.event._get_icon()
+			'Subsystem':
+				%GeneralInfo.text = "Subsystems hold more complex functionality. They mostly manage communication between events and dialogic nodes. Often they provide handy methods that can be accessed by the user like this: Dialogic.Subsystem.a_method()."
+				%Icon.texture = get_theme_icon("Callable", "EditorIcons")
+			'Effect':
+				%GeneralInfo.text = "Text effects can be used in text events. They will be executed once reached and can take a single argument."
+				%Icon.texture = get_theme_icon("RichTextEffect", "EditorIcons")
+			'Modifier':
+				%GeneralInfo.text = "Modifiers can modify text from text events before it is shown."
+				%Icon.texture = get_theme_icon("RichTextEffect", "EditorIcons")
+			'Style':
+				%GeneralInfo.text = "Style presets can be activated and modified in the Styles editor. They provide the design of the dialog interface in your game."
+				%Icon.texture = get_theme_icon("PopupMenu", "EditorIcons")
+			'Editor':
+				%GeneralInfo.text = "Editors provide a user interface for editing dialogic data."
+				%Icon.texture = get_theme_icon("ConfirmationDialog", "EditorIcons")
+			'Settings':
+				%GeneralInfo.text = "Settings pages provide settings that are usually used by subsystems, events and dialogic nodes."
+				%Icon.texture = get_theme_icon("PluginScript", "EditorIcons")
+			
+			'_':
+				%GeneralInfo.text = ""
+				%Icon.texture = null
+
+
+func _on_external_link_pressed():
+	if %ExternalLink.has_meta('url'):
+		OS.shell_open(%ExternalLink.get_meta('url'))
+
+
+################################################################################
+##						EVENT DEFAULT SETTINGS
+################################################################################
+func load_event_settings(event:DialogicEvent) -> void:
+	for child in %EventDefaults.get_children():
+		child.queue_free()
+	
+	var event_default_overrides :Dictionary = ProjectSettings.get_setting('dialogic/editor/event_default_overrides', {})
+	
+	var params := event.get_shortcode_parameters()
+	for prop in params:
+		# Label
+		var label := Label.new()
+		label.text = prop.capitalize()
+		%EventDefaults.add_child(label)
+		
+		# Editing field
+		var editor_node :Node = null
+		var current_value :Variant = params[prop].default
+		if event_default_overrides.get(event.event_name, {}).has(params[prop].property):
+			current_value = event_default_overrides.get(event.event_name, {}).get(params[prop].property)
+		match typeof(event.get(params[prop].property)):
+			TYPE_STRING:
+				editor_node = LineEdit.new()
+				editor_node.custom_minimum_size.x = 150
+				editor_node.text = str(current_value)
+				editor_node.text_submitted.connect(_on_event_default_string_submitted.bind(params[prop].property))
+			TYPE_INT, TYPE_FLOAT:
+				if params[prop].has('suggestions'):
+					editor_node = OptionButton.new()
+					for i in params[prop].suggestions.call():
+						editor_node.add_item(i, int(params[prop].suggestions.call()[i].value))
+					editor_node.select(int(current_value))
+				else:
+					editor_node = SpinBox.new()
+					
+					editor_node.allow_greater = true
+					editor_node.allow_lesser = true
+					if typeof(event.get(params[prop].property)) == TYPE_INT:
+						editor_node.step = 1
+					else:
+						editor_node.step = 0.001
+				
+					editor_node.value = float(current_value)
+			TYPE_VECTOR2:
+				editor_node = load("res://addons/dialogic/Editor/Events/Fields/Vector2.tscn").instantiate()
+				editor_node.set_value(current_value)
+			TYPE_BOOL:
+				editor_node = CheckBox.new()
+				editor_node.button_pressed = bool(current_value)
+			TYPE_ARRAY:
+				editor_node = load("res://addons/dialogic/Editor/Events/Fields/Array.tscn").instantiate()
+				editor_node.set_value(current_value)
+		
+		%EventDefaults.add_child(editor_node)
+
+
+func set_event_default_override(prop:String, value:Variant) -> void:
+	var event_default_overrides :Dictionary = ProjectSettings.get_setting('dialogic/editor/event_default_overrides', {})
+	var event = %Tree.get_selected().get_metadata(0).event
+	
+	if not event_default_overrides.has(event.event_name):
+		event_default_overrides[event.event_name] = {}
+	
+	event_default_overrides[event.event_name][prop] = value
+	
+	ProjectSettings.set_setting('dialogic/editor/event_default_overrides', event_default_overrides)
+
+
+func _on_event_default_string_submitted(text:String, prop:String) -> void:
+	set_event_default_override(prop, text)
+

--- a/addons/dialogic/Editor/Settings/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/settings_modules.gd
@@ -19,12 +19,13 @@ func _ready() -> void:
 	%GeneralInfo.add_theme_color_override("font_color", get_theme_color("accent_color", "Editor"))
 	%GeneralInfo.add_theme_font_override("font", get_theme_font("doc_italic", "EditorFonts"))
 	
-	$Settings/EventDefaultsPanel.add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
+	$Scroll/Settings/EventDefaultsPanel.add_theme_stylebox_override('panel', get_theme_stylebox("Background", "EditorStyles"))
 	
 	%ExternalLink.icon = get_theme_icon("Help", "EditorIcons")
 
 
 func refresh() -> void:
+	$Scroll/Settings/EventDefaultsPanel.hide()
 	load_modules_tree()
 
 
@@ -184,7 +185,7 @@ func _on_tree_item_selected() -> void:
 	
 	if metadata is Dictionary:
 		%Title.text = selected_item.get_text(0)
-		$Settings/EventDefaultsPanel.hide()
+		$Scroll/Settings/EventDefaultsPanel.hide()
 		%Icon.texture = null
 		%ExternalLink.hide()
 		match metadata.type:
@@ -193,7 +194,7 @@ func _on_tree_item_selected() -> void:
 				
 				load_event_settings(metadata.event)
 				if %EventDefaults.get_child_count():
-					$Settings/EventDefaultsPanel.show()
+					$Scroll/Settings/EventDefaultsPanel.show()
 				
 				if metadata.event.help_page_path:
 					%ExternalLink.show()

--- a/addons/dialogic/Editor/Settings/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/settings_modules.tscn
@@ -136,48 +136,54 @@ size_flags_vertical = 3
 allow_reselect = true
 hide_root = true
 
-[node name="Settings" type="VBoxContainer" parent="."]
+[node name="Scroll" type="ScrollContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
+horizontal_scroll_mode = 0
 
-[node name="HBox" type="HBoxContainer" parent="Settings"]
+[node name="Settings" type="VBoxContainer" parent="Scroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="HBox" type="HBoxContainer" parent="Scroll/Settings"]
 layout_mode = 2
 
-[node name="Icon" type="TextureRect" parent="Settings/HBox"]
+[node name="Icon" type="TextureRect" parent="Scroll/Settings/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
 expand_mode = 3
 
-[node name="Title" type="Label" parent="Settings/HBox"]
+[node name="Title" type="Label" parent="Scroll/Settings/HBox"]
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
 
-[node name="ExternalLink" type="Button" parent="Settings/HBox"]
+[node name="ExternalLink" type="Button" parent="Scroll/Settings/HBox"]
 unique_name_in_owner = true
 visible = false
 layout_mode = 2
 icon = SubResource("ImageTexture_vaa32")
 flat = true
 
-[node name="EventDefaultsPanel" type="PanelContainer" parent="Settings"]
+[node name="EventDefaultsPanel" type="PanelContainer" parent="Scroll/Settings"]
 visible = false
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_tga5r")
 
-[node name="VBox" type="VBoxContainer" parent="Settings/EventDefaultsPanel"]
+[node name="VBox" type="VBoxContainer" parent="Scroll/Settings/EventDefaultsPanel"]
 layout_mode = 2
 
-[node name="Title" type="Label" parent="Settings/EventDefaultsPanel/VBox"]
+[node name="Title" type="Label" parent="Scroll/Settings/EventDefaultsPanel/VBox"]
 layout_mode = 2
 text = "Edit event defaults:"
 
-[node name="EventDefaults" type="GridContainer" parent="Settings/EventDefaultsPanel/VBox"]
+[node name="EventDefaults" type="GridContainer" parent="Scroll/Settings/EventDefaultsPanel/VBox"]
 unique_name_in_owner = true
 layout_mode = 2
 columns = 2
 
-[node name="GeneralInfo" type="Label" parent="Settings"]
+[node name="GeneralInfo" type="Label" parent="Scroll/Settings"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/font_color = Color(0, 0, 0, 1)
@@ -194,4 +200,4 @@ autowrap_mode = 3
 [connection signal="toggled" from="Overview/ScrollContainer/HBox/Collapse" to="." method="_on_collapse_toggled"]
 [connection signal="button_clicked" from="Overview/Tree" to="." method="_on_tree_button_clicked"]
 [connection signal="item_selected" from="Overview/Tree" to="." method="_on_tree_item_selected"]
-[connection signal="pressed" from="Settings/HBox/ExternalLink" to="." method="_on_external_link_pressed"]
+[connection signal="pressed" from="Scroll/Settings/HBox/ExternalLink" to="." method="_on_external_link_pressed"]

--- a/addons/dialogic/Editor/Settings/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/settings_modules.tscn
@@ -1,0 +1,201 @@
+[gd_scene load_steps=5 format=3 uid="uid://o7ljiritpgap"]
+
+[ext_resource type="Script" path="res://addons/dialogic/Editor/Settings/settings_modules.gd" id="1_l2hk0"]
+
+[sub_resource type="Image" id="Image_cwq51"]
+data = {
+"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 131, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 128, 128, 4, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 93, 93, 55, 255, 97, 97, 58, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 98, 98, 47, 255, 97, 97, 42, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 94, 94, 46, 255, 93, 93, 236, 255, 93, 93, 233, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 93, 93, 252, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"format": "RGBA8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id="ImageTexture_vaa32"]
+image = SubResource("Image_cwq51")
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tga5r"]
+content_margin_left = 4.0
+content_margin_top = 4.0
+content_margin_right = 4.0
+content_margin_bottom = 4.0
+bg_color = Color(1, 0.365, 0.365, 1)
+draw_center = false
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+corner_detail = 1
+
+[node name="ModuleManagement" type="HSplitContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_l2hk0")
+
+[node name="Overview" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="ScrollContainer" type="ScrollContainer" parent="Overview"]
+layout_mode = 2
+size_flags_horizontal = 3
+follow_focus = true
+horizontal_scroll_mode = 3
+vertical_scroll_mode = 0
+
+[node name="HBox" type="HBoxContainer" parent="Overview/ScrollContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 8
+alignment = 2
+
+[node name="Filter_Events" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Events"
+toggle_mode = true
+button_pressed = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Filter_Subsystems" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Subsystems"
+toggle_mode = true
+button_pressed = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Filter_EffectsAndModifiers" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Text Effects and Modifiers"
+toggle_mode = true
+button_pressed = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Filter_Styles" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Preset Style Scenes"
+toggle_mode = true
+button_pressed = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Filter_Settings" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Settings Pages"
+toggle_mode = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Filter_Editors" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Include Editors"
+toggle_mode = true
+text = "0"
+flat = true
+icon_alignment = 2
+
+[node name="Search" type="LineEdit" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(100, 0)
+layout_mode = 2
+placeholder_text = "Search"
+clear_button_enabled = true
+
+[node name="Refresh" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Refresh"
+
+[node name="Collapse" type="Button" parent="Overview/ScrollContainer/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Collapse All"
+toggle_mode = true
+
+[node name="Tree" type="Tree" parent="Overview"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_vertical = 3
+allow_reselect = true
+hide_root = true
+
+[node name="Settings" type="VBoxContainer" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="HBox" type="HBoxContainer" parent="Settings"]
+layout_mode = 2
+
+[node name="Icon" type="TextureRect" parent="Settings/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+expand_mode = 3
+
+[node name="Title" type="Label" parent="Settings/HBox"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="ExternalLink" type="Button" parent="Settings/HBox"]
+unique_name_in_owner = true
+visible = false
+layout_mode = 2
+icon = SubResource("ImageTexture_vaa32")
+flat = true
+
+[node name="EventDefaultsPanel" type="PanelContainer" parent="Settings"]
+visible = false
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_tga5r")
+
+[node name="VBox" type="VBoxContainer" parent="Settings/EventDefaultsPanel"]
+layout_mode = 2
+
+[node name="Title" type="Label" parent="Settings/EventDefaultsPanel/VBox"]
+layout_mode = 2
+text = "Edit event defaults:"
+
+[node name="EventDefaults" type="GridContainer" parent="Settings/EventDefaultsPanel/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+columns = 2
+
+[node name="Control" type="Control" parent="Settings"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="GeneralInfo" type="Label" parent="Settings"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+autowrap_mode = 3
+
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Events" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Subsystems" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_EffectsAndModifiers" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Styles" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Settings" to="." method="filters_updated"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Filter_Editors" to="." method="filters_updated"]
+[connection signal="text_changed" from="Overview/ScrollContainer/HBox/Search" to="." method="_on_search_text_changed"]
+[connection signal="pressed" from="Overview/ScrollContainer/HBox/Refresh" to="." method="_on_refresh_pressed"]
+[connection signal="toggled" from="Overview/ScrollContainer/HBox/Collapse" to="." method="_on_collapse_toggled"]
+[connection signal="button_clicked" from="Overview/Tree" to="." method="_on_tree_button_clicked"]
+[connection signal="item_selected" from="Overview/Tree" to="." method="_on_tree_item_selected"]
+[connection signal="pressed" from="Settings/HBox/ExternalLink" to="." method="_on_external_link_pressed"]

--- a/addons/dialogic/Editor/Settings/settings_modules.tscn
+++ b/addons/dialogic/Editor/Settings/settings_modules.tscn
@@ -177,10 +177,6 @@ unique_name_in_owner = true
 layout_mode = 2
 columns = 2
 
-[node name="Control" type="Control" parent="Settings"]
-layout_mode = 2
-size_flags_vertical = 3
-
 [node name="GeneralInfo" type="Label" parent="Settings"]
 unique_name_in_owner = true
 layout_mode = 2

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -665,13 +665,15 @@ func _add_event_button_pressed(event_resource:DialogicEvent):
 		at_index = %Timeline.get_child_count()
 	
 	var remove_event_index := 1
+	var resource := event_resource.duplicate()
+	resource._load_custom_defaults()
 	
 	TimelineUndoRedo.create_action("[D] Add "+event_resource.event_name+" event.")
 	if event_resource.can_contain_events:
-		TimelineUndoRedo.add_do_method(add_event_with_end_branch.bind(event_resource.duplicate(), at_index, true, true))
+		TimelineUndoRedo.add_do_method(add_event_with_end_branch.bind(resource, at_index, true, true))
 		TimelineUndoRedo.add_undo_method(remove_events_at_index.bind(at_index, 2))
 	else:
-		TimelineUndoRedo.add_do_method(add_event_node.bind(event_resource.duplicate(), at_index, true, true))
+		TimelineUndoRedo.add_do_method(add_event_node.bind(resource, at_index, true, true))
 		TimelineUndoRedo.add_undo_method(remove_events_at_index.bind(at_index, 1))
 	TimelineUndoRedo.commit_action()
 	

--- a/addons/dialogic/Events/Audio/event_music.gd
+++ b/addons/dialogic/Events/Audio/event_music.gd
@@ -74,9 +74,9 @@ func build_event_editor():
 			'placeholder' 	: "No music", 
 			'editor_icon' 	: ["AudioStreamPlayer", "EditorIcons"]})
 	add_body_edit('fade_length', ValueType.Float, 'Fade Time:')
-	add_body_edit('volume', ValueType.Decibel, 'volume:', '', {}, '!file_path.is_empty()')
-	add_body_edit('audio_bus', ValueType.SinglelineText, 'audio_bus:', '', {}, '!file_path.is_empty()')
-	add_body_edit('loop', ValueType.Bool, 'loop:', '', {}, '!file_path.is_empty()')
+	add_body_edit('volume', ValueType.Decibel, 'Volume:', '', {}, '!file_path.is_empty()')
+	add_body_edit('audio_bus', ValueType.SinglelineText, 'Audio Bus:', '', {}, '!file_path.is_empty()')
+	add_body_edit('loop', ValueType.Bool, 'Loop:', '', {}, '!file_path.is_empty()')
 
 
 func get_bus_suggestions() -> Dictionary:

--- a/addons/dialogic/Events/Audio/event_sound.gd
+++ b/addons/dialogic/Events/Audio/event_sound.gd
@@ -71,8 +71,8 @@ func build_event_editor():
 			{'file_filter' 	: '*.mp3, *.ogg, *.wav', 
 			'placeholder' 	: "Select file", 
 			'editor_icon' 	: ["AudioStreamPlayer", "EditorIcons"]})
-	add_body_edit('volume', ValueType.Decibel, 'volume:', '', {}, '!file_path.is_empty()')
-	add_body_edit('audio_bus', ValueType.SinglelineText, 'audio_bus:', '', {}, '!file_path.is_empty()')
+	add_body_edit('volume', ValueType.Decibel, 'Volume:', '', {}, '!file_path.is_empty()')
+	add_body_edit('audio_bus', ValueType.SinglelineText, 'Audio Bus:', '', {}, '!file_path.is_empty()')
 
 func get_bus_suggestions() -> Dictionary:
 	var bus_name_list := {}

--- a/addons/dialogic/Events/Text/event_text.gd
+++ b/addons/dialogic/Events/Text/event_text.gd
@@ -29,7 +29,7 @@ var _character_from_directory: String:
 			if _character_directory[item]['resource'] == character:
 				return item
 				break
-		return ""
+		return _character_from_directory
 	set(value): 
 		_character_from_directory = value
 		if value in _character_directory.keys():
@@ -141,40 +141,48 @@ func from_text(string:String) -> void:
 		_character_directory = Dialogic.character_directory
 	else:
 		_character_directory = self.get_meta("editor_character_directory")
+	
+	# load default character
+	if !_character_from_directory.is_empty() and _character_directory != null and _character_directory.size() > 0:
+		if _character_from_directory in _character_directory.keys():
+			character = _character_directory[_character_from_directory]['resource']
+	
 	var reg := RegEx.new()
 	
 	# Reference regex without Godot escapes: ((")?(?<name>(?(2)[^"\n]*|[^(: \n]*))(?(2)"|)(\W*\((?<portrait>.*)\))?\s*(?<!\\):)?(?<text>(.|\n)*)
-	reg.compile("((\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?\\s*(?<!\\\\):)?(?<text>(.|\\n)*)")
+	reg.compile("((\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*(?<portrait>\\(.*\\)))?\\s*(?<!\\\\):)?(?<text>(.|\\n)*)")
 	var result := reg.search(string)
 	if result and !result.get_string('name').is_empty():
 		var name := result.get_string('name').strip_edges()
-		
-		if _character_directory != null:
-			if _character_directory.size() > 0:
-				character = null
-				if _character_directory.has(name):
-					character = _character_directory[name]['resource']
-				else:
-					name = name.replace('"', "")
-					# First do a full search to see if more of the path is there then necessary:
-					for character in _character_directory:
-						if name in _character_directory[character]['full_path']:
-							character = _character_directory[character]['resource']
-							break								
-					
-					# If it doesn't exist,  at runtime we'll consider it a guest and create a temporary character
-					if character == null:
-						if Engine.is_editor_hint() == false:
-							character = DialogicCharacter.new()
-							character.display_name = name
-							var entry: Dictionary = {}
-							entry['resource'] = character
-							entry['full_path'] = "runtime://" + name
-							_character_directory[name] = entry
-							
+		if name == '_':
+			character = null
+		elif _character_directory != null and _character_directory.size() > 0:
+			character = null
+			if _character_directory.has(name):
+				character = _character_directory[name]['resource']
+			else:
+				name = name.replace('"', "")
+				# First do a full search to see if more of the path is there then necessary:
+				for character in _character_directory:
+					if name in _character_directory[character]['full_path']:
+						character = _character_directory[character]['resource']
+						break								
+				
+				# If it doesn't exist,  at runtime we'll consider it a guest and create a temporary character
+				if character == null:
+					if Engine.is_editor_hint() == false:
+						character = DialogicCharacter.new()
+						character.display_name = name
+						var entry: Dictionary = {}
+						entry['resource'] = character
+						entry['full_path'] = "runtime://" + name
+						_character_directory[name] = entry
+
 		if !result.get_string('portrait').is_empty():
-			portrait = result.get_string('portrait').strip_edges()
-	
+			portrait = result.get_string('portrait').strip_edges().trim_prefix('(').trim_suffix(')')
+			if portrait.is_empty():
+				portrait = character.default_portrait
+		
 	if result:
 		text = result.get_string('text').replace("\\\n", "\n").replace('\\:', ':').strip_edges()
 
@@ -186,6 +194,15 @@ func is_valid_event(string:String) -> bool:
 func is_string_full_event(string:String) -> bool:
 	return !string.ends_with('\\')
 
+
+# this is only here to provide a list of default values
+# this way the module manager can add custom default overrides to this event.
+func get_shortcode_parameters() -> Dictionary:
+	return {
+		#param_name 	: property_info
+		"character"		: {"property": "_character_from_directory", "default": ""},
+		"portrait"		: {"property": "portrait", 					"default": ""},
+	}
 
 ################################################################################
 ## 						TRANSLATIONS

--- a/addons/dialogic/Events/Text/event_text.gd
+++ b/addons/dialogic/Events/Text/event_text.gd
@@ -166,7 +166,7 @@ func from_text(string:String) -> void:
 				for character in _character_directory:
 					if name in _character_directory[character]['full_path']:
 						character = _character_directory[character]['resource']
-						break								
+						break
 				
 				# If it doesn't exist,  at runtime we'll consider it a guest and create a temporary character
 				if character == null:
@@ -180,8 +180,6 @@ func from_text(string:String) -> void:
 
 		if !result.get_string('portrait').is_empty():
 			portrait = result.get_string('portrait').strip_edges().trim_prefix('(').trim_suffix(')')
-			if portrait.is_empty():
-				portrait = character.default_portrait
 		
 	if result:
 		text = result.get_string('text').replace("\\\n", "\n").replace('\\:', ':').strip_edges()

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -257,3 +257,13 @@ static func setup_script_property_edit_node(property_info: Dictionary, value:Var
 				input.text = value
 			input.text_submitted.connect(methods.get('string').bind(property_info['name']))
 	return input
+
+
+static func get_custom_event_defaults(event_name:String) -> Dictionary:
+	if Engine.is_editor_hint():
+		return ProjectSettings.get_setting('dialogic/editor/event_default_overrides', {}).get(event_name, {})
+	else:
+		if !Engine.get_main_loop().has_meta('dialogic_event_defaults'):
+			Engine.get_main_loop().set_meta('dialogic_event_defaults', ProjectSettings.get_setting('dialogic/editor/event_default_overrides', {}))
+		return Engine.get_main_loop().get_meta('dialogic_event_defaults').get(event_name, {})
+

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -222,13 +222,20 @@ func update_text_version() -> void:
 
 ## Used by timeline processor (DGH).
 func _load_from_string(string:String) -> void:
+	_load_custom_defaults()
 	if '#id:' in string and can_be_translated():
 		_translation_id = string.get_slice('#id:', 1).strip_edges()
 		from_text(string.get_slice('#id:', 0))
-		event_node_ready = true
 	else:
 		from_text(string)
-		event_node_ready = true
+	event_node_ready = true
+
+
+## Assigns the custom defaults
+func _load_custom_defaults():
+	for default_prop in DialogicUtil.get_custom_event_defaults(event_name):
+		if default_prop in self:
+			set(default_prop, DialogicUtil.get_custom_event_defaults(event_name)[default_prop])
 
 
 ## Used by the timeline processor (DGH).
@@ -258,8 +265,9 @@ func get_shortcode_parameters() -> Dictionary:
 func to_text() -> String:
 	var result_string : String = "["+self.get_shortcode()
 	var params : Dictionary = get_shortcode_parameters()
+	var custom_defaults :Dictionary = DialogicUtil.get_custom_event_defaults(event_name)
 	for parameter in params.keys():
-		if get(params[parameter]["property"]) != params[parameter]["default"]:
+		if get(params[parameter].property) != custom_defaults.get(params[parameter].property, params[parameter].default):
 			if typeof(get(params[parameter]["property"])) == TYPE_OBJECT:
 				result_string += " "+parameter+'="'+str(get(params[parameter]["property"]).resource_path)+'"'
 			elif typeof(get(params[parameter]["property"])) == TYPE_STRING:


### PR DESCRIPTION
There is a new settings tab that allows managing all the modules and extensions. It has a fully functional tree list of all the modules and their parts.

There is a editor for the event defaults. If changed these will be stored in a event default override dictionary. From there they are automatically set in each event before the actual event is loaded. Shortcode events also take these defaults into account for saving (won't add a value if it's the custom default).

I had to make sure these custom defaults are also applied to new events in the visual editor (as they are not acutally "loaded" there if new).

You can also specify default values for the text event (character and portrait settings). 

For this to be fully functional, I had to add some syntax flavors. 

With no default character and portrait set:
`This is some text` will be said by noone
`John: Some text` will be said by John with his default portrait

With a default character set:
`This is some text` will be said by the default character
`_: This is some text` will be said by noone

If a default portrait is set for the event, it will have a higher rank then the default portrait of the character. To revert to the latter, you can write:
`John(): Some text` which will be said with Johns default portrait even if a default portrait is set for the text event.

Similar things are true for the character event. Some parameters cannot be edited for this one, as they clash with the already existing animation settings in the portrait settings tab.

# Other
- fixed capitalization in Sound and Music event  