### PR TITLE
Stop First Event Skip

### DIFF
--- a/addons/dialogic/Events/Text/default_input_handler.gd
+++ b/addons/dialogic/Events/Text/default_input_handler.gd
@@ -10,13 +10,16 @@ func _input(event:InputEvent) -> void:
 	if Input.is_action_just_pressed(DialogicUtil.get_project_setting('dialogic/text/input_action', 'dialogic_default_action')):
 		if Dialogic.paused: return
 		
-		if Dialogic.current_state == Dialogic.states.IDLE and Dialogic.Text.can_manual_advance():
-			Dialogic.handle_next_event()
-			autoadvance_timer.stop()
-		
-		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT:
-			if Dialogic.Text.can_skip():
-				Dialogic.Text.skip_text_animation()
+		match Dialogic.current_state:
+			Dialogic.states.IDLE:
+				if Dialogic.Text.can_manual_advance():
+					Dialogic.handle_next_event()
+					autoadvance_timer.stop()
+			Dialogic.states.SHOWING_TEXT:
+				if Dialogic.Text.can_skip():
+					Dialogic.Text.skip_text_animation()
+			Dialogic.states.JUST_BY_ACTION:
+				Dialogic.current_state = Dialogic.states.SHOWING_TEXT
 
 
 ####################################################################################################

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -1,6 +1,8 @@
 extends Node
 
-enum states {IDLE, SHOWING_TEXT, ANIMATING, AWAITING_CHOICE, WAITING}
+enum states {IDLE, SHOWING_TEXT, ANIMATING, AWAITING_CHOICE, WAITING, JUST_BY_ACTION}
+
+const START_BY_ACTION_PRESSED = -2
 
 var current_timeline: Variant = null
 var current_timeline_events: Array = []
@@ -80,7 +82,9 @@ func start_timeline(timeline_resource:Variant, label_or_idx:Variant = "") -> voi
 			if has_subsystem('Jump'):
 				self.Jump.jump_to_label(label_or_idx)
 	elif typeof(label_or_idx) == TYPE_INT:
-		if label_or_idx >-1:
+		if label_or_idx == START_BY_ACTION_PRESSED:
+			current_state = states.JUST_BY_ACTION
+		if label_or_idx > -1:
 			current_event_idx = label_or_idx -1
 	
 	timeline_started.emit()
@@ -459,7 +463,7 @@ func process_timeline(timeline: DialogicTimeline) -> DialogicTimeline:
 ################################################################################
 ##						FOR END USER
 ################################################################################
-func start(timeline, single_instance = true) -> Node:
+func start(timeline, label_or_idx:Variant = "", single_instance = true) -> Node:
 	var scene :Node = null
 	if single_instance:
 		# if none exists, create a new one
@@ -478,7 +482,7 @@ func start(timeline, single_instance = true) -> Node:
 		else:
 			scene = get_tree().get_meta('dialogic_layout_node', null)
 			scene.show()
-	Dialogic.start_timeline(timeline)
+	Dialogic.start_timeline(timeline, label_or_idx)
 	return scene
 
 


### PR DESCRIPTION
When an action button is used to start a timeline, this PR will prevent the button press from skipping the first event by accident.