### PR TITLE
Addressing Issue #1552 remove auto-pauses

### DIFF
--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -88,7 +88,7 @@ func add_autopause_set(text:String, time:float) -> void:
 	%AutoPauseSets.add_child(hbox)
 	var remove_btn := Button.new()
 	remove_btn.icon = get_theme_icon('Remove', 'EditorIcons')
-	remove_btn.pressed.connect(_on_remove_autopauses_set.bind(hbox))
+	remove_btn.pressed.connect(_on_remove_autopauses_set_pressed.bind(hbox))
 	hbox.add_child(remove_btn)
 	var line_edit := LineEdit.new()
 	line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -102,5 +102,5 @@ func add_autopause_set(text:String, time:float) -> void:
 	hbox.add_child(spin_box)
 
 
-func _on_remove_autopauses_set(set: HBoxContainer):
+func _on_remove_autopauses_set_pressed(set: HBoxContainer):
 	set.queue_free()

--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -73,8 +73,8 @@ func save_autopauses() -> void:
 	var dictionary := {}
 	for i in %AutoPauseSets.get_children():
 		if i.get_index() != 0:
-			if i.get_child(0).text:
-				dictionary[i.get_child(0).text] = i.get_child(1).value
+			if i.get_child(1).text:
+				dictionary[i.get_child(1).text] = i.get_child(2).value
 	ProjectSettings.set_setting('dialogic/text/autopauses', dictionary)
 	ProjectSettings.save()
 
@@ -86,6 +86,10 @@ func _on_add_autopauses_set_pressed():
 func add_autopause_set(text:String, time:float) -> void:
 	var hbox := HBoxContainer.new()
 	%AutoPauseSets.add_child(hbox)
+	var remove_btn := Button.new()
+	remove_btn.icon = get_theme_icon('Remove', 'EditorIcons')
+	remove_btn.pressed.connect(_on_remove_autopauses_set.bind(hbox))
+	hbox.add_child(remove_btn)
 	var line_edit := LineEdit.new()
 	line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	line_edit.placeholder_text = 'e.g. "?!.,;:"'
@@ -97,3 +101,6 @@ func add_autopause_set(text:String, time:float) -> void:
 	spin_box.value = time
 	hbox.add_child(spin_box)
 
+
+func _on_remove_autopauses_set(set: HBoxContainer):
+	set.queue_free()

--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -73,8 +73,8 @@ func save_autopauses() -> void:
 	var dictionary := {}
 	for i in %AutoPauseSets.get_children():
 		if i.get_index() != 0:
-			if i.get_child(1).text:
-				dictionary[i.get_child(1).text] = i.get_child(2).value
+			if i.get_child(0).text:
+				dictionary[i.get_child(0).text] = i.get_child(1).value
 	ProjectSettings.set_setting('dialogic/text/autopauses', dictionary)
 	ProjectSettings.save()
 
@@ -86,10 +86,6 @@ func _on_add_autopauses_set_pressed():
 func add_autopause_set(text:String, time:float) -> void:
 	var hbox := HBoxContainer.new()
 	%AutoPauseSets.add_child(hbox)
-	var remove_btn := Button.new()
-	remove_btn.icon = get_theme_icon('Remove', 'EditorIcons')
-	remove_btn.pressed.connect(_on_remove_autopauses_set_pressed.bind(hbox))
-	hbox.add_child(remove_btn)
 	var line_edit := LineEdit.new()
 	line_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	line_edit.placeholder_text = 'e.g. "?!.,;:"'
@@ -100,6 +96,10 @@ func add_autopause_set(text:String, time:float) -> void:
 	spin_box.step = 0.01
 	spin_box.value = time
 	hbox.add_child(spin_box)
+	var remove_btn := Button.new()
+	remove_btn.icon = get_theme_icon('Remove', 'EditorIcons')
+	remove_btn.pressed.connect(_on_remove_autopauses_set_pressed.bind(hbox))
+	hbox.add_child(remove_btn)
 
 
 func _on_remove_autopauses_set_pressed(set: HBoxContainer):


### PR DESCRIPTION
Hey, this is my first PR so I'm a little bit lost, I hope everything it's okay, tell me if I need to change anything :)

I felt fairly confident I could help with this issue in particular. But as I was approaching it I thought it could've been done in different ways:

![image](https://github.com/coppolaemilio/dialogic/assets/133830154/fcac7a59-01b7-4100-907e-b1099ba948ca)

I went with the 'D' case, with the 'B' one being the second I like the most. I feel like if the remove button is to the right of the time input I would delete the auto-pause set trying to change the value with the arrows.

Also while addressing this I realized 2 things:

- When you add a lot of auto-pauses the UI breaks, I don't think anyone is gonna need that much but maybe is worth to know: 
![image](https://github.com/coppolaemilio/dialogic/assets/133830154/f00ad6e7-5b92-4a84-86c1-de038e4ade16)

- It only saves the auto-pauses when swapping the main tabs:
![image](https://github.com/coppolaemilio/dialogic/assets/133830154/239b2826-4f26-476c-a543-1d2d5ac975ce)

I'm not sure if that's already known but I wanted to say them in case they aren't