### PR TITLE
Add persistent settings and Settings subsystem/event

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -206,7 +206,7 @@ func build_event_editor() -> void:
 ##					STATE
 ####################################################################################################
 
-func clear_game_state():
+func clear_game_state(clear_flag:=Dialogic.ClearFlags.FullClear):
 	pass
 
 func load_game_state():

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -11,6 +11,7 @@ var character_event_regex := RegEx.new()
 var shortcode_regex := RegEx.new()
 var shortcode_param_regex := RegEx.new()
 var text_effects_regex := RegEx.new()
+var settings_event_regex := RegEx.new()
 
 ## Colors
 var normal_color : Color 
@@ -25,6 +26,7 @@ var variable_color : Color
 var string_color : Color
 
 var keyword_VAR_color : Color
+var keyword_SETTING_color : Color
 
 var character_event_color : Color
 var character_name_color : Color
@@ -55,7 +57,8 @@ func _init():
 		shortcode_value_color = editor_settings.get('text_editor/theme/highlighting/gdscript/node_reference_color')
 
 		keyword_VAR_color = editor_settings.get('text_editor/theme/highlighting/keyword_color')
-
+		keyword_SETTING_color = editor_settings.get('text_editor/theme/highlighting/member_variable_color')
+		
 		character_event_color = editor_settings.get('text_editor/theme/highlighting/symbol_color')
 		character_name_color = editor_settings.get('text_editor/theme/highlighting/executing_line_color')
 		character_portrait_color = character_name_color.lightened(0.6)
@@ -128,6 +131,14 @@ func _get_line_syntax_highlighting(line:int) -> Dictionary:
 		dict[str_line.find('VAR')+3] = {"color":normal_color}
 		dict = color_region(dict, string_color, str_line, '"', '"', str_line.find('VAR'))
 		dict = color_region(dict, variable_color, str_line, '{', '}', str_line.find('VAR'))
+		return dict
+	
+	if str_line.strip_edges().begins_with('Setting'):
+		dict[str_line.find('Setting')] = {"color":keyword_SETTING_color}
+		dict[str_line.find('Setting')+7] = {"color":normal_color}
+		dict = color_word(dict, keyword_SETTING_color, str_line, 'reset')
+		dict = color_region(dict, string_color, str_line, '"', '"')
+		dict = color_region(dict, variable_color, str_line, '{', '}')
 		return dict
 	
 	var result := text_event_regex.search(str_line)

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -3,7 +3,6 @@ class_name DialogicCharacterEvent
 extends DialogicEvent
 ## Event that allows to manipulate character portraits.
 
-enum PortraitModes {VisualNovel, RPG}
 enum ActionTypes {Join, Leave, Update}
 
 

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -9,6 +9,8 @@ signal character_moved(info:Dictionary)
 signal position_changed(info:Dictionary)
 
 
+enum PortraitModes {VisualNovel, RPG}
+
 ## The default portrait scene.
 var default_portrait_scene :PackedScene = load(get_script().resource_path.get_base_dir().path_join('default_portrait.tscn'))
 
@@ -360,7 +362,7 @@ func get_character_resource(character_name:String) -> DialogicCharacter:
 
 
 func update_rpg_portrait_mode(character:DialogicCharacter = null, portrait:String = "") -> void:
-	if ProjectSettings.get_setting('dialogic/portrait_mode', 0) == DialogicCharacterEvent.PortraitModes.RPG:
+	if ProjectSettings.get_setting('dialogic/portrait_mode', 0) == PortraitModes.RPG:
 		if !Dialogic.current_state_info.has('rpg_last_portrait'):
 			Dialogic.current_state_info['rpg_last_portraits'] = {}
 		

--- a/addons/dialogic/Modules/Settings/event_setting.gd
+++ b/addons/dialogic/Modules/Settings/event_setting.gd
@@ -1,0 +1,185 @@
+@tool
+class_name DialogicSettingEvent
+extends DialogicEvent
+
+## Event that allows changing a specific setting.
+
+
+### Settings
+
+enum Modes {Set, Reset, ResetAll}
+
+## The name of the setting to save to. 
+var name: String = ""
+var _value_type := 0
+var value: Variant = ""
+
+var mode := Modes.Set
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+func _execute() -> void:
+	if mode == Modes.Reset or mode == Modes.ResetAll:
+		if !name.is_empty() and mode != Modes.ResetAll:
+			dialogic.Settings.reset_setting(name)
+		else:
+			dialogic.Settings.reset_all()
+	else:
+		match _value_type:
+			0:
+				dialogic.Settings.set(name, value)
+			1:
+				dialogic.Settings.set(name, float(value))
+			2:
+				if dialogic.has_subsystem('VAR'):
+					dialogic.Settings.set(name, dialogic.VAR.get_variable('{'+value+'}'))
+			3:
+				if dialogic.has_subsystem('VAR'):
+					dialogic.Settings.set(name, dialogic.VAR.get_variable(value))
+	finish()
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+func _init() -> void:
+	event_name = "Setting"
+	set_default_color('Color6')
+	event_category = "Helpers"
+	event_sorting_index = 2
+
+
+func _get_icon() -> Resource:
+	return load(self.get_script().get_path().get_base_dir().path_join('icon.svg'))
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+
+func to_text() -> String:
+	var string := "Setting "
+	if mode == Modes.Reset:
+		string += "reset "
+	
+	if !name.is_empty() and mode != Modes.ResetAll:
+		string += '"' + name + '"'
+	
+	if mode == Modes.Set:
+		string += " = "
+		value = str(value)
+		match _value_type:
+			0: # String
+				string += '"'+value.replace('"', '\\"')+'"'
+			1,3: # Float or Expression
+				string += str(value)
+			2: # Variable
+				string += '{'+value+'}'
+	
+	return string
+
+
+func from_text(string:String) -> void:
+	var reg := RegEx.new()
+	reg.compile('Setting (?<reset>reset)? *("(?<name>[^=+\\-*\\/]*)")?( *= *(?<value>.*))?')
+	var result := reg.search(string)
+	if !result:
+		return
+	
+	if result.get_string('reset'):
+		mode = Modes.Reset
+	
+	name = result.get_string('name').strip_edges()
+	
+	if name.is_empty() and mode == Modes.Reset:
+		mode = Modes.ResetAll
+	
+	if result.get_string('value'):
+		value = result.get_string('value').strip_edges()
+		if value.begins_with('"') and value.ends_with('"') and value.count('"')-value.count('\\"') == 2:
+			value = result.get_string('value').strip_edges().replace('"', '')
+			_value_type = 0
+		elif value.begins_with('{') and value.ends_with('}') and value.count('{') == 1:
+			value = result.get_string('value').strip_edges().trim_suffix('}').trim_prefix('{')
+			_value_type = 2
+		else:
+			value = result.get_string('value').strip_edges()
+			if value.is_valid_float():
+				_value_type = 1
+			else:
+				_value_type = 3
+
+
+func is_valid_event(string:String) -> bool:
+	return string.begins_with('Setting')
+
+
+################################################################################
+## 						EDITOR REPRESENTATION
+################################################################################
+
+func build_event_editor():
+	add_header_edit('mode', ValueType.FixedOptionSelector, '', '', {
+		'selector_options': [{
+				'label': 'Set',
+				'value': Modes.Set,
+				'icon': load("res://addons/dialogic/Editor/Images/Dropdown/default.svg")
+			},{
+				'label': 'Reset',
+				'value': Modes.Reset,
+				'icon': load("res://addons/dialogic/Editor/Images/Dropdown/update.svg")
+			},{
+				'label': 'Reset All',
+				'value': Modes.ResetAll,
+				'icon': load("res://addons/dialogic/Editor/Images/Dropdown/update.svg")
+			},
+			]})
+	
+	add_header_edit('name', ValueType.ComplexPicker, '', '', {'placeholder':'Type setting', 'suggestions_func':get_settings_suggestions}, 'mode != 2')
+	add_header_edit('_value_type', ValueType.FixedOptionSelector, 'to', '', {
+		'selector_options': [
+			{
+				'label': 'String',
+				'icon': ["String", "EditorIcons"],
+				'value': 0
+			},{
+				'label': 'Number',
+				'icon': ["float", "EditorIcons"],
+				'value': 1
+			},{
+				'label': 'Variable',
+				'icon': ["ClassList", "EditorIcons"],
+				'value': 2
+			},{
+				'label': 'Expression',
+				'icon': ["Variant", "EditorIcons"],
+				'value': 3
+			}],
+		'symbol_only':true}, 
+		'!name.is_empty() and mode == 0')
+	add_header_edit('value', ValueType.SinglelineText, '', '', {}, '!name.is_empty() and (_value_type == 0 or _value_type == 3) and mode == 0')
+	add_header_edit('value', ValueType.Float, '', '', {}, '!name.is_empty()  and _value_type == 1 and mode == 0')
+	add_header_edit('value', ValueType.ComplexPicker, '', '', 
+			{'suggestions_func' : get_value_suggestions, 'placeholder':'Select Variable'}, 
+			'!name.is_empty() and _value_type == 2 and mode == 0')
+
+
+func get_settings_suggestions(filter:String) -> Dictionary:
+	var suggestions := {filter:{'value':filter, 'editor_icon':["GDScriptInternal", "EditorIcons"]}}
+	
+	for prop in ProjectSettings.get_property_list():
+		if prop.name.begins_with('dialogic/settings/'):
+			suggestions[prop.name.trim_prefix('dialogic/settings/')] = {'value':prop.name.trim_prefix('dialogic/settings/'), 'editor_icon':["GDScript", "EditorIcons"]}
+	return suggestions
+
+
+func get_value_suggestions(filter:String) -> Dictionary:
+	var suggestions := {}
+	
+	var vars: Dictionary = ProjectSettings.get_setting('dialogic/variables', {})
+	for var_path in DialogicUtil.list_variables(vars):
+		suggestions[var_path] = {'value':var_path, 'editor_icon':["ClassList", "EditorIcons"]}
+	return suggestions

--- a/addons/dialogic/Modules/Settings/icon.svg
+++ b/addons/dialogic/Modules/Settings/icon.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 40V44C18 44.5523 18.4477 45 19 45H45C45.5523 45 46 44.5523 46 44V40" stroke="white" stroke-width="5"/>
+<path d="M32.5212 36L32.5212 19M32.5212 36L28 32.4211M32.5212 36L37 32.4211" stroke="white" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/addons/dialogic/Modules/Settings/icon.svg.import
+++ b/addons/dialogic/Modules/Settings/icon.svg.import
@@ -1,0 +1,40 @@
+[remap]
+
+importer="texture"
+type="CompressedTexture2D"
+uid="uid://bpl3chvmbnfhm"
+path="res://.godot/imported/icon.svg-d4407cb145fa5c1d965de3d2bd63ce5f.ctex"
+metadata={
+"editor_dark_theme": true,
+"editor_scale": 1.0,
+"has_editor_variant": true,
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/dialogic/Modules/Settings/icon.svg"
+dest_files=["res://.godot/imported/icon.svg-d4407cb145fa5c1d965de3d2bd63ce5f.ctex"]
+
+[params]
+
+compress/mode=0
+compress/high_quality=false
+compress/lossy_quality=0.7
+compress/hdr_compression=1
+compress/normal_map=0
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
+svg/scale=1.0
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true

--- a/addons/dialogic/Modules/Settings/index.gd
+++ b/addons/dialogic/Modules/Settings/index.gd
@@ -1,0 +1,10 @@
+@tool
+extends DialogicIndexer
+
+
+func _get_events() -> Array:
+	return [this_folder.path_join('event_setting.gd')]
+
+
+func _get_subsystems() -> Array:
+	return [{'name':'Settings', 'script':this_folder.path_join('subsystem_settings.gd')}]

--- a/addons/dialogic/Modules/Settings/subsystem_settings.gd
+++ b/addons/dialogic/Modules/Settings/subsystem_settings.gd
@@ -1,0 +1,63 @@
+extends DialogicSubsystem
+
+## Subsystem that allows setting and getting settings that are automatically saved slot independent.
+## All settings that are stored in the project settings dialogic/settings section are supported.
+## For example the text_speed setting is stored there. 
+## Thus it can be acessed like this:
+##    Dialogic.Settings.text_speed = 0.05
+## Settings stored there can also be changed with the Settings event.
+
+var settings := {}
+
+
+####################################################################################################
+##					MAIN METHODS
+####################################################################################################
+
+## Built-in, called by DialogicGameHandler.
+func clear_game_state(clear_flag:=Dialogic.ClearFlags.FullClear):
+	_reload_settings()
+
+
+func _reload_settings() -> void:
+	settings = {}
+	for prop in ProjectSettings.get_property_list():
+		if prop.name.begins_with('dialogic/settings'):
+			settings[prop.name.trim_prefix('dialogic/settings/')] = ProjectSettings.get_setting(prop.name)
+	
+	if dialogic.has_subsystem('Save'):
+		for i in settings:
+			settings[i] = dialogic.Save.get_global_info(i, settings[i])
+
+
+func _set(property:StringName, value:Variant) -> bool:
+	settings[property] = value
+	if dialogic.has_subsystem('Save'):
+		dialogic.Save.set_global_info(property, value)
+	return true
+
+
+func _get(property:StringName) -> Variant:
+	if property in settings:
+		return settings[property]
+	return null
+
+####################################################################################################
+##					HANDY METHODS
+####################################################################################################
+
+func get_setting(property:StringName, default:Variant) -> Variant:
+	return _get(property) if _get(property) != null else default
+
+
+func reset_all() -> void:
+	for setting in settings:
+		reset_setting(setting)
+
+
+func reset_setting(property:StringName) -> void:
+	if ProjectSettings.has_setting('dialogic/settings/'+property):
+		settings[property] = ProjectSettings.get_setting('dialogic/settings/'+property)
+	else:
+		settings.erase(property)
+

--- a/addons/dialogic/Modules/Text/character_settings/ui_mood_item.gd
+++ b/addons/dialogic/Modules/Text/character_settings/ui_mood_item.gd
@@ -74,7 +74,7 @@ func preview():
 	var preview_timer = Timer.new()
 	DialogicUtil.update_timer_process_callback(preview_timer)
 	add_child(preview_timer)
-	preview_timer.start(ProjectSettings.get_setting('text/speed', 0.01))
+	preview_timer.start(ProjectSettings.get_setting('dialogic/settings/text_speed', 0.01))
 	for i in range(20):
 		$Preview._on_continued_revealing_text("a")
 		await preview_timer.timeout

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -97,6 +97,7 @@ func _execute() -> void:
 	else:
 		dialogic.Text.show_next_indicators()
 		finish()
+	
 	if dialogic.has_subsystem('History'):
 		if character:
 			dialogic.History.store_simple_history_entry(final_text, event_name, {'character':character.display_name, 'character_color':character.color})

--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -25,7 +25,7 @@ func _ready() -> void:
 
 # this is called by the DialogicGameHandler to set text
 func reveal_text(_text:String) -> void:
-	speed = ProjectSettings.get_setting('dialogic/text/speed', 0.01)
+	speed = Dialogic.Settings.get_setting('text_speed', 0.01)
 	text = _text
 	if alignment == ALIGNMENT.CENTER:
 		text = '[center]'+text

--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -4,7 +4,7 @@ extends HBoxContainer
 func refresh():
 	%Info.add_theme_color_override('default_color', get_theme_color("accent_color", "Editor"))
 	
-	%DefaultSpeed.value = ProjectSettings.get_setting('dialogic/text/speed', 0.01)
+	%DefaultSpeed.value = ProjectSettings.get_setting('dialogic/settings/text_speed', 0.01)
 	%Skippable.button_pressed = ProjectSettings.get_setting('dialogic/text/skippable', true)
 	%Autoadvance.button_pressed = ProjectSettings.get_setting('dialogic/text/autoadvance', false)
 	%AutoadvanceDelay.value = ProjectSettings.get_setting('dialogic/text/autoadvance_delay', 1)
@@ -14,6 +14,7 @@ func refresh():
 	%InputAction.set_value(ProjectSettings.get_setting('dialogic/text/input_action', 'dialogic_default_action'))
 	%InputAction.get_suggestions_func = suggest_actions
 	load_autopauses(ProjectSettings.get_setting('dialogic/text/autopauses', {}))
+
 
 func _about_to_close():
 	save_autopauses()
@@ -34,7 +35,7 @@ func _on_Skippable_toggled(button_pressed):
 
 
 func _on_DefaultSpeed_value_changed(value):
-	ProjectSettings.set_setting('dialogic/text/speed', value)
+	ProjectSettings.set_setting('dialogic/settings/text_speed', value)
 	ProjectSettings.save()
 
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -367,7 +367,7 @@ func effect_speed(text_node:Control, skipped:bool, argument:String) -> void:
 	if argument:
 		text_node.speed = float(argument)
 	else:
-		text_node.speed = ProjectSettings.get_setting('dialogic/text/speed', 0.01)
+		text_node.speed = dialogic.Settings.get_setting('text_speed', 0.01)
 
 
 func effect_signal(text_node:Control, skipped:bool, argument:String) -> void:

--- a/addons/dialogic/Modules/Variable/event_variable.gd
+++ b/addons/dialogic/Modules/Variable/event_variable.gd
@@ -224,7 +224,7 @@ func build_event_editor():
 	add_header_edit('value', ValueType.SinglelineText, '', '', {}, '!name.is_empty() and (_value_type == 0 or _value_type == 3) ')
 	add_header_edit('value', ValueType.Float, '', '', {}, '!name.is_empty()  and _value_type == 1')
 	add_header_edit('value', ValueType.ComplexPicker, '', '', 
-			{'suggestions_func' : get_value_suggestions}, 
+			{'suggestions_func' : get_value_suggestions, 'placeholder':'Select Variable'}, 
 			'!name.is_empty() and _value_type == 2')
 	add_header_label('a number between', '_value_type == 4')
 	add_header_edit('random_min', ValueType.Integer, '', 'and', {}, '!name.is_empty() and  _value_type == 4')

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -266,7 +266,8 @@ func to_text() -> String:
 	var params : Dictionary = get_shortcode_parameters()
 	var custom_defaults :Dictionary = DialogicUtil.get_custom_event_defaults(event_name)
 	for parameter in params.keys():
-		if get(params[parameter].property) != custom_defaults.get(params[parameter].property, params[parameter].default):
+		if (typeof(get(params[parameter].property)) != typeof(custom_defaults.get(params[parameter].property, params[parameter].default))) or \
+		(get(params[parameter].property) != custom_defaults.get(params[parameter].property, params[parameter].default)):
 			if typeof(get(params[parameter]["property"])) == TYPE_OBJECT:
 				result_string += " "+parameter+'="'+str(get(params[parameter]["property"]).resource_path)+'"'
 			elif typeof(get(params[parameter]["property"])) == TYPE_STRING:

--- a/addons/dialogic/plugin.gd
+++ b/addons/dialogic/plugin.gd
@@ -105,6 +105,7 @@ func add_dialogic_default_action() -> void:
 		var input_left_click : InputEventMouseButton = InputEventMouseButton.new()
 		input_left_click.button_index = MOUSE_BUTTON_LEFT
 		input_left_click.pressed = true
+		input_left_click.device = -1
 		var input_space : InputEventKey = InputEventKey.new()
 		input_space.keycode = KEY_SPACE
 		var input_x : InputEventKey = InputEventKey.new()


### PR DESCRIPTION
Adds a new settings subsystem and event.
## Settings subsystem
The settings subsystem will manage any settings stored in ProjectSettings dialogic/settings category.
The pros:
- settings are persistent and global
- settings can be accessed from code easily
- settings can be accessed from settings event

## Settings  event
Can change or reset settings values. Has a custom syntax. Has syntax highlighting.

## Settings
The only setting to utilize this right now is the text_speed setting.

 #### Other
- add placeholder text to set variable variable picker
- moves PortraitMode enum from character event to character subsystem (where it is used)
- fixes generated event script from Module creation
- makes the default_input_event mouse action "All devices"