### PR TITLE
Multiple fixes (portraits, backgrounds, glossary)

### DIFF
--- a/addons/dialogic/Modules/Background/default_background.tscn
+++ b/addons/dialogic/Modules/Background/default_background.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://cl6g6ymkhjven"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Background/default_background.gd" id="1_nkdrp"]
 
 [node name="DefaultBackground" type="TextureRect"]
 offset_right = 40.0
 offset_bottom = 40.0
+mouse_filter = 0
 script = ExtResource("1_nkdrp")

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -265,8 +265,9 @@ func change_portrait_z_index(character:DialogicCharacter, z_index:int, update_zi
 
 func remove_portrait(character:DialogicCharacter) -> void:
 	if dialogic.current_state_info['portraits'].has(character.resource_path):
-		character_left.emit({'character':character})
-		dialogic.current_state_info['portraits'][character.resource_path].node.queue_free()
+		if dialogic.current_state_info['portraits'][character.resource_path].node is Node:
+			character_left.emit({'character':character})
+			dialogic.current_state_info['portraits'][character.resource_path].node.queue_free()
 		dialogic.current_state_info['portraits'].erase(character.resource_path)
 
 

--- a/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.tscn
+++ b/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.tscn
@@ -457,6 +457,7 @@ script = ExtResource("15_ptoy3")
 
 [node name="NameLabelHolder" type="Control" parent="DefaultStyle/DialogTextAnimationParent/DialogTextPanel"]
 layout_mode = 2
+mouse_filter = 2
 
 [node name="NameLabelPanel" type="PanelContainer" parent="DefaultStyle/DialogTextAnimationParent/DialogTextPanel/NameLabelHolder"]
 unique_name_in_owner = true
@@ -479,18 +480,6 @@ theme_override_colors/font_color = Color(1, 1, 1, 1)
 theme_override_font_sizes/font_size = 15
 text = "S"
 script = ExtResource("3")
-
-[node name="Something" type="Control" parent="DefaultStyle"]
-layout_mode = 1
-anchors_preset = 7
-anchor_left = 0.5
-anchor_top = 1.0
-anchor_right = 0.5
-anchor_bottom = 1.0
-offset_left = -2.0
-offset_right = 2.0
-grow_horizontal = 2
-grow_vertical = 0
 
 [node name="DialogicNode_TextInput" type="Control" parent="DefaultStyle"]
 layout_mode = 1


### PR DESCRIPTION
- Safety check in `remove_portrait()`. This makes sure dialogic doesn't try to remove outdated nodes based on "saved" references (which are NOT nodes anymore at that point)
- Make backgrounds click-blocking (clicking through backgrounds seemed very weird)
- Make sure glossary works (make input-blocking control node pass through)
