### PR TITLE
Improve start method

### DIFF
--- a/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.gd
+++ b/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.gd
@@ -26,10 +26,13 @@ enum Alignments {Left, Center, Right}
 @export var name_label_box_modulate : Color = box_modulate
 @export var name_label_alignment := Alignments.Left
 
-## FOR TESTING PURPOSES
+
 func _ready():
 	add_to_group('dialogic_main_node')
-	
+
+
+## Called by dialogic whenever export overrides might change
+func _apply_export_overrides():
 	## FONT SETTINGS
 	%DialogicNode_DialogText.alignment = text_alignment
 	

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -196,6 +196,8 @@ static func apply_scene_export_overrides(node:Node, export_overrides:Dictionary)
 	for i in export_overrides:
 		if i in node:
 			node.set(i, str_to_var(export_overrides[i]))
+	if node.has_method('_apply_export_overrides'):
+		node._apply_export_overrides()
 
 static func setup_script_property_edit_node(property_info: Dictionary, value:Variant, methods:Dictionary) -> Control:
 	var input :Control = null


### PR DESCRIPTION
The single-instance argument was removed as multiple instances have little to no use. 
Instead the ability to specify a custom scene and custom export overrides was added to the add_layout_node() method. This allows using different themes along with the .start() method (by calling add_layout_node() before).

Also added helpful comments