### PR TITLE
Multiple fixes (all over the place)

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_modules.gd
+++ b/addons/dialogic/Editor/Settings/settings_modules.gd
@@ -73,7 +73,7 @@ func _on_search_text_changed(new_text:String) -> void:
 		
 		for i in range(child.get_button_count(0)):
 			child.erase_button(0, child.get_button_count(0)-1)
-		var any_visible = false
+		var any_visible := false
 		var counter := 0
 		for sub_child in child.get_children():
 			if sub_child.visible:
@@ -87,7 +87,6 @@ func _on_search_text_changed(new_text:String) -> void:
 				counter += 1
 				any_visible = true
 		child.visible = any_visible
-#		child.collapsed = %Collapse.button_pressed
 
 
 
@@ -320,6 +319,7 @@ func load_event_settings(event:DialogicEvent) -> void:
 		var current_value :Variant = params[prop].default
 		if event_default_overrides.get(event.event_name, {}).has(params[prop].property):
 			current_value = event_default_overrides.get(event.event_name, {}).get(params[prop].property)
+		
 		match typeof(event.get(params[prop].property)):
 			TYPE_STRING:
 				editor_node = LineEdit.new()

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -274,8 +274,10 @@ func _request_code_completion(force):
 		if symbol == '[':
 			# suggest shortcodes if a shortcode event has just begun
 			for shortcode in completion_shortcodes.keys():
-				add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode, completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
-		
+				if completion_shortcodes[shortcode].get_shortcode_parameters().is_empty():
+					add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode, completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
+				else:
+					add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode+" ", completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
 		else:
 			# suggest either parameters or values
 			var current_shortcode := completion_shortcode_getter_regex.search(line)

--- a/addons/dialogic/Modules/Choice/settings_choices.gd
+++ b/addons/dialogic/Modules/Choice/settings_choices.gd
@@ -3,11 +3,22 @@ extends HBoxContainer
 
 func refresh() -> void:
 	%Autofocus.button_pressed = ProjectSettings.get_setting('dialogic/choices/autofocus_first', true)
-	var delay_value:float = ProjectSettings.get_setting('dialogic/choices/delay', 0.2)
-	%Delay.value = delay_value
+	%Delay.value = ProjectSettings.get_setting('dialogic/choices/delay', 0.2)
 	%FalseBehaviour.select(ProjectSettings.get_setting('dialogic/choices/def_false_behaviour', 0))
 	%HotkeyType.select(ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0))
-
+	
+	var reveal_delay := ProjectSettings.get_setting('dialogic/choices/reveal_delay', 0)
+	var reveal_by_input := ProjectSettings.get_setting('dialogic/choices/reveal_by_input', false)
+	if not reveal_by_input and reveal_delay == 0:
+		_on_appear_mode_item_selected(0)
+	if not reveal_by_input and reveal_delay != 0:
+		_on_appear_mode_item_selected(1)
+	if reveal_by_input and reveal_delay == 0:
+		_on_appear_mode_item_selected(2)
+	if reveal_by_input and reveal_delay != 0:
+		_on_appear_mode_item_selected(3)
+	
+	%RevealDelay.value = reveal_delay
 
 func _on_Autofocus_toggled(button_pressed: bool) -> void:
 	ProjectSettings.set_setting('dialogic/choices/autofocus_first', button_pressed)
@@ -26,4 +37,31 @@ func _on_HotkeyType_item_selected(index) -> void:
 
 func _on_Delay_value_changed(value) -> void:
 	ProjectSettings.set_setting('dialogic/choices/delay', value)
+	ProjectSettings.save()
+
+
+func _on_reveal_delay_value_changed(value) -> void:
+	ProjectSettings.set_setting('dialogic/choices/reveal_delay', value)
+	ProjectSettings.save()
+
+
+func _on_appear_mode_item_selected(index:int) -> void:
+	%AppearMode.selected = index
+	match index:
+		0:
+			ProjectSettings.set_setting('dialogic/choices/reveal_delay', 0)
+			ProjectSettings.set_setting('dialogic/choices/reveal_by_input', false)
+			%RevealDelayBox.hide()
+		1:
+			ProjectSettings.set_setting('dialogic/choices/reveal_delay', %RevealDelay.value)
+			ProjectSettings.set_setting('dialogic/choices/reveal_by_input', false)
+			%RevealDelayBox.show()
+		2:
+			ProjectSettings.set_setting('dialogic/choices/reveal_delay', 0)
+			ProjectSettings.set_setting('dialogic/choices/reveal_by_input', true)
+			%RevealDelayBox.hide()
+		3:
+			ProjectSettings.set_setting('dialogic/choices/reveal_delay', %RevealDelay.value)
+			ProjectSettings.set_setting('dialogic/choices/reveal_by_input', true)
+			%RevealDelayBox.show()
 	ProjectSettings.save()

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -38,8 +38,27 @@ func hide_all_choices() -> void:
 
 
 ## Lists all current choices and shows buttons.
-func show_current_choices() -> void:
+func show_current_choices(instant:=true) -> void:
 	hide_all_choices()
+	choice_blocker.stop()
+	
+	var reveal_delay := float(ProjectSettings.get_setting('dialogic/choices/reveal_delay', 0.0))
+	var reveal_by_input :bool = ProjectSettings.get_setting('dialogic/choices/reveal_by_input', false)
+	
+	if !instant and (reveal_delay != 0 or reveal_by_input):
+		if reveal_delay != 0:
+			choice_blocker.start(reveal_delay)
+			choice_blocker.timeout.connect(show_current_choices)
+		if reveal_by_input:
+			Dialogic.Text.input_handler.dialogic_action.connect(show_current_choices)
+		return
+	
+	if choice_blocker.timeout.is_connected(show_current_choices):
+		choice_blocker.timeout.disconnect(show_current_choices)
+	if Dialogic.Text.input_handler.dialogic_action.is_connected(show_current_choices):
+		Dialogic.Text.input_handler.dialogic_action.disconnect(show_current_choices)
+	
+	
 	var button_idx := 1
 	last_question_info = {'choices':[]}
 	for choice_index in get_current_choice_indexes():

--- a/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.gd
+++ b/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.gd
@@ -42,6 +42,9 @@ func _ready():
 
 ## Called by dialogic whenever export overrides might change
 func _apply_export_overrides():
+	if !is_inside_tree():
+		await ready
+	
 	## FONT SETTINGS
 	%DialogicNode_DialogText.alignment = text_alignment
 	
@@ -78,6 +81,7 @@ func _apply_export_overrides():
 	
 	%NameLabelPanel.self_modulate = name_label_box_modulate
 	
+	%NameLabelPanel.position.x = 0
 	%NameLabelPanel.anchor_left = name_label_alignment/2.0
 	%NameLabelPanel.anchor_right = name_label_alignment/2.0
 	%NameLabelPanel.grow_horizontal = [1, 2, 0][name_label_alignment]

--- a/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.tscn
+++ b/addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=31 format=3 uid="uid://uan2wdyuprb6"]
+[gd_scene load_steps=30 format=3 uid="uid://uan2wdyuprb6"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/DefaultStyles/Default/DialogicDefaultLayout.gd" id="1"]
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Text/node_dialog_text.gd" id="2"]
@@ -174,15 +174,15 @@ _data = {
 }
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q3vpc"]
+content_margin_left = 15.0
+content_margin_top = 15.0
+content_margin_right = 15.0
+content_margin_bottom = 15.0
 bg_color = Color(1, 1, 1, 1)
 corner_radius_top_left = 5
 corner_radius_top_right = 5
 corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
-expand_margin_left = 15.0
-expand_margin_top = 15.0
-expand_margin_right = 15.0
-expand_margin_bottom = 15.0
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wpkyg"]
 bg_color = Color(1, 1, 1, 1)
@@ -210,33 +210,9 @@ expand_margin_top = 5.0
 expand_margin_right = 5.0
 expand_margin_bottom = 5.0
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_nnmvp"]
-content_margin_left = 10.0
-content_margin_top = 10.0
-content_margin_right = 10.0
-content_margin_bottom = 10.0
-bg_color = Color(0.6, 0.576471, 0.54902, 0.956863)
-border_width_left = 10
-border_width_top = 10
-border_width_right = 10
-border_width_bottom = 10
-border_color = Color(0.733333, 0.670588, 0.627451, 1)
-border_blend = true
-corner_radius_top_left = 20
-corner_radius_top_right = 20
-corner_radius_bottom_right = 20
-corner_radius_bottom_left = 20
-shadow_color = Color(0.823529, 0.803922, 0.756863, 1)
-shadow_size = 5
-
 [node name="DefaultDialogNode" type="CanvasLayer"]
 script = ExtResource("1")
 name_label_box_modulate = Color(0.00784314, 0.00784314, 0.00784314, 0.843137)
-next_indicator_enabled = null
-next_indicator_animation = null
-next_indicator_texture = null
-next_indicator_show_on_questions = null
-next_indicator_show_on_autoadvance = null
 
 [node name="DialogicNode_BackgroundHolder" type="CanvasLayer" parent="."]
 layer = -1
@@ -406,24 +382,24 @@ grow_vertical = 0
 [node name="DialogTextPanel" type="PanelContainer" parent="DefaultStyle/DialogTextAnimationParent"]
 unique_name_in_owner = true
 self_modulate = Color(0.00784314, 0.00784314, 0.00784314, 0.843137)
-custom_minimum_size = Vector2(550, 110)
+custom_minimum_size = Vector2(500, 110)
 layout_mode = 1
 anchors_preset = -1
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = -275.0
-offset_top = -143.0
-offset_right = 275.0
-offset_bottom = -33.0
+offset_left = -294.0
+offset_top = -154.0
+offset_right = 294.0
+offset_bottom = -22.0
 grow_horizontal = 2
 grow_vertical = 0
 pivot_offset = Vector2(275, 60)
 theme_override_styles/panel = SubResource("StyleBoxFlat_q3vpc")
 metadata/_edit_layout_mode = 1
 
-[node name="DialogicNode_DialogText" type="RichTextLabel" parent="DefaultStyle/DialogTextAnimationParent/DialogTextPanel"]
+[node name="DialogicNode_DialogText" type="RichTextLabel" parent="DefaultStyle/DialogTextAnimationParent/DialogTextPanel" node_paths=PackedStringArray("textbox_root")]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_colors/default_color = Color(1, 1, 1, 1)
@@ -435,6 +411,7 @@ bbcode_enabled = true
 text = "Some default text"
 visible_characters_behavior = 1
 script = ExtResource("2")
+textbox_root = NodePath("..")
 
 [node name="DialogicNode_TypeSounds" type="AudioStreamPlayer" parent="DefaultStyle/DialogTextAnimationParent/DialogTextPanel/DialogicNode_DialogText"]
 script = ExtResource("10")
@@ -470,7 +447,7 @@ self_modulate = Color(0.00784314, 0.00784314, 0.00784314, 0.843137)
 layout_mode = 1
 offset_left = -10.0
 offset_top = -49.0
-offset_right = 1.0
+offset_right = -1.0
 offset_bottom = -24.0
 theme_override_styles/panel = SubResource("StyleBoxFlat_wpkyg")
 script = ExtResource("23")
@@ -595,103 +572,6 @@ rotation = 0.75799
 size_flags_horizontal = 4
 size_flags_vertical = 8
 theme_override_styles/panel = SubResource("StyleBoxFlat_a3cyk")
-
-[node name="SpecialStyle" type="Control" parent="."]
-visible = false
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-mouse_filter = 2
-script = ExtResource("12")
-style_name = "Special"
-
-[node name="Choices" type="VBoxContainer" parent="SpecialStyle"]
-layout_mode = 1
-anchors_preset = 3
-anchor_left = 1.0
-anchor_top = 1.0
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_left = -208.0
-offset_top = -276.0
-offset_right = -27.0
-offset_bottom = -30.0
-grow_horizontal = 0
-grow_vertical = 0
-alignment = 2
-metadata/_edit_layout_mode = 1
-
-[node name="DialogicNode_ChoiceButton1" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="DialogicNode_ChoiceButton2" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="DialogicNode_ChoiceButton3" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="DialogicNode_ChoiceButton4" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="DialogicNode_ChoiceButton5" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="DialogicNode_ChoiceButton6" type="Button" parent="SpecialStyle/Choices"]
-layout_mode = 2
-size_flags_horizontal = 8
-text = "Text"
-script = ExtResource("4")
-
-[node name="PanelContainer" type="PanelContainer" parent="SpecialStyle"]
-layout_mode = 1
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = -204.0
-offset_top = 26.0
-offset_right = 202.0
-offset_bottom = 95.0
-grow_horizontal = 2
-theme_override_styles/panel = SubResource("StyleBoxFlat_nnmvp")
-metadata/_edit_layout_mode = 1
-
-[node name="MarginContainer" type="MarginContainer" parent="SpecialStyle/PanelContainer"]
-layout_mode = 2
-
-[node name="VBoxContainer" type="VBoxContainer" parent="SpecialStyle/PanelContainer/MarginContainer"]
-layout_mode = 2
-theme_override_constants/separation = 0
-alignment = 1
-
-[node name="DialogicNode_NameLabel" type="Label" parent="SpecialStyle/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Name"
-horizontal_alignment = 1
-script = ExtResource("3")
-use_character_color = false
-
-[node name="DialogicNode_DialogText" type="RichTextLabel" parent="SpecialStyle/PanelContainer/MarginContainer/VBoxContainer"]
-layout_mode = 2
-text = "Some default text"
-script = ExtResource("2")
 
 [node name="ExampleHistoryScene" parent="." instance=ExtResource("22_854kg")]
 history_font_normal = ExtResource("23_gyqve")

--- a/addons/dialogic/Modules/Text/default_input_handler.gd
+++ b/addons/dialogic/Modules/Text/default_input_handler.gd
@@ -3,6 +3,8 @@ extends Node
 
 var autoadvance_timer := Timer.new()
 
+signal dialogic_action()
+
 ################################################################################
 ## 						INPUT
 ################################################################################
@@ -14,9 +16,10 @@ func _input(event:InputEvent) -> void:
 			Dialogic.handle_next_event()
 			autoadvance_timer.stop()
 		
-		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT:
-			if Dialogic.Text.can_skip():
-				Dialogic.Text.skip_text_animation()
+		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT and Dialogic.Text.can_skip():
+			Dialogic.Text.skip_text_animation()
+		
+		dialogic_action.emit()
 
 
 ####################################################################################################

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -94,7 +94,7 @@ func _execute() -> void:
 	#end of dialog
 	if dialogic.has_subsystem('Choices') and dialogic.Choices.is_question(dialogic.current_event_idx):
 		dialogic.Text.show_next_indicators(true)
-		dialogic.Choices.show_current_choices()
+		dialogic.Choices.show_current_choices(false)
 		dialogic.current_state = dialogic.states.AWAITING_CHOICE
 	elif Dialogic.Text.should_autoadvance():
 		dialogic.Text.show_next_indicators(false, true)

--- a/addons/dialogic/Modules/Wait/event_wait.gd
+++ b/addons/dialogic/Modules/Wait/event_wait.gd
@@ -52,7 +52,8 @@ func get_shortcode_parameters() -> Dictionary:
 	return {
 		#param_name : property_info
 		"time" 		:  {"property": "time", 		"default": 1},
-		"hide_text" :  {"property": "hide_text", 	"default": true},
+		"hide_text" :  {"property": "hide_text", 	"default": true, 
+						"suggestions": func(): return {'True':{'value':'true'}, 'False':{'value':'false'}}},
 	}
 
 

--- a/addons/dialogic/Modules/WaitInput/event_wait_input.gd
+++ b/addons/dialogic/Modules/WaitInput/event_wait_input.gd
@@ -4,12 +4,14 @@ extends DialogicEvent
 
 ## Event that waits for input before continuing.
 
+var hide_textbox := true
+
 ################################################################################
 ## 						EXECUTE
 ################################################################################
 
 func _execute() -> void:
-	dialogic.Text.hide_text_boxes()
+	if hide_textbox: dialogic.Text.hide_text_boxes()
 	dialogic.current_state = Dialogic.states.IDLE
 	finish()
 
@@ -32,3 +34,14 @@ func _init() -> void:
 
 func get_shortcode() -> String:
 	return "wait_input"
+
+func get_shortcode_parameters() -> Dictionary:
+	return {
+		#param_name : property_info
+		"hide_text" :  {"property": "hide_textbox", 	"default": true, 
+						"suggestions": func(): return {'True':{'value':'true'}, 'False':{'value':'false'}}},
+	}
+
+
+func build_event_editor():
+	add_body_edit('hide_textbox', ValueType.Bool, 'Hide text box:')


### PR DESCRIPTION
This is an unfortunate mess. I've been working on the example projects and making changes as needed along the way. This is the result of that.

Here is a list of the most prominent changes:

## Choices
- you can now choose how/when choices are revealed. either
    - instantly when the text finished (default, because previous behaviour)
    - after a certain time (very useful if text speed is instant (0))
    - after another input
    - after an input OR a certain time

## Input
- The input handler now emits a dialogic_action signal that can be listend to
- The input handler reference in the Text subsystem is now named input_handler (previously input_handler_node)

## Textbox
The DialogText node now has three new settings: `enabled`, `hide_when_empty` and `textbox_root`. 
- if enabled is false, this node will ignore calls to `reveal_text()` and the text subsystem will ignore the node
- if hide_when_empty() is true, the node will hide itself (without animation though) whenever set to an empty text
- textbox root determines what node should be hidden/revealed when the textbox shows/hides. It defaults to "self", but on the default layout it is set to the Panel containing the node.

- fixed a bug where text effects at the very end of a text event would be ignored

## Other
- Add hide_textbox setting to [await input] event 
- adds autocompletion for the wait events hide_text setting
- Make shortcode suggestions add a space if it has settings
- Add some static typing
- Removed the "Special" style from the default layout, as it was in bad shape and isn't really needed