### PR TITLE
Use ResourceLoader.exists() for glossary check

### DIFF
--- a/addons/dialogic/Modules/Glossary/subsystem_glossary.gd
+++ b/addons/dialogic/Modules/Glossary/subsystem_glossary.gd
@@ -47,7 +47,7 @@ func parse_glossary(text:String) -> String:
 
 
 func add_glossary(path:String) -> void:
-	if FileAccess.file_exists(path) or FileAccess.file_exists(path+".remap"):
+	if ResourceLoader.exists(path):
 		var x = load(path)
 		if x is DialogicGlossary:
 			glossaries.append(x)


### PR DESCRIPTION
A better fix for #1587