### PR TITLE
Fixed input bugs with event pressed and gamepad (#1609)

### DIFF
--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -315,8 +315,9 @@ func _input(event:InputEvent) -> void:
 		return
 	if !((event is InputEventKey or !event is InputEventWithModifiers) and is_visible_in_tree()):
 		return
-	if !event.pressed:
-		return
+	if "pressed" in event:
+		if !event.pressed:
+			return
 	match event.as_text():
 		"Ctrl+Z": # UNDO
 			TimelineUndoRedo.undo()


### PR DESCRIPTION
Fixes the issue with #1609 in a better way, by making sure we only check if event is pressed, if event has a pressed property (thus fixing it if someone has connected in gamepad or even possible issues if someone has connected in a midi input device)