### PR TITLE
Fix extensions_folder typo

### DIFF
--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -94,9 +94,9 @@ static func get_indexers(include_custom := true, force_reload := false) -> Array
 		var possible_script:String = DialogicUtil.get_module_path(file).path_join("index.gd")
 		if FileAccess.file_exists(possible_script):
 			indexers.append(load(possible_script).new())
-	
+
 	if include_custom:
-		var extensions_folder :String= ProjectSettings.get_setting('dialogic/extension_folder/', "res://addons/dialogic_additions/")
+		var extensions_folder: String = ProjectSettings.get_setting('dialogic/extensions_folder', "res://addons/dialogic_additions/")
 		for file in listdir(extensions_folder, false, false):
 			var possible_script: String = extensions_folder.path_join(file + "/index.gd")
 			if FileAccess.file_exists(possible_script):


### PR DESCRIPTION
The property is supposed to be `dialogic/extensions_folder`, plural and without the trailing `/`. This broke custom extensions folders.