### PR TITLE
Separate CodeCompletion & SyntaxHighligh logic to reuse in MultilineText field

### DIFF
--- a/addons/dialogic/Editor/Events/Fields/MultilineText.gd
+++ b/addons/dialogic/Editor/Events/Fields/MultilineText.gd
@@ -1,19 +1,61 @@
 @tool
-extends Control
+extends CodeEdit
 
 ## Event block field that allows entering multiline text (mainly text event).
 
 var property_name : String
 signal value_changed
 
-func _ready():
-	$TextEdit.text_changed.connect(text_changed)
-
-func text_changed(value = ""):
-	emit_signal("value_changed", property_name, $TextEdit.text)
-
-func set_value(value):
-	$TextEdit.text = str(value)
+func _ready() -> void:
+	text_changed.connect(_on_text_changed)
+	syntax_highlighter = load('res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd').new()
+	syntax_highlighter.mode = syntax_highlighter.Modes.TextEventOnly
 	
-func take_autofocus():
-	$TextEdit.grab_focus()
+
+func _on_text_changed(value := "") -> void:
+	emit_signal("value_changed", property_name, text)
+	request_code_completion(true)
+	print_tree_pretty()
+
+
+func set_value(value:Variant) -> void:
+	text = str(value)
+
+
+func take_autofocus() -> void:
+	grab_focus()
+
+
+################################################################################
+## 					AUTO COMPLETION
+################################################################################
+
+# Called if something was typed
+func _request_code_completion(force:bool):
+	$CodeCompletionHelper.request_code_completion(force, self)
+
+
+# Filters the list of all possible options, depending on what was typed
+# Purpose of the different Kinds is explained in [_request_code_completion]
+func _filter_code_completion_candidates(candidates:Array) -> Array:
+	return $CodeCompletionHelper.filter_code_completion_candidates(candidates, self)
+
+
+# Called when code completion was activated
+# Inserts the selected item
+func _confirm_code_completion(replace:bool) -> void:
+	$CodeCompletionHelper.confirm_code_completion(replace, self)
+
+
+################################################################################
+##					SYMBOL CLICKING
+################################################################################
+
+# Performs an action (like opening a link) when a valid symbol was clicked
+func _on_symbol_lookup(symbol, line, column):
+	$CodeCompletionHelper.symbol_lookup(symbol, line, column)
+
+
+# Called to test if a symbol can be clicked
+func _on_symbol_validate(symbol:String) -> void:
+	$CodeCompletionHelper.symbol_validate(symbol, self)

--- a/addons/dialogic/Editor/Events/Fields/MultilineText.tscn
+++ b/addons/dialogic/Editor/Events/Fields/MultilineText.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://dyp7m2nvab1aj"]
+[gd_scene load_steps=6 format=3 uid="uid://dyp7m2nvab1aj"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/Events/Fields/MultilineText.gd" id="1"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd" id="1_wj4ha"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd" id="3_mmga0"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bofjx"]
 content_margin_left = 10.0
@@ -11,20 +13,30 @@ corner_radius_top_right = 8
 corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
-[node name="MultilineText" type="HBoxContainer"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-size_flags_horizontal = 3
-theme_override_constants/separation = 0
-script = ExtResource("1")
+[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_yj848"]
+script = ExtResource("1_wj4ha")
 
-[node name="TextEdit" type="TextEdit" parent="."]
-layout_mode = 2
+[node name="MultilineText" type="CodeEdit"]
+offset_right = 1152.0
+offset_bottom = 648.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/normal = SubResource("StyleBoxFlat_bofjx")
 wrap_mode = 1
+syntax_highlighter = SubResource("SyntaxHighlighter_yj848")
 scroll_fit_content_height = true
+symbol_lookup_on_click = true
+delimiter_strings = Array[String]([])
+code_completion_enabled = true
+code_completion_prefixes = Array[String](["[", "{"])
+indent_automatic_prefixes = Array[String]([":", "{", "[", ")"])
+auto_brace_completion_enabled = true
+auto_brace_completion_pairs = {
+"[": "]",
+"{": "}"
+}
+script = ExtResource("1")
+
+[node name="CodeCompletionHelper" type="Node" parent="."]
+script = ExtResource("3_mmga0")
+mode = 0

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd
@@ -1,0 +1,256 @@
+@tool
+extends Node
+
+enum Modes {TextEventOnly, FullHighlighting}
+@export var mode := Modes.FullHighlighting
+
+# These RegEx's are used to deduce information from the current line for auto-completion
+# E.g. the character for portrait suggestions or the event type for parameter suggestions
+
+# To find the currently typed word and the symbol before
+var completion_word_regex := RegEx.new()
+# To find the shortcode of the current shortcode event (basically the type)
+var completion_shortcode_getter_regex := RegEx.new()
+# To find the parameter name of the current if typing a value
+var completion_shortcode_param_getter_regex := RegEx.new()
+# To find the character from a character event (for portrait suggestions)
+var completion_character_getter_regex := RegEx.new()
+# To find the character from a text event (for portrait suggestions)
+var completion_text_character_getter_regex := RegEx.new()
+
+# Stores references to all shortcode events for parameter and value suggestions
+var completion_shortcodes := {}
+var completion_text_effects := {}
+ 
+func _ready():
+	# Compile RegEx's
+	completion_word_regex.compile("(?<s>(\\W)|^)(?<word>\\w*)\\x{FFFF}")
+	completion_shortcode_getter_regex.compile("\\[(?<code>\\w*)")
+	completion_character_getter_regex.compile("(?<type>Join|Update|Leave)\\s*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?(\\s*(?<position>\\d))?(\\s*\\[(?<shortcode>.*)\\])?")
+	completion_text_character_getter_regex.compile("\\W*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(1)\"|)")
+	completion_shortcode_param_getter_regex.compile("(?<param>\\w*)\\W*=\\s*\"?"+String.chr(0xFFFF))
+
+################################################################################
+## 					AUTO COMPLETION
+################################################################################
+
+# Helper that gets the current line with a special character where the caret is
+func get_code_completion_line(text:CodeEdit) -> String:
+	return text.get_line(text.get_caret_line()).insert(text.get_caret_column(), String.chr(0xFFFF)).strip_edges()
+
+
+# Helper that gets the currently typed word
+func get_code_completion_word(text:CodeEdit) -> String:
+	var result := completion_word_regex.search(get_code_completion_line(text))
+	return result.get_string('word') if result else ""
+
+
+# Helper that gets the symbol before the current word
+func get_code_completion_prev_symbol(text:CodeEdit) -> String:
+	var result := completion_word_regex.search(get_code_completion_line(text))
+	return result.get_string('s') if result else ""
+
+
+# Called if something was typed
+# Adds all kinds of options depending on the 
+#   content of the current line, the last word and the symbol that came before
+# Triggers opening of the popup
+func request_code_completion(force:bool, text:CodeEdit):
+	# make sure shortcode event references are loaded
+	if mode == Modes.FullHighlighting:
+		if completion_shortcodes.is_empty():
+			for event in text.get_parent().editors_manager.resource_helper.event_script_cache:
+				if event.get_shortcode() != 'default_shortcode':
+					completion_shortcodes[event.get_shortcode()] = event
+	if completion_text_effects.is_empty():
+		for idx in DialogicUtil.get_indexers():
+			for effect in idx._get_text_effects():
+				completion_text_effects[effect['command']] = effect
+	
+	# fill helpers
+	var line := get_code_completion_line(text)
+	var word := get_code_completion_word(text)
+	var symbol := get_code_completion_prev_symbol(text)
+	
+	
+	## Note on use of KIND types for options. 
+	# These types are mostly useless for us.
+	# However I decidede to assign some special cases for them:
+	# - KIND_PLAIN_TEXT is only shown if the beginnging of the option is already typed 
+			# !word.is_empty() and option.begins_with(word)
+	# - KIND_CLASS is only shown if anything from the options is already typed
+			# !word.is_empty() and word in option
+	# - KIND_CONSTANT is shown and checked against the beginning
+			# option.begins_with(word)
+	# - KIND_MEMBER is shown and searched completely 
+			# word in option
+	
+	## Note on VALUE key
+	# The value key is used to store a potential closing letter for the completion.
+	# The completion will check if the letter is already present and add it otherwise.
+	
+	if mode == Modes.FullHighlighting:
+		# Shortcode event suggestions
+		if line.begins_with('['):
+			if symbol == '[':
+				# suggest shortcodes if a shortcode event has just begun
+				for shortcode in completion_shortcodes.keys():
+					if completion_shortcodes[shortcode].get_shortcode_parameters().is_empty():
+						text.add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode, completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
+					else:
+						text.add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode+" ", completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
+			else:
+				# suggest either parameters or values
+				var current_shortcode := completion_shortcode_getter_regex.search(line)
+				if current_shortcode:
+					var code := current_shortcode.get_string('code')
+					if code in completion_shortcodes.keys():
+						if symbol == ' ':
+							for param in completion_shortcodes[code].get_shortcode_parameters().keys():
+								text.add_code_completion_option(CodeEdit.KIND_MEMBER, param, param+'="' , text.syntax_highlighter.shortcode_param_color)
+						elif symbol == '=' or symbol == '"':
+							var current_parameter_gex := completion_shortcode_param_getter_regex.search(line)
+							if current_parameter_gex: 
+								var current_parameter := current_parameter_gex.get_string('param')
+								if completion_shortcodes[code].get_shortcode_parameters().has(current_parameter):
+									if completion_shortcodes[code].get_shortcode_parameters()[current_parameter].has('suggestions'):
+										var suggestions : Dictionary= completion_shortcodes[code].get_shortcode_parameters()[current_parameter]['suggestions'].call()
+										for key in suggestions.keys():
+											text.add_code_completion_option(CodeEdit.KIND_MEMBER, key, suggestions[key].value, text.syntax_highlighter.shortcode_value_color, suggestions[key].get('icon', null), '"')
+
+		# Condition event suggestions
+		elif line.begins_with('if') or line.begins_with('elif'):
+			if symbol == '{':
+				suggest_variables(text)
+
+		# Choice Event suggestions
+		elif line.begins_with('-') and '[' in line:
+			if symbol == '[':
+				text.add_code_completion_option(CodeEdit.KIND_MEMBER, 'if', 'if ', text.syntax_highlighter.code_flow_color)
+			elif symbol == '{':
+				suggest_variables(text)
+
+		# Character Event suggestions
+		elif line.begins_with('Join') or line.begins_with('Leave') or line.begins_with('Update'):
+			if symbol == ' ' and line.count(' ') <= max(line.count('"'), 1):
+				suggest_characters(text)
+				if line.begins_with('Leave'):
+					text.add_code_completion_option(CodeEdit.KIND_MEMBER, 'All', '--All-- ', text.syntax_highlighter.character_name_color, text.get_theme_icon("GuiEllipsis", "EditorIcons"))
+			
+			if symbol == '(':
+				var character:= completion_character_getter_regex.search(line).get_string('name')
+				suggest_portraits(text, character)
+
+		# Start of line suggestions
+		# These are all as KIND_PLAIN_TEXT, because that means they won't 
+		# be suggested unless at least the first letter is typed in.
+		elif not ' ' in line:
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Join', 'Join ', text.syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/join.svg'))
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Leave', 'Leave ', text.syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/leave.svg'))
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Update', 'Update ', text.syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/update.svg'))
+			
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'if', 'if ', text.syntax_highlighter.code_flow_color)
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'elif', 'elif ', text.syntax_highlighter.code_flow_color)
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'else', 'else:', text.syntax_highlighter.code_flow_color)
+			
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'VAR', 'VAR ', text.syntax_highlighter.keyword_VAR_color)
+			text.add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Setting', 'Setting ', text.syntax_highlighter.keyword_SETTING_color)
+			
+			suggest_characters(text, CodeEdit.KIND_CLASS)
+
+	# Text Event Suggestions
+	if not ':' in line.substr(0, text.get_caret_column()) and symbol == '(':
+		var character := completion_text_character_getter_regex.search(line).get_string('name')
+		suggest_portraits(text, character)
+	if symbol == '[':
+		suggest_bbcode(text)
+		for effect in completion_text_effects:
+			text.add_code_completion_option(CodeEdit.KIND_MEMBER, effect, effect, text.syntax_highlighter.normal_color, text.get_theme_icon("RichTextEffect", "EditorIcons"), ']')
+	if symbol == '{':
+		suggest_variables(text)
+	
+	# Force update and showing of the popup
+	text.update_code_completion_options(true)
+
+
+# Helper that adds all characters as options
+func suggest_characters(text:CodeEdit, type := CodeEdit.KIND_MEMBER) -> void:
+	for character in text.get_parent().editors_manager.resource_helper.character_directory:
+		text.add_code_completion_option(type, character, character, text.syntax_highlighter.character_name_color, load("res://addons/dialogic/Editor/Images/Resources/character.svg"))
+
+
+# Helper that adds all portraits of a given character as options
+func suggest_portraits(text:CodeEdit, character_name:String) -> void:
+	var character_resource :DialogicCharacter= text.get_parent().editors_manager.resource_helper.character_directory[character_name]['resource']
+	for portrait in character_resource.portraits:
+		text.add_code_completion_option(CodeEdit.KIND_MEMBER, portrait, portrait, text.syntax_highlighter.character_portrait_color, load("res://addons/dialogic/Editor/Images/Resources/character.svg"), ')')
+	if character_resource.portraits.is_empty():
+		text.add_code_completion_option(CodeEdit.KIND_MEMBER, 'Has no portraits!', '', text.syntax_highlighter.character_portrait_color, load("res://addons/dialogic/Editor/Images/Pieces/warning.svg"))
+
+
+# Helper that adds all variable paths as options
+func suggest_variables(text:CodeEdit):
+	for variable in DialogicUtil.list_variables(ProjectSettings.get_setting('dialogic/variables')):
+		text.add_code_completion_option(CodeEdit.KIND_MEMBER, variable, variable, text.syntax_highlighter.variable_color, text.get_theme_icon("MemberProperty", "EditorIcons"), '}')
+
+
+func suggest_bbcode(text:CodeEdit):
+	for i in [['b (bold)', 'b'], ['i (italics)', 'i'], ['color', 'color='], ['font size','font_size=']]:
+		text.add_code_completion_option(CodeEdit.KIND_MEMBER, i[0], i[1],  text.syntax_highlighter.normal_color, text.get_theme_icon("RichTextEffect", "EditorIcons"),)
+		text.add_code_completion_option(CodeEdit.KIND_CLASS, 'end '+i[0], '/'+i[1],  text.syntax_highlighter.normal_color, text.get_theme_icon("RichTextEffect", "EditorIcons"), ']')
+
+# Filters the list of all possible options, depending on what was typed
+# Purpose of the different Kinds is explained in [_request_code_completion]
+func filter_code_completion_candidates(candidates:Array, text:CodeEdit) -> Array:
+	var valid_candidates := []
+	var current_word := get_code_completion_word(text)
+	for candidate in candidates:
+		if candidate.kind == text.KIND_PLAIN_TEXT:
+			if !current_word.is_empty() and candidate.insert_text.begins_with(current_word):
+				valid_candidates.append(candidate)
+		elif candidate.kind == text.KIND_MEMBER:
+			if current_word.is_empty() or current_word.to_lower() in candidate.insert_text.to_lower():
+				valid_candidates.append(candidate)
+		elif candidate.kind == text.KIND_CONSTANT:
+			if current_word.is_empty() or candidate.insert_text.begins_with(current_word):
+				valid_candidates.append(candidate)
+		elif candidate.kind == text.KIND_CLASS:
+			if !current_word.is_empty() and current_word.to_lower() in candidate.insert_text.to_lower():
+				valid_candidates.append(candidate)
+	valid_candidates.reverse()
+	return valid_candidates
+
+
+# Called when code completion was activated
+# Inserts the selected item
+func confirm_code_completion(replace:bool, text:CodeEdit) -> void:
+	# Note: I decided to ALWAYS use replace mode, as dialogic is supposed to be beginner friendly 
+	var word := get_code_completion_word(text)
+	var code_completion := text.get_code_completion_option(text.get_code_completion_selected_index())
+	text.remove_text(text.get_caret_line(), text.get_caret_column()-len(word), text.get_caret_line(), text.get_caret_column())
+	text.set_caret_column(text.get_caret_column()-len(word))
+	text.insert_text_at_caret(code_completion.insert_text)#
+	if code_completion.has('default_value') and typeof(code_completion['default_value']) == TYPE_STRING:
+		var next_letter := text.get_line(text.get_caret_line()).substr(text.get_caret_column(), 1)
+		if next_letter != code_completion['default_value']:
+			text.insert_text_at_caret(code_completion['default_value'])
+		else:
+			text.set_caret_column(text.get_caret_column()+1)
+
+
+################################################################################
+##					SYMBOL CLICKING
+################################################################################
+
+# Performs an action (like opening a link) when a valid symbol was clicked
+func symbol_lookup(symbol:String, line:int, column:int) -> void:
+	if symbol in completion_shortcodes.keys():
+		if !completion_shortcodes[symbol].help_page_path.is_empty():
+			OS.shell_open(completion_shortcodes[symbol].help_page_path)
+
+
+# Called to test if a symbol can be clicked
+func symbol_validate(symbol:String, text:CodeEdit) -> void:
+	if symbol in completion_shortcodes.keys():
+		if !completion_shortcodes[symbol].help_page_path.is_empty():
+			text.set_symbol_lookup_word_as_valid(true)

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -1,7 +1,11 @@
 @tool
 extends SyntaxHighlighter
 
-## Syntax highlighter for the dialogic text timeline editor.
+## Syntax highlighter for the dialogic text timeline editor and text events in the visual editor.
+
+enum Modes {TextEventOnly, FullHighlighting}
+var mode := Modes.FullHighlighting
+
 
 ## RegEx's
 var word_regex := RegEx.new()
@@ -74,6 +78,7 @@ func _init():
 	text_effects_regex.compile("(?<!\\\\)\\[\\s*/?(?<command>"+text_effects+")\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
 	character_event_regex.compile("(?<type>Join|Update|Leave)\\s*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?(\\s*(?<position>\\d))?(\\s*\\[(?<shortcode>.*)\\])?")
 
+
 func _get_line_syntax_highlighting(line:int) -> Dictionary:
 	var str_line := get_text_edit().get_line(line)
 	
@@ -82,74 +87,77 @@ func _get_line_syntax_highlighting(line:int) -> Dictionary:
 
 	dict = color_translation_id(dict, str_line)
 	
-	if str_line.strip_edges().begins_with('#'):
-		dict[0] = {'color':comment_color}
-		return dict
-	
-	if str_line.strip_edges().begins_with("["):
-		if !text_effects_regex.search(str_line.get_slice(' ', 0)):
-			var result:= shortcode_regex.search(str_line)
-			if result:
-				dict[result.get_start('id')] = {"color":shortcode_color}
-				dict[result.get_end('id')] = {"color":normal_color}
-				if result.get_string('args'):
-					color_shortcode_content(dict, str_line, result.get_start('args'), result.get_end('args'))
+	if mode == Modes.FullHighlighting:
+		if str_line.strip_edges().begins_with('#'):
+			dict[0] = {'color':comment_color}
+			return dict
+		
+		if str_line.strip_edges().begins_with("["):
+			if !text_effects_regex.search(str_line.get_slice(' ', 0)):
+				var result:= shortcode_regex.search(str_line)
+				if result:
+					dict[result.get_start('id')] = {"color":shortcode_color}
+					dict[result.get_end('id')] = {"color":normal_color}
+					if result.get_string('args'):
+						color_shortcode_content(dict, str_line, result.get_start('args'), result.get_end('args'))
+				return dict
+		
+		if str_line.strip_edges().begins_with('-'):
+			dict[0] = {'color':choice_color}
+			if '[' in str_line:
+				dict[str_line.find('[')] = {"color":normal_color}
+				dict = color_word(dict, code_flow_color, str_line, 'if', str_line.find('['), str_line.find(']'))
+				dict = color_condition(dict, str_line, str_line.find('['), str_line.find(']'))
+			return dict
+		
+		for word in ['if', 'elif', 'else']:
+			if str_line.strip_edges().begins_with(word):
+				dict[str_line.find(word)] = {"color":code_flow_color}
+				dict[str_line.find(word)+len(word)] = {"color":normal_color}
+				dict = color_condition(dict, str_line)
+				return dict
+		
+		for word in ['Join', 'Update', 'Leave']:
+			if str_line.strip_edges().begins_with(word):
+				dict[str_line.find(word)] = {"color":character_event_color}
+				dict[str_line.find(word)+len(word)] = {"color":normal_color}
+				var result := character_event_regex.search(str_line)
+				if result.get_string('name'):
+					dict[result.get_start('name')] = {"color":character_name_color}
+					dict[result.get_end('name')] = {"color":normal_color}
+				if result.get_string('portrait'):
+					dict[result.get_start('portrait')] = {"color":character_portrait_color}
+					dict[result.get_end('portrait')] = {"color":normal_color}
+				if result.get_string('shortcode'):
+					dict = color_shortcode_content(dict, str_line, result.get_start('shortcode'), result.get_end('shortcode'))
+				return dict
+		
+		if str_line.strip_edges().begins_with('VAR'):
+			dict[str_line.find('VAR')] = {"color":keyword_VAR_color}
+			dict[str_line.find('VAR')+3] = {"color":normal_color}
+			dict = color_region(dict, string_color, str_line, '"', '"', str_line.find('VAR'))
+			dict = color_region(dict, variable_color, str_line, '{', '}', str_line.find('VAR'))
+			return dict
+		
+		if str_line.strip_edges().begins_with('Setting'):
+			dict[str_line.find('Setting')] = {"color":keyword_SETTING_color}
+			dict[str_line.find('Setting')+7] = {"color":normal_color}
+			dict = color_word(dict, keyword_SETTING_color, str_line, 'reset')
+			dict = color_region(dict, string_color, str_line, '"', '"')
+			dict = color_region(dict, variable_color, str_line, '{', '}')
 			return dict
 	
-	if str_line.strip_edges().begins_with('-'):
-		dict[0] = {'color':choice_color}
-		if '[' in str_line:
-			dict[str_line.find('[')] = {"color":normal_color}
-			dict = color_word(dict, code_flow_color, str_line, 'if', str_line.find('['), str_line.find(']'))
-			dict = color_condition(dict, str_line, str_line.find('['), str_line.find(']'))
-		return dict
-	
-	for word in ['if', 'elif', 'else']:
-		if str_line.strip_edges().begins_with(word):
-			dict[str_line.find(word)] = {"color":code_flow_color}
-			dict[str_line.find(word)+len(word)] = {"color":normal_color}
-			dict = color_condition(dict, str_line)
-			return dict
-	
-	for word in ['Join', 'Update', 'Leave']:
-		if str_line.strip_edges().begins_with(word):
-			dict[str_line.find(word)] = {"color":character_event_color}
-			dict[str_line.find(word)+len(word)] = {"color":normal_color}
-			var result := character_event_regex.search(str_line)
-			if result.get_string('name'):
-				dict[result.get_start('name')] = {"color":character_name_color}
-				dict[result.get_end('name')] = {"color":normal_color}
-			if result.get_string('portrait'):
-				dict[result.get_start('portrait')] = {"color":character_portrait_color}
-				dict[result.get_end('portrait')] = {"color":normal_color}
-			if result.get_string('shortcode'):
-				dict = color_shortcode_content(dict, str_line, result.get_start('shortcode'), result.get_end('shortcode'))
-			return dict
-	
-	if str_line.strip_edges().begins_with('VAR'):
-		dict[str_line.find('VAR')] = {"color":keyword_VAR_color}
-		dict[str_line.find('VAR')+3] = {"color":normal_color}
-		dict = color_region(dict, string_color, str_line, '"', '"', str_line.find('VAR'))
-		dict = color_region(dict, variable_color, str_line, '{', '}', str_line.find('VAR'))
-		return dict
-	
-	if str_line.strip_edges().begins_with('Setting'):
-		dict[str_line.find('Setting')] = {"color":keyword_SETTING_color}
-		dict[str_line.find('Setting')+7] = {"color":normal_color}
-		dict = color_word(dict, keyword_SETTING_color, str_line, 'reset')
-		dict = color_region(dict, string_color, str_line, '"', '"')
-		dict = color_region(dict, variable_color, str_line, '{', '}')
-		return dict
 	
 	var result := text_event_regex.search(str_line)
 	if !result:
 		return dict
-	if result.get_string('name'):
-		dict[result.get_start('name')] = {"color":character_name_color}
-		dict[result.get_end('name')] = {"color":normal_color}
-	if result.get_string('portrait'):
-		dict[result.get_start('portrait')] = {"color":character_portrait_color}
-		dict[result.get_end('portrait')] = {"color":normal_color}
+	if mode == Modes.FullHighlighting:
+		if result.get_string('name'):
+			dict[result.get_start('name')] = {"color":character_name_color}
+			dict[result.get_end('name')] = {"color":normal_color}
+		if result.get_string('portrait'):
+			dict[result.get_start('portrait')] = {"color":character_portrait_color}
+			dict[result.get_end('portrait')] = {"color":normal_color}
 	if result.get_string('text'):
 		var effects_result = text_effects_regex.search_all(str_line)
 		for eff in effects_result:

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -3,39 +3,13 @@ extends CodeEdit
 
 ## Sub-Editor that allows editing timelines in a text format.
 
-# These RegEx's are used to deduce information from the current line for auto-completion
-# E.g. the character for portrait suggestions or the event type for parameter suggestions
-
-# To find the currently typed word and the symbol before
-var completion_word_regex := RegEx.new()
-# To find the shortcode of the current shortcode event (basically the type)
-var completion_shortcode_getter_regex := RegEx.new()
-# To find the parameter name of the current if typing a value
-var completion_shortcode_param_getter_regex := RegEx.new()
-# To find the character from a character event (for portrait suggestions)
-var completion_character_getter_regex := RegEx.new()
-# To find the character from a text event (for portrait suggestions)
-var completion_text_character_getter_regex := RegEx.new()
-
-# Stores references to all shortcode events for parameter and value suggestions
-var completion_shortcodes := {}
-var completion_text_effects := {}
- 
 func _ready():
 	syntax_highlighter = load("res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd").new()
-	
-	# Compile RegEx's
-	completion_word_regex.compile("(?<s>(\\W)|^)(?<word>\\w*)\\x{FFFF}")
-	completion_shortcode_getter_regex.compile("\\[(?<code>\\w*)")
-	completion_character_getter_regex.compile("(?<type>Join|Update|Leave)\\s*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?(\\s*(?<position>\\d))?(\\s*\\[(?<shortcode>.*)\\])?")
-	completion_text_character_getter_regex.compile("\\W*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(1)\"|)")
-	completion_shortcode_param_getter_regex.compile("(?<param>\\w*)\\W*=\\s*\"?"+String.chr(0xFFFF))
 
 
 func _on_text_editor_text_changed():
 	get_parent().current_resource_state = DialogicEditor.ResourceStates.Unsaved
 	request_code_completion(true)
-
 
 
 func clear_timeline():
@@ -214,208 +188,21 @@ func _drop_data(at_position:Vector2, data:Variant) -> void:
 ## 					AUTO COMPLETION
 ################################################################################
 
-# Helper that gets the current line with a special character where the caret is
-func get_code_completion_line() -> String:
-	return get_line(get_caret_line()).insert(get_caret_column(), String.chr(0xFFFF)).strip_edges()
-
-
-# Helper that gets the currently typed word
-func get_code_completion_word() -> String:
-	var result := completion_word_regex.search(get_code_completion_line())
-	return result.get_string('word') if result else ""
-
-
-# Helper that gets the symbol before the current word
-func get_code_completion_prev_symbol() -> String:
-	var result := completion_word_regex.search(get_code_completion_line())
-	return result.get_string('s') if result else ""
-
-
 # Called if something was typed
-# Adds all kinds of options depending on the 
-#   content of the current line, the last word and the symbol that came before
-# Triggers opening of the popup
-func _request_code_completion(force):
-	# make sure shortcode event references are loaded
-	if completion_shortcodes.is_empty():
-		for event in get_parent().editors_manager.resource_helper.event_script_cache:
-			if event.get_shortcode() != 'default_shortcode':
-				completion_shortcodes[event.get_shortcode()] = event
-	if completion_text_effects.is_empty():
-		for idx in DialogicUtil.get_indexers():
-			for effect in idx._get_text_effects():
-				completion_text_effects[effect['command']] = effect
-	
-	# fill helpers
-	var line := get_code_completion_line()
-	var word := get_code_completion_word()
-	var symbol := get_code_completion_prev_symbol()
-	
-	
-	## Note on use of KIND types for options. 
-	# These types are mostly useless for us.
-	# However I decidede to assign some special cases for them:
-	# - KIND_PLAIN_TEXT is only shown if the beginnging of the option is already typed 
-			# !word.is_empty() and option.begins_with(word)
-	# - KIND_CLASS is only shown if anything from the options is already typed
-			# !word.is_empty() and word in option
-	# - KIND_CONSTANT is shown and checked against the beginning
-			# option.begins_with(word)
-	# - KIND_MEMBER is shown and searched completely 
-			# word in option
-	
-	## Note on VALUE key
-	# The value key is used to store a potential closing letter for the completion.
-	# The completion will check if the letter is already present and add it otherwise.
-	
-	
-	# Shortcode event suggestions
-	if line.begins_with('['):
-		if symbol == '[':
-			# suggest shortcodes if a shortcode event has just begun
-			for shortcode in completion_shortcodes.keys():
-				if completion_shortcodes[shortcode].get_shortcode_parameters().is_empty():
-					add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode, completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
-				else:
-					add_code_completion_option(CodeEdit.KIND_MEMBER, shortcode, shortcode+" ", completion_shortcodes[shortcode].event_color, completion_shortcodes[shortcode]._get_icon())
-		else:
-			# suggest either parameters or values
-			var current_shortcode := completion_shortcode_getter_regex.search(line)
-			if current_shortcode:
-				var code := current_shortcode.get_string('code')
-				if code in completion_shortcodes.keys():
-					if symbol == ' ':
-						for param in completion_shortcodes[code].get_shortcode_parameters().keys():
-							add_code_completion_option(CodeEdit.KIND_MEMBER, param, param+'="' , syntax_highlighter.shortcode_param_color)
-					elif symbol == '=' or symbol == '"':
-						var current_parameter_gex := completion_shortcode_param_getter_regex.search(line)
-						if current_parameter_gex: 
-							var current_parameter := current_parameter_gex.get_string('param')
-							if completion_shortcodes[code].get_shortcode_parameters().has(current_parameter):
-								if completion_shortcodes[code].get_shortcode_parameters()[current_parameter].has('suggestions'):
-									var suggestions : Dictionary= completion_shortcodes[code].get_shortcode_parameters()[current_parameter]['suggestions'].call()
-									for key in suggestions.keys():
-										add_code_completion_option(CodeEdit.KIND_MEMBER, key, suggestions[key].value, syntax_highlighter.shortcode_value_color, suggestions[key].get('icon', null), '"')
-	
-	# Condition event suggestions
-	elif line.begins_with('if') or line.begins_with('elif'):
-		if symbol == '{':
-			suggest_variables()
-	
-	# Choice Event suggestions
-	elif line.begins_with('-') and '[' in line:
-		if symbol == '[':
-			add_code_completion_option(CodeEdit.KIND_MEMBER, 'if', 'if ', syntax_highlighter.code_flow_color)
-		elif symbol == '{':
-			suggest_variables()
-	
-	# Character Event suggestions
-	elif line.begins_with('Join') or line.begins_with('Leave') or line.begins_with('Update'):
-		if symbol == ' ' and line.count(' ') <= max(line.count('"'), 1):
-			suggest_characters()
-			if line.begins_with('Leave'):
-				add_code_completion_option(CodeEdit.KIND_MEMBER, 'All', '--All-- ', syntax_highlighter.character_name_color, get_theme_icon("GuiEllipsis", "EditorIcons"))
-		
-		if symbol == '(':
-			var character:= completion_character_getter_regex.search(line).get_string('name')
-			suggest_portraits(character)
-	
-	# Start of line suggestions
-	# These are all as KIND_PLAIN_TEXT, because that means they won't 
-	# be suggested unless at least the first letter is typed in.
-	elif not ' ' in line:
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Join', 'Join ', syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/join.svg'))
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Leave', 'Leave ', syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/leave.svg'))
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Update', 'Update ', syntax_highlighter.character_event_color, load('res://addons/dialogic/Editor/Images/Dropdown/update.svg'))
-		
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'if', 'if ', syntax_highlighter.code_flow_color)
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'elif', 'elif ', syntax_highlighter.code_flow_color)
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'else', 'else:', syntax_highlighter.code_flow_color)
-		
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'VAR', 'VAR ', syntax_highlighter.keyword_VAR_color)
-		add_code_completion_option(CodeEdit.KIND_PLAIN_TEXT, 'Setting', 'Setting ', syntax_highlighter.keyword_SETTING_color)
-		
-		suggest_characters(CodeEdit.KIND_CLASS)
-	
-	# Text Event Suggestions
-	else:
-		if not ':' in line.substr(0, get_caret_column()) and symbol == '(':
-			var character := completion_text_character_getter_regex.search(line).get_string('name')
-			suggest_portraits(character)
-		if symbol == '[':
-			suggest_bbcode()
-			for effect in completion_text_effects:
-				add_code_completion_option(CodeEdit.KIND_MEMBER, effect, effect, syntax_highlighter.normal_color, get_theme_icon("RichTextEffect", "EditorIcons"), ']')
-		if symbol == '{':
-			suggest_variables()
-	
-	# Force update and showing of the popup
-	update_code_completion_options(true)
+func _request_code_completion(force:bool):
+	$CodeCompletionHelper.request_code_completion(force, self)
 
-
-# Helper that adds all characters as options
-func suggest_characters(type := CodeEdit.KIND_MEMBER) -> void:
-	for character in get_parent().editors_manager.resource_helper.character_directory:
-		add_code_completion_option(type, character, character, syntax_highlighter.character_name_color, load("res://addons/dialogic/Editor/Images/Resources/character.svg"))
-
-
-# Helper that adds all portraits of a given character as options
-func suggest_portraits(character_name:String) -> void:
-	var character_resource :DialogicCharacter= get_parent().editors_manager.resource_helper.character_directory[character_name]['resource']
-	for portrait in character_resource.portraits:
-		add_code_completion_option(CodeEdit.KIND_MEMBER, portrait, portrait, syntax_highlighter.character_portrait_color, load("res://addons/dialogic/Editor/Images/Resources/character.svg"), ')')
-	if character_resource.portraits.is_empty():
-		add_code_completion_option(CodeEdit.KIND_MEMBER, 'Has no portraits!', '', syntax_highlighter.character_portrait_color, load("res://addons/dialogic/Editor/Images/Pieces/warning.svg"))
-
-
-# Helper that adds all variable paths as options
-func suggest_variables():
-	for variable in DialogicUtil.list_variables(ProjectSettings.get_setting('dialogic/variables')):
-		add_code_completion_option(CodeEdit.KIND_MEMBER, variable, variable, syntax_highlighter.variable_color, get_theme_icon("MemberProperty", "EditorIcons"), '}')
-
-
-func suggest_bbcode():
-	for i in [['b (bold)', 'b'], ['i (italics)', 'i'], ['color', 'color='], ['font size','font_size=']]:
-		add_code_completion_option(CodeEdit.KIND_MEMBER, i[0], i[1],  syntax_highlighter.normal_color, get_theme_icon("RichTextEffect", "EditorIcons"),)
-		add_code_completion_option(CodeEdit.KIND_CLASS, 'end '+i[0], '/'+i[1],  syntax_highlighter.normal_color, get_theme_icon("RichTextEffect", "EditorIcons"), ']')
 
 # Filters the list of all possible options, depending on what was typed
 # Purpose of the different Kinds is explained in [_request_code_completion]
-func _filter_code_completion_candidates(candidates:Array):
-	var valid_candidates := []
-	var current_word := get_code_completion_word()
-	for candidate in candidates:
-		if candidate.kind == KIND_PLAIN_TEXT:
-			if !current_word.is_empty() and candidate.insert_text.begins_with(current_word):
-				valid_candidates.append(candidate)
-		elif candidate.kind == KIND_MEMBER:
-			if current_word.is_empty() or current_word.to_lower() in candidate.insert_text.to_lower():
-				valid_candidates.append(candidate)
-		elif candidate.kind == KIND_CONSTANT:
-			if current_word.is_empty() or candidate.insert_text.begins_with(current_word):
-				valid_candidates.append(candidate)
-		elif candidate.kind == KIND_CLASS:
-			if !current_word.is_empty() and current_word.to_lower() in candidate.insert_text.to_lower():
-				valid_candidates.append(candidate)
-	valid_candidates.reverse()
-	return valid_candidates
+func _filter_code_completion_candidates(candidates:Array) -> Array:
+	return $CodeCompletionHelper.filter_code_completion_candidates(candidates, self)
 
 
 # Called when code completion was activated
 # Inserts the selected item
-func _confirm_code_completion(replace):
-	# Note: I decided to ALWAYS use replace mode, as dialogic is supposed to be beginner friendly 
-	var word := get_code_completion_word()
-	var code_completion := get_code_completion_option(get_code_completion_selected_index())
-	remove_text(get_caret_line(), get_caret_column()-len(word), get_caret_line(), get_caret_column())
-	set_caret_column(get_caret_column()-len(word))
-	insert_text_at_caret(code_completion.insert_text)#
-	if code_completion.has('default_value') and typeof(code_completion['default_value']) == TYPE_STRING:
-		var next_letter := get_line(get_caret_line()).substr(get_caret_column(), 1)
-		if next_letter != code_completion['default_value']:
-			insert_text_at_caret(code_completion['default_value'])
-		else:
-			set_caret_column(get_caret_column()+1)
+func _confirm_code_completion(replace:bool) -> void:
+	$CodeCompletionHelper.confirm_code_completion(replace, self)
 
 
 ################################################################################
@@ -424,13 +211,9 @@ func _confirm_code_completion(replace):
 
 # Performs an action (like opening a link) when a valid symbol was clicked
 func _on_symbol_lookup(symbol, line, column):
-	if symbol in completion_shortcodes.keys():
-		if !completion_shortcodes[symbol].help_page_path.is_empty():
-			OS.shell_open(completion_shortcodes[symbol].help_page_path)
+	$CodeCompletionHelper.symbol_lookup(symbol, line, column)
 
 
 # Called to test if a symbol can be clicked
 func _on_symbol_validate(symbol:String) -> void:
-	if symbol in completion_shortcodes.keys():
-		if !completion_shortcodes[symbol].help_page_path.is_empty():
-			set_symbol_lookup_word_as_valid(true)
+	$CodeCompletionHelper.symbol_validate(symbol, self)

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=4 format=3 uid="uid://defdeav8rli6o"]
+[gd_scene load_steps=5 format=3 uid="uid://defdeav8rli6o"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd" id="1_1kbx2"]
 [ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd" id="1_5qfro"]
+[ext_resource type="Script" path="res://addons/dialogic/Editor/TimelineEditor/TextEditor/CodeCompletionHelper.gd" id="3_3bgmj"]
 
-[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_q86qr"]
+[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_yb1h4"]
 script = ExtResource("1_5qfro")
 
 [node name="TimelineTextEditor" type="CodeEdit"]
@@ -13,18 +14,21 @@ offset_bottom = 600.0
 theme_override_constants/line_spacing = 10
 highlight_current_line = true
 draw_tabs = true
-syntax_highlighter = SubResource("SyntaxHighlighter_q86qr")
+syntax_highlighter = SubResource("SyntaxHighlighter_yb1h4")
 minimap_draw = true
 caret_blink = true
 line_folding = true
 gutters_draw_line_numbers = true
 gutters_draw_fold_gutter = true
 code_completion_enabled = true
-code_completion_prefixes = ["[", "{", "f"]
+code_completion_prefixes = Array[String](["[", "{"])
 indent_automatic = true
 auto_brace_completion_enabled = true
 auto_brace_completion_highlight_matching = true
 script = ExtResource("1_1kbx2")
+
+[node name="CodeCompletionHelper" type="Node" parent="."]
+script = ExtResource("3_3bgmj")
 
 [connection signal="code_completion_requested" from="." to="." method="_on_code_completion_requested"]
 [connection signal="symbol_lookup" from="." to="." method="_on_symbol_lookup"]


### PR DESCRIPTION
This PR adds syntax highlighting and auto-completion for text effects and variables to the MultilineText field (text event in visual editor). 

However in most cases the auto-completion list is clipped and thus unusable. I've made [a proposal](https://github.com/godotengine/godot-proposals/issues/7162) for this to be fixed. 