### PR TITLE
Add skip delay

### DIFF
--- a/addons/dialogic/Modules/Text/settings_text.gd
+++ b/addons/dialogic/Modules/Text/settings_text.gd
@@ -6,6 +6,7 @@ func refresh():
 	
 	%DefaultSpeed.value = ProjectSettings.get_setting('dialogic/settings/text_speed', 0.01)
 	%Skippable.button_pressed = ProjectSettings.get_setting('dialogic/text/skippable', true)
+	%SkippableDelay.value = ProjectSettings.get_setting('dialogic/text/skippable_delay', 0.1)
 	%Autoadvance.button_pressed = ProjectSettings.get_setting('dialogic/text/autoadvance', false)
 	%AutoadvanceDelay.value = ProjectSettings.get_setting('dialogic/text/autoadvance_delay', 1)
 	%AutocolorNames.button_pressed = ProjectSettings.get_setting('dialogic/text/autocolor_names', false)
@@ -31,6 +32,11 @@ func _on_Autoadvance_toggled(button_pressed):
 
 func _on_Skippable_toggled(button_pressed):
 	ProjectSettings.set_setting('dialogic/text/skippable', button_pressed)
+	ProjectSettings.save()
+
+
+func _on_skippable_delay_value_changed(value: float) -> void:
+	ProjectSettings.set_setting('dialogic/text/skippable_delay', value)
 	ProjectSettings.save()
 
 

--- a/addons/dialogic/Modules/Text/settings_text.tscn
+++ b/addons/dialogic/Modules/Text/settings_text.tscn
@@ -67,6 +67,13 @@ text = "Skippable"
 unique_name_in_owner = true
 layout_mode = 2
 
+[node name="SkippableDelay" type="SpinBox" parent="VBoxContainer/Skippable"]
+unique_name_in_owner = true
+layout_mode = 2
+tooltip_text = "Delay before you can skip again"
+step = 0.01
+suffix = "s"
+
 [node name="ColorNames" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
 
@@ -178,6 +185,7 @@ Learn more about bbcode in the official godot docs."
 [connection signal="value_changed" from="VBoxContainer/DefaultSpeed/DefaultSpeed" to="." method="_on_DefaultSpeed_value_changed"]
 [connection signal="value_changed" from="VBoxContainer/InputAction/InputAction" to="." method="_on_InputAction_value_changed"]
 [connection signal="toggled" from="VBoxContainer/Skippable/Skippable" to="." method="_on_Skippable_toggled"]
+[connection signal="value_changed" from="VBoxContainer/Skippable/SkippableDelay" to="." method="_on_skippable_delay_value_changed"]
 [connection signal="toggled" from="VBoxContainer/ColorNames/AutocolorNames" to="." method="_on_AutocolorNames_toggled"]
 [connection signal="toggled" from="VBoxContainer/TextboxHidden/TextboxHidden" to="." method="_on_textbox_hidden_toggled"]
 [connection signal="toggled" from="VBoxContainer/Autoadvance/Autoadvance" to="." method="_on_Autoadvance_toggled"]


### PR DESCRIPTION
Adds a timer to the input handler that discards inputs every x seconds, which effectively delays the skipping of events and animations.
Adds config to configure that x delay. Delay is optional, 0.0 results in the default behavior.

Fixes problems with dialogic eating inputs or processing them twice sometimes, leading to accidently skipped events, especially on web builds. (Which I was too lazy to open an issue for)
Enables users to set a general global delay for skipping events.

Tested with some styles and configurations, but I'm not proficient with the dialogic structure.