### PR TITLE
Silence error on get_meta(..., null)

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -449,7 +449,7 @@ func update_preview() -> void:
 		var offset:Vector2 =current_portrait_data.get('offset', Vector2()) + current_resource.offset
 		
 		if current_previewed_scene != null \
-			and current_previewed_scene.get_meta('path', null) == current_portrait_data.get('scene') \
+			and current_previewed_scene.get_meta('path', '') == current_portrait_data.get('scene') \
 			and current_previewed_scene.has_method('_should_do_portrait_update') \
 			and is_instance_valid(current_previewed_scene.get_script()) \
 			and current_previewed_scene._should_do_portrait_update(current_resource, selected_item.get_text(0)):

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -177,9 +177,9 @@ func _update_portrait_transform(character_node:Node2D, time:float = 0.0) -> void
 
 ## Animates the portrait in the given container with the given animation.
 func _animate_portrait(character_node:Node2D, animation_path:String, length:float, repeats = 1) -> DialogicAnimation:
-	if character_node.get_meta('animation_node', null) != null and is_instance_valid(character_node.get_meta('animation_node', null)):
+	if character_node.has_meta('animation_node') and is_instance_valid(character_node.get_meta('animation_node')):
 		character_node.get_meta('animation_node').queue_free()
-	
+
 	var anim_script :Script = load(animation_path)
 	var anim_node := Node.new()
 	anim_node.set_script(anim_script)
@@ -192,7 +192,7 @@ func _animate_portrait(character_node:Node2D, animation_path:String, length:floa
 	add_child(anim_node)
 	anim_node.animate()
 	character_node.set_meta('animation_node', anim_node)
-	
+
 	return anim_node
 
 


### PR DESCRIPTION
As per the `Object` docs, providing a default value of `null` to the `get_meta` call doesn't silence the error in the event that the metadata key doesn't exist. We have a few instances of this pattern throughout the codebase, which were producing unintended error messages under certain circumstances.

This commit replaces them with explicit `has_meta` checks, where appropriate. In situations where the null value should be an error (typically because it was previously checked) I removed the default argument, to avoid confusion (the behavior is the same).

Also did some boy scout rule cleanup of trailing whitespace and refactored some confusing branch logic in `DialogicGameHandler.gd`.