### PR TITLE
Fix skip delay of 0 and add short input block after natural text finish

### DIFF
--- a/addons/dialogic/Modules/Text/default_input_handler.gd
+++ b/addons/dialogic/Modules/Text/default_input_handler.gd
@@ -1,31 +1,44 @@
 @tool
 extends Node
 
-var autoadvance_timer := Timer.new()
-var skip_delay_timer := Timer.new()
-
 signal dialogic_action()
+
+var autoadvance_timer := Timer.new()
+var input_block_timer := Timer.new()
+var skip_delay :float = ProjectSettings.get_setting('dialogic/text/skippable_delay', 0.1)
 
 ################################################################################
 ## 						INPUT
 ################################################################################
 func _input(event:InputEvent) -> void:
 	if Input.is_action_just_pressed(ProjectSettings.get_setting('dialogic/text/input_action', 'dialogic_default_action')):
-		if Dialogic.paused: return
+		if Dialogic.paused:
+			return
 		
-		if skip_delay_timer.wait_time > 0.0:
-			if skip_delay_timer.time_left > 0.0:
-				return
-			skip_delay_timer.start()
+		if is_input_blocked():
+			return
 		
 		if Dialogic.current_state == Dialogic.states.IDLE and Dialogic.Text.can_manual_advance():
 			Dialogic.handle_next_event()
 			autoadvance_timer.stop()
+			block_input(skip_delay)
 		
 		elif Dialogic.current_state == Dialogic.states.SHOWING_TEXT and Dialogic.Text.can_skip():
 			Dialogic.Text.skip_text_animation()
+			block_input(skip_delay)
 		
 		dialogic_action.emit()
+
+
+func is_input_blocked() -> bool:
+	return input_block_timer.time_left > 0.0
+
+
+func block_input(time:=0.1) -> void:
+	if time > 0:
+		input_block_timer.stop()
+		input_block_timer.wait_time = time
+		input_block_timer.start()
 
 
 ####################################################################################################
@@ -36,9 +49,9 @@ func _ready() -> void:
 	add_child(autoadvance_timer)
 	autoadvance_timer.one_shot = true
 	autoadvance_timer.timeout.connect(_on_autoadvance_timer_timeout)
-	add_child(skip_delay_timer)
-	skip_delay_timer.one_shot = true
-	skip_delay_timer.wait_time = ProjectSettings.get_setting('dialogic/text/skippable_delay', 0.1)
+	
+	add_child(input_block_timer)
+	input_block_timer.one_shot = true
 
 
 func _on_text_finished(info:Dictionary) -> void:
@@ -60,8 +73,8 @@ func get_autoadvance_time_left() -> float:
 
 func pause() -> void:
 	autoadvance_timer.paused = true
-	skip_delay_timer.paused = true
+	input_block_timer.paused = true
 
 func resume() -> void:
 	autoadvance_timer.paused = false
-	skip_delay_timer.paused = false
+	input_block_timer.paused = false

--- a/addons/dialogic/Modules/Text/node_dialog_text.gd
+++ b/addons/dialogic/Modules/Text/node_dialog_text.gd
@@ -70,6 +70,9 @@ func continue_reveal() -> void:
 			continued_revealing_text.emit(get_parsed_text()[visible_characters-1])
 	else:
 		finish_text()
+		# if the text finished organically, add a small input block
+		# this prevents accidental skipping when you expected the text to be longer
+		Dialogic.Text.input_handler.block_input(0.3)
 
 
 # shows all the text imidiatly


### PR DESCRIPTION
Skip delay of 0 wasn't working because timers don't accept a wait time of 0.
I also converted the skip_delay_timer to a more general input_block_timer. 
I also added a 0.1 second input block when text finishes naturally. This is useful as often (for short texts) you think you want to reveal the full text, but then when you click it already finished revealing and you go to the next event. Hopefully this helps prevent this, by giving a short moment to realize the text finished (as indicated by the next inidicator).