### PR TITLE
Fix for #1635 and #1593 and random selection highlighting

### DIFF
--- a/addons/dialogic/Editor/HomePage/home_page.gd
+++ b/addons/dialogic/Editor/HomePage/home_page.gd
@@ -86,11 +86,9 @@ func _on_tip_action(action:String) -> void:
 	elif action.begins_with('editor://'):
 		var editor_name := action.trim_prefix('editor://').get_slice('->',0)
 		var extra_info := action.trim_prefix('editor://').get_slice('->',1)
-		print(editors_manager.editors)
 		if editor_name in editors_manager.editors:
 			editors_manager.open_editor(editors_manager.editors[editor_name].node, false, extra_info)
 			return
-
 	print("Tip button doesn't do anything (", action, ")")
 
 
@@ -101,4 +99,9 @@ func _open(extra_info:Variant="") -> void:
 	
 	randomize()
 	var tip := tips[randi()%len(tips)]
-	show_tip(tip.get_slice(';',0).strip_edges(), tip.get_slice(';',1).strip_edges())
+	var text := tip.get_slice(';',0).strip_edges()
+	var action := tip.get_slice(';',1).strip_edges()
+	if action == text:
+		action = ""
+	show_tip(text, action)
+	

--- a/addons/dialogic/Editor/HomePage/tips.txt
+++ b/addons/dialogic/Editor/HomePage/tips.txt
@@ -3,7 +3,7 @@ You can create [b]custom modules[/b] for dialogic, including events, subsystems,
 If there are events you never need, you can hide them from the list in the editor!; editor://Settings->Modules
 Did you know that dialogic supports translations? It does!; editor://Settings->Translations
 You can use [b]bbcode effects[/b] in text events! What are they though???; https://docs.godotengine.org/en/latest/tutorials/ui/bbcode_in_richtextlabel.html
-Writing [/i][Oh hi, Hello you, Well\, well][i] in a text event will pick a random one of the three strings!
+Writing [/i]<Oh hi/Hello you/Well, well>[i] in a text event will pick a random one of the three strings!
 There are a number of cool text effects like [pause=x], [speed=x] and [portrait=x]. Try them out!; editor://Settings->DialogText
 You can use scenes as portraits! This gives you basically limiteless freedom.; https://github.com/coppolaemilio/dialogic/wiki/Tutorial:-Custom-Portraits
 You can use scenes as backgrounds. This way they can be animated or whatever you want!

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -11,6 +11,7 @@ var character_event_regex := RegEx.new()
 var shortcode_regex := RegEx.new()
 var shortcode_param_regex := RegEx.new()
 var text_effects_regex := RegEx.new()
+var text_random_word_regex := RegEx.new()
 var settings_event_regex := RegEx.new()
 
 ## Colors
@@ -73,6 +74,7 @@ func _init():
 	text_effects += "b|i|u|s|code|p|center|left|right|fill|indent|url|img|font|font_size|opentype_features|color|bg_color|fg_color|outline_size|outline_color|table|cell|ul|ol|lb|rb|br"
 	text_effects_regex.compile("(?<!\\\\)\\[\\s*/?(?<command>"+text_effects+")\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
 	character_event_regex.compile("(?<type>Join|Update|Leave)\\s*(\")?(?<name>(?(2)[^\"\\n]*|[^(: \\n]*))(?(2)\"|)(\\W*\\((?<portrait>.*)\\))?(\\s*(?<position>\\d))?(\\s*\\[(?<shortcode>.*)\\])?")
+	text_random_word_regex.compile("(?<!\\\\)\\<[^\\[\\>]+(\\/[^\\>]*)\\>")
 
 func _get_line_syntax_highlighting(line:int) -> Dictionary:
 	var str_line := get_text_edit().get_line(line)
@@ -151,12 +153,24 @@ func _get_line_syntax_highlighting(line:int) -> Dictionary:
 		dict[result.get_start('portrait')] = {"color":character_portrait_color}
 		dict[result.get_end('portrait')] = {"color":normal_color}
 	if result.get_string('text'):
-		var effects_result = text_effects_regex.search_all(str_line)
+		var effects_result := text_effects_regex.search_all(str_line)
 		for eff in effects_result:
 			dict[eff.get_start()] = {"color":text_effect_color}
 			dict[eff.get_end()] = {"color":normal_color}
 		dict = color_region(dict, variable_color, str_line, '{', '}', result.get_start('text'))
-	
+		for replace_mod_match in text_random_word_regex.search_all(result.get_string('text')):
+			var color := string_color
+			color = color.lerp(normal_color, 0.4)
+			dict[replace_mod_match.get_start()+result.get_start('text')] = {'color':string_color}
+			var offset := 1
+			for b in replace_mod_match.get_string().trim_suffix('>').trim_prefix('<').split('/'):
+				color.h = wrap(color.h+0.2, 0, 1)
+				dict[replace_mod_match.get_start()+result.get_start('text')+offset] = {'color':color}
+				offset += len(b)
+				dict[replace_mod_match.get_start()+result.get_start('text')+offset] = {'color':string_color}
+				offset += 1
+			dict[replace_mod_match.get_end()+result.get_start('text')] = {'color':normal_color}
+			
 	return dict
 
 

--- a/addons/dialogic/Modules/Text/settings_text.tscn
+++ b/addons/dialogic/Modules/Text/settings_text.tscn
@@ -173,7 +173,7 @@ bbcode_enabled = true
 text = "There are a number of useful commands you can use in text events:
 - [b][speed=x][/b] changes the speed until the next speed command or the end of the text
 - [b][br][/b] adds a line break
-- [b][Word, Other Word][/b] selects a random entry from the comma separated list. You can write \\, if one of the entry should contain a comma.
+- [b]<Word/Other Word>[/b] selects a random entry from the comma separated list. You can write // if one of the entry should contain a slash.
 - [b][portrait=sad][/b] changes the portrait of the speaker to the given portrait.
 - [b][pause=x][/b] pauses for x seconds.
 - [b][mood=sad][/b] changes the typing sound mood.

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -20,10 +20,9 @@ var text_effects := {}
 var parsed_text_effect_info : Array[Dictionary]= []
 var text_effects_regex := RegEx.new()
 var text_modifiers := []
-
 var input_handler :Node = null
 
-var autopauses := {} 
+var autopauses := {}
 
 ####################################################################################################
 ##					STATE
@@ -263,6 +262,7 @@ func collect_text_effects() -> void:
 	text_effects_regex.compile("(?<!\\\\)\\[\\s*(?<command>"+text_effect_names.trim_suffix("|")+")\\s*(=\\s*(?<value>.+?)\\s*)?\\]")
 
 
+
 ## Returns the string with all text effects removed
 ## Use get_parsed_text_effects() after calling this to get all effect information
 func parse_text_effects(text:String) -> String:
@@ -417,10 +417,10 @@ func effect_autoadvance(text_node:Control, skipped:bool, argument:String) -> voi
 		set_autoadvance(true, argument, true)
 
 
-var modifier_words_select_regex := RegEx.create_from_string("(?<!\\\\)\\[[^\\[\\]]+(\\/[^\\]]*)\\]")
+var modifier_words_select_regex := RegEx.create_from_string("(?<!\\\\)\\<[^\\[\\>]+(\\/[^\\>]*)\\>")
 func modifier_random_selection(text:String) -> String:
 	for replace_mod_match in modifier_words_select_regex.search_all(text):
-		var string :String= replace_mod_match.get_string().trim_prefix("[").trim_suffix("]")
+		var string :String= replace_mod_match.get_string().trim_prefix("<").trim_suffix(">")
 		string = string.replace('//', '<slash>')
 		var list :PackedStringArray= string.split('/')
 		var item :String= list[randi()%len(list)]


### PR DESCRIPTION
Random selection is now indicated like this <OptionA/OptionB>.

It is also highlighted in the text editor.
![grafik](https://github.com/coppolaemilio/dialogic/assets/42868150/b0f3cc10-e97a-4c02-8f9d-8cd4958b4f45)
