### PR TITLE
Rework jump+label+return system

### DIFF
--- a/addons/dialogic/Editor/Common/sidebar.gd
+++ b/addons/dialogic/Editor/Common/sidebar.gd
@@ -141,3 +141,11 @@ func update_content_list(list:PackedStringArray) -> void:
 	for i in list:
 		if i.is_empty(): continue
 		%ContentList.add_item(i)
+	if list.is_empty():
+		return
+	
+	for i in editors_manager.resource_helper.timeline_directory:
+		if editors_manager.resource_helper.timeline_directory[i] == editors_manager.get_current_editor().current_resource.resource_path:
+			editors_manager.resource_helper.label_directory[i] = list
+	editors_manager.resource_helper.label_directory[''] = list
+	DialogicUtil.set_editor_setting('label_ref', editors_manager.resource_helper.label_directory)

--- a/addons/dialogic/Editor/Events/Fields/MultilineText.gd
+++ b/addons/dialogic/Editor/Events/Fields/MultilineText.gd
@@ -10,7 +10,7 @@ func _ready() -> void:
 	text_changed.connect(_on_text_changed)
 	syntax_highlighter = load('res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd').new()
 	syntax_highlighter.mode = syntax_highlighter.Modes.TEXT_EVENT_ONLY
-	
+
 
 func _on_text_changed(value := "") -> void:
 	emit_signal("value_changed", property_name, text)

--- a/addons/dialogic/Editor/Events/Fields/MultilineText.tscn
+++ b/addons/dialogic/Editor/Events/Fields/MultilineText.tscn
@@ -13,7 +13,7 @@ corner_radius_top_right = 8
 corner_radius_bottom_right = 8
 corner_radius_bottom_left = 8
 
-[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_ivuc0"]
+[sub_resource type="SyntaxHighlighter" id="SyntaxHighlighter_6ufpd"]
 script = ExtResource("1_wj4ha")
 
 [node name="MultilineText" type="CodeEdit"]
@@ -23,7 +23,7 @@ size_flags_horizontal = 3
 size_flags_vertical = 3
 theme_override_styles/normal = SubResource("StyleBoxFlat_bofjx")
 wrap_mode = 1
-syntax_highlighter = SubResource("SyntaxHighlighter_ivuc0")
+syntax_highlighter = SubResource("SyntaxHighlighter_6ufpd")
 scroll_fit_content_height = true
 symbol_lookup_on_click = true
 delimiter_strings = Array[String]([])

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd
@@ -32,6 +32,8 @@ var string_color : Color
 
 var keyword_VAR_color : Color
 var keyword_SETTING_color : Color
+var keyword_label_color : Color
+var keyword_return_color : Color
 
 var character_event_color : Color
 var character_name_color : Color
@@ -56,13 +58,14 @@ func _init():
 		variable_color = editor_settings.get('text_editor/theme/highlighting/engine_type_color')
 		string_color = editor_settings.get('text_editor/theme/highlighting/string_color')
 
-
 		shortcode_color =  editor_settings.get('text_editor/theme/highlighting/gdscript/annotation_color')
 		shortcode_param_color = editor_settings.get('text_editor/theme/highlighting/gdscript/node_path_color')
 		shortcode_value_color = editor_settings.get('text_editor/theme/highlighting/gdscript/node_reference_color')
 
 		keyword_VAR_color = editor_settings.get('text_editor/theme/highlighting/keyword_color')
 		keyword_SETTING_color = editor_settings.get('text_editor/theme/highlighting/member_variable_color')
+		keyword_label_color = editor_settings.get("text_editor/theme/highlighting/engine_type_color")
+		keyword_return_color = editor_settings.get("text_editor/theme/highlighting/brace_mismatch_color")
 		
 		character_event_color = editor_settings.get('text_editor/theme/highlighting/symbol_color')
 		character_name_color = editor_settings.get('text_editor/theme/highlighting/executing_line_color')
@@ -110,6 +113,7 @@ func _get_line_syntax_highlighting(line:int) -> Dictionary:
 				dict[str_line.find('[')] = {"color":normal_color}
 				dict = color_word(dict, code_flow_color, str_line, 'if', str_line.find('['), str_line.find(']'))
 				dict = color_condition(dict, str_line, str_line.find('['), str_line.find(']'))
+				dict = color_shortcode_content(dict, str_line, str_line.find(']'))
 			return fix_dict(dict)
 		
 		for word in ['if', 'elif', 'else']:
@@ -140,6 +144,20 @@ func _get_line_syntax_highlighting(line:int) -> Dictionary:
 			dict = color_region(dict, string_color, str_line, '"', '"', str_line.find('VAR'))
 			dict = color_region(dict, variable_color, str_line, '{', '}', str_line.find('VAR'))
 			return fix_dict(dict)
+		
+		if str_line.strip_edges().begins_with('label'):
+			dict[str_line.find('label')] = {"color":keyword_label_color}
+			dict[str_line.find('label')+5] = {"color":string_color}
+		
+		if str_line.strip_edges().begins_with('return'):
+			dict[str_line.find('return')] = {"color":keyword_return_color}
+			dict[str_line.find('return')+6] = {"color":string_color}
+		
+		
+		if str_line.strip_edges().begins_with('jump'):
+			dict[str_line.find('jump')] = {"color":keyword_label_color}
+			dict[str_line.find('jump')+4] = {"color":string_color}
+		
 		
 		if str_line.strip_edges().begins_with('Setting'):
 			dict[str_line.find('Setting')] = {"color":keyword_SETTING_color}
@@ -193,17 +211,17 @@ func fix_dict(dict:Dictionary) -> Dictionary:
 
 
 func color_condition(dict:Dictionary, line:String, from:int = 0, to:int = 0) -> Dictionary:
-	dict = color_region(dict, variable_color, line, '{', '}', from, to)
-	dict = color_region(dict, string_color, line, '"', '"', from, to)
-	
 	dict = color_word(dict, code_flow_color, line, 'or',  from, to)
 	dict = color_word(dict, code_flow_color, line, 'and', from, to)
 	dict = color_word(dict, code_flow_color, line, '==',  from, to)
 	dict = color_word(dict, code_flow_color, line, '!=',  from, to)
-	dict = color_word(dict, code_flow_color, line, '>',   from, to)
-	dict = color_word(dict, code_flow_color, line, '<',   from, to)
 	dict = color_word(dict, code_flow_color, line, '>=',  from, to)
 	dict = color_word(dict, code_flow_color, line, '<=',  from, to)
+	dict = color_word(dict, code_flow_color, line, '> ',   from, to)
+	dict = color_word(dict, code_flow_color, line, '< ',   from, to)
+	dict = color_region(dict, variable_color, line, '{', '}', from, to)
+	dict = color_region(dict, string_color, line, '"', '"', from, to)
+	
 	
 	return dict
 

--- a/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
+++ b/addons/dialogic/Editor/TimelineEditor/TextEditor/timeline_editor_text.gd
@@ -5,7 +5,7 @@ extends CodeEdit
 
 @onready var timeline_editor := get_parent().get_parent()
 
-var label_regex := RegEx.create_from_string('\\[label *name ?= ?"(?<name>.+)"')
+var label_regex := RegEx.create_from_string('label +(?<name>\\w+)')
 
 func _ready():
 	syntax_highlighter = load("res://addons/dialogic/Editor/TimelineEditor/TextEditor/syntax_highlighter.gd").new()

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -165,7 +165,7 @@ func _ready():
 
 func _on_content_item_clicked(label:String) -> void:
 	if label == "~ Top":
-		scroll_to_piece(0)
+		%TimelineArea.scroll_vertical = 0
 		return
 	
 	for event in %Timeline.get_children():

--- a/addons/dialogic/Editor/directory_holder.gd
+++ b/addons/dialogic/Editor/directory_holder.gd
@@ -9,11 +9,17 @@ var dialogic_handler: Node
 var event_script_cache: Array[DialogicEvent] = []
 var character_directory: Dictionary = {}
 var timeline_directory: Dictionary = {}
+var label_directory :Dictionary = {}:
+	set(value):
+		label_directory = value
+		Engine.get_main_loop().set_meta("dialogic_label_directory", value)
+
 
 
 func _ready() -> void:
 	if owner.get_parent() is SubViewport:
 		return
+	
 	## DIRECTORIES SETUP
 	#initialize DGH, and set the local variables to references of the DGH ones
 	#since we're not actually adding it to the event node, we have to manually run the commands to build the cache's
@@ -21,6 +27,10 @@ func _ready() -> void:
 	rebuild_character_directory()
 	rebuild_timeline_directory()
 	rebuild_event_script_cache()
+	label_directory = DialogicUtil.get_editor_setting('label_ref', {})
+	for i in label_directory:
+		if !i in timeline_directory:
+			label_directory.erase(i)
 	
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_file_system_dock().files_moved.connect(_on_file_moved)
 

--- a/addons/dialogic/Modules/Jump/event_label.gd
+++ b/addons/dialogic/Modules/Jump/event_label.gd
@@ -16,7 +16,7 @@ var name: String = ""
 ################################################################################
 
 func _execute() -> void:
-	# This event is mainly implemented in the DialogicGameHandlers jump_to_label() method.
+	# This event is mainly implemented in the Jump subsystem.
 	finish()
 
 
@@ -39,11 +39,24 @@ func _get_icon() -> Resource:
 ################################################################################
 ## 						SAVING/LOADING
 ################################################################################
+func to_text() -> String:
+	return "label "+name
 
-func get_shortcode() -> String:
-	return "label"
+
+func from_text(string:String) -> void:
+	var regex = RegEx.create_from_string('label +(?<name>.+)')
+	var result := regex.search(string.strip_edges())
+	name = result.get_string('name')
 
 
+func is_valid_event(string:String) -> bool:
+	if string.strip_edges().begins_with("label "):
+		return true
+	return false
+
+
+# this is only here to provide a list of default values
+# this way the module manager can add custom default overrides to this event.
 func get_shortcode_parameters() -> Dictionary:
 	return {
 		#param_name 	: property_info

--- a/addons/dialogic/Modules/Jump/event_return.gd
+++ b/addons/dialogic/Modules/Jump/event_return.gd
@@ -11,7 +11,10 @@ extends DialogicEvent
 ################################################################################
 
 func _execute() -> void:
-	Dialogic.Jump.resume_from_last_jump()
+	if !dialogic.Jump.is_jump_stack_empty():
+		dialogic.Jump.resume_from_last_jump()
+	else:
+		dialogic.end_timeline()
 
 
 ################################################################################

--- a/addons/dialogic/Modules/Jump/event_return.gd
+++ b/addons/dialogic/Modules/Jump/event_return.gd
@@ -1,0 +1,47 @@
+@tool
+class_name DialogicReturnEvent
+extends DialogicEvent
+
+## Event that will make dialogic jump back to the last jump point.
+
+
+
+################################################################################
+## 						EXECUTION
+################################################################################
+
+func _execute() -> void:
+	Dialogic.Jump.resume_from_last_jump()
+
+
+################################################################################
+## 						INITIALIZE
+################################################################################
+
+func _init() -> void:
+	event_name = "Return"
+	set_default_color('Color3')
+	event_category = "Timeline"
+	event_sorting_index = 0
+	expand_by_default = false
+
+
+func _get_icon() -> Resource:
+	return load(self.get_script().get_path().get_base_dir().path_join('icon_jump.png'))
+
+
+################################################################################
+## 						SAVING/LOADING
+################################################################################
+func to_text() -> String:
+	return "return"
+
+
+func from_text(string:String) -> void:
+	pass
+
+
+func is_valid_event(string:String) -> bool:
+	if string.strip_edges() == "return":
+		return true
+	return false

--- a/addons/dialogic/Modules/Jump/index.gd
+++ b/addons/dialogic/Modules/Jump/index.gd
@@ -3,7 +3,7 @@ extends DialogicIndexer
 
 
 func _get_events() -> Array:
-	return [this_folder.path_join('event_jump.gd'), this_folder.path_join('event_label.gd')]
+	return [this_folder.path_join('event_jump.gd'), this_folder.path_join('event_label.gd'), this_folder.path_join('event_return.gd')]
 
 func _get_subsystems() -> Array:
 	return [{'name':'Jump', 'script':this_folder.path_join('subsystem_jump.gd')}]

--- a/addons/dialogic/Modules/Jump/subsystem_jump.gd
+++ b/addons/dialogic/Modules/Jump/subsystem_jump.gd
@@ -50,7 +50,7 @@ func resume_from_last_jump() -> void:
 		dialogic.current_state_info['jump_stack'][-1].timeline, 
 		dialogic.current_state_info['jump_stack'][-1].index+1)
 	dialogic.current_state_info['jump_stack'].pop_back()
-	returned_from_jump.emit({'sub_timeline':sub_timeline, 'label':dialogic.current_timeline.get_event(dialogic.current_event_idx-1).name})
+	returned_from_jump.emit({'sub_timeline':sub_timeline, 'label':dialogic.current_timeline.get_event(dialogic.current_event_idx-1).label_name})
 
 
 func is_jump_stack_empty():

--- a/addons/dialogic/Resources/timeline.gd
+++ b/addons/dialogic/Resources/timeline.gd
@@ -33,12 +33,14 @@ func _set(property, value):
 
 	return false
 
+
 func _get(property):
 	if str(property).begins_with("event/"):
 		var event_idx:int = str(property).split("/", true, 2)[1].to_int()
 		if event_idx < len(events):
 			return events[event_idx]
 			return true
+
 
 func _init() -> void:
 	events = []


### PR DESCRIPTION
This changes the syntax for jump & label and introduces the new return event.

New syntax:

```
label MyLabel

# jump to a label
jump MyLabel

# jump to a timeline start
jump SomeTimeline/ 

# jump to a label in a timeline
jump SomeTimeline/SomeLabel

# return to the last jump and continue from there
return
```

The best thing is probably that it brings autocompletion back for labels... YES!