### PR TITLE
Make custom animations part of the module system

### DIFF
--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -431,32 +431,27 @@ func get_animation_suggestions(search_text:String) -> Dictionary:
 		Actions.UPDATE:
 			suggestions['None'] = {'value':"", 'editor_icon':["GuiRadioUnchecked", "EditorIcons"]}
 	
-	for anim in list_animations():
-		match action:
-			Actions.JOIN:
-				if '_in' in anim.get_file():
-					suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
-			Actions.LEAVE:
-				if '_out' in anim.get_file():
-					suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
-			Actions.UPDATE:
-				if not ('_in' in anim.get_file() or '_out' in anim.get_file()):
-					suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
-					continue
+	
+	match action:
+		Actions.JOIN:
+			for anim in DialogicUtil.get_portrait_animation_scripts(DialogicUtil.AnimationType.IN):
+				suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
+		Actions.LEAVE:
+			for anim in DialogicUtil.get_portrait_animation_scripts(DialogicUtil.AnimationType.OUT):
+				suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
+		Actions.UPDATE:
+			for anim in DialogicUtil.get_portrait_animation_scripts(DialogicUtil.AnimationType.ACTION):
+				suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
+
 	return suggestions
 
 
-func list_animations() -> Array:
-	var list := DialogicUtil.listdir(get_script().resource_path.get_base_dir().path_join('DefaultAnimations'), true, false, true)
-	list.append_array(DialogicUtil.listdir(ProjectSettings.get_setting('dialogic/animations/custom_folder', 'res://addons/dialogic_additions/Animations'), true, false, true))
-	return list
-
-
 func guess_animation_file(animation_name: String) -> String:
-	for file in list_animations():
+	for file in DialogicUtil.get_portrait_animation_scripts():
 		if DialogicUtil.pretty_name(animation_name) == DialogicUtil.pretty_name(file):
 			return file
 	return animation_name
+
 
 func _on_character_edit_pressed() -> void:
 	var editor_manager := _editor_node.find_parent('EditorsManager')

--- a/addons/dialogic/Modules/Character/index.gd
+++ b/addons/dialogic/Modules/Character/index.gd
@@ -15,3 +15,7 @@ func _get_settings_pages() -> Array:
 
 func _get_text_effects() -> Array[Dictionary]:
 	return [{'command':'portrait', 'subsystem':'Portraits', 'method':'text_effect_portrait'}]
+
+
+func _get_portrait_animations() -> Array:
+	return list_dir('DefaultAnimations')

--- a/addons/dialogic/Modules/Character/settings_portraits.gd
+++ b/addons/dialogic/Modules/Character/settings_portraits.gd
@@ -1,20 +1,15 @@
 @tool
 extends DialogicSettingsPage
 
-var current_animation_path := ""
 
 func _ready():
 	%JoinDefault.get_suggestions_func = get_join_animation_suggestions
 	%JoinDefault.enable_pretty_name = true
 	%LeaveDefault.get_suggestions_func = get_leave_animation_suggestions
 	%LeaveDefault.enable_pretty_name = true
-	%CustomAnimationsFolder.value_changed.connect(custom_anims_folder_selected)
 
 
 func _refresh():
-	%CustomAnimationsFolder.resource_icon = get_theme_icon("Folder", "EditorIcons")
-	%CustomAnimationsFolder.set_value(ProjectSettings.get_setting('dialogic/animations/custom_folder', 'res://addons/dialogic_additions/Animations'))
-	
 	%JoinDefault.resource_icon = get_theme_icon("Animation", "EditorIcons")
 	%LeaveDefault.resource_icon = get_theme_icon("Animation", "EditorIcons")
 	%JoinDefault.set_value(DialogicUtil.pretty_name(ProjectSettings.get_setting('dialogic/animations/join_default', 
@@ -73,7 +68,3 @@ func list_animations() -> Array:
 	var list = DialogicUtil.listdir(get_script().resource_path.get_base_dir().path_join('DefaultAnimations'), true, false, true)
 	list.append_array(DialogicUtil.listdir(ProjectSettings.get_setting('dialogic/animations/custom_folder', 'res://addons/dialogic_additions/Animations'), true, false, true))
 	return list
-
-func custom_anims_folder_selected(setting:String, path:String):
-	ProjectSettings.set_setting('dialogic/animations/custom_folder', path)
-	ProjectSettings.save()

--- a/addons/dialogic/Modules/Character/settings_portraits.tscn
+++ b/addons/dialogic/Modules/Character/settings_portraits.tscn
@@ -1,11 +1,10 @@
-[gd_scene load_steps=8 format=3 uid="uid://cp463rpri5j8a"]
+[gd_scene load_steps=6 format=3 uid="uid://cp463rpri5j8a"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Character/settings_portraits.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_dce78"]
 [ext_resource type="PackedScene" uid="uid://dpwhshre1n4t6" path="res://addons/dialogic/Editor/Events/Fields/ComplexPicker.tscn" id="3"]
-[ext_resource type="PackedScene" uid="uid://7mvxuaulctcq" path="res://addons/dialogic/Editor/Events/Fields/FilePicker.tscn" id="4_mdfuu"]
 
-[sub_resource type="Image" id="Image_2imc3"]
+[sub_resource type="Image" id="Image_wuu7a"]
 data = {
 "data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
 "format": "RGBA8",
@@ -14,62 +13,14 @@ data = {
 "width": 16
 }
 
-[sub_resource type="ImageTexture" id="ImageTexture_udy8i"]
-image = SubResource("Image_2imc3")
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1d6cs"]
-content_margin_left = 4.0
-content_margin_top = 0.0
-content_margin_right = 4.0
-content_margin_bottom = 0.0
-bg_color = Color(0.1, 0.1, 0.1, 0.6)
-border_width_bottom = 2
-border_color = Color(0, 0, 0, 0.6)
-corner_radius_top_left = 3
-corner_radius_top_right = 3
-corner_radius_bottom_right = 3
-corner_radius_bottom_left = 3
-corner_detail = 5
+[sub_resource type="ImageTexture" id="ImageTexture_hg5vp"]
+image = SubResource("Image_wuu7a")
 
 [node name="Portraits" type="VBoxContainer"]
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource("2")
-
-[node name="Animations" type="HBoxContainer" parent="."]
-layout_mode = 2
-size_flags_horizontal = 3
-size_flags_stretch_ratio = 0.5
-
-[node name="Title" type="Label" parent="Animations"]
-layout_mode = 2
-theme_type_variation = &"DialogicSettingsSection"
-text = "Custom Animations
-"
-
-[node name="HintTooltip" parent="Animations" instance=ExtResource("2_dce78")]
-layout_mode = 2
-tooltip_text = "Set where dialogic will look for custom animations."
-texture = SubResource("ImageTexture_udy8i")
-hint_text = "Set where dialogic will look for custom animations."
-
-[node name="HBoxContainer" type="HBoxContainer" parent="."]
-layout_mode = 2
-
-[node name="Label2" type="Label" parent="HBoxContainer"]
-layout_mode = 2
-text = "Custom animations folder"
-
-[node name="CustomAnimationsFolder" parent="HBoxContainer" instance=ExtResource("4_mdfuu")]
-unique_name_in_owner = true
-layout_mode = 2
-size_flags_horizontal = 3
-theme_override_styles/panel = SubResource("StyleBoxFlat_1d6cs")
-file_mode = 2
-
-[node name="HSeparator" type="HSeparator" parent="."]
-layout_mode = 2
 
 [node name="Animations2" type="HBoxContainer" parent="."]
 layout_mode = 2
@@ -85,7 +36,7 @@ text = "Default Animations
 [node name="HintTooltip" parent="Animations2" instance=ExtResource("2_dce78")]
 layout_mode = 2
 tooltip_text = "These settings are used for Leave and Join events if no animation is selected."
-texture = SubResource("ImageTexture_udy8i")
+texture = SubResource("ImageTexture_hg5vp")
 hint_text = "These settings are used for Leave and Join events if no animation is selected."
 
 [node name="GridContainer" type="GridContainer" parent="."]

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -5,6 +5,8 @@ class_name DialogicUtil
 ## Used whenever the same thing is needed in different parts of the plugin.
  
 
+enum AnimationType {ALL, IN, OUT, ACTION}
+
 ################################################################################
 ##					EDITOR
 ################################################################################
@@ -104,6 +106,23 @@ static func get_indexers(include_custom := true, force_reload := false) -> Array
 	
 	Engine.get_main_loop().set_meta('dialogic_indexers', indexers)
 	return indexers
+
+
+static func get_portrait_animation_scripts(type:=AnimationType.ALL, include_custom:=true) -> Array:
+	var animations := []
+	if Engine.get_main_loop().has_meta('dialogic_animation_names'):
+		animations = Engine.get_main_loop().get_meta('dialogic_animation_names')
+	else:
+		for i in get_indexers():
+			animations.append_array(i._get_portrait_animations())
+		Engine.get_main_loop().set_meta('dialogic_animation_names', animations)
+
+	return animations.filter(
+		func(script):
+			if type == AnimationType.ALL: return true;
+			if type == AnimationType.IN: return '_in' in script;
+			if type == AnimationType.OUT: return '_out' in script;
+			if type == AnimationType.ACTION: return not ('_in' in script or '_out' in script))
 
 
 static func pretty_name(script:String) -> String:

--- a/addons/dialogic/Other/index_class.gd
+++ b/addons/dialogic/Other/index_class.gd
@@ -57,6 +57,15 @@ func _get_text_modifiers() -> Array[Dictionary]:
 	return []
 
 
+## Should return array of animation scripts.
+func _get_portrait_animations() -> Array:
+	return []
+
+
+func list_dir(subdir:='') -> Array:
+	return Array(DirAccess.get_files_at(this_folder.path_join(subdir))).map(func(file):return this_folder.path_join(subdir).path_join(file))
+
+
 ## Helper that allows scanning sub directories that might be styles
 func scan_for_layouts() -> Array[Dictionary]:
 	var dir := DirAccess.open(this_folder)


### PR DESCRIPTION
This removes the "Custom Animations Folder" setting and will instead allow animations to be added by modules. This should allow animation packs being distributed the same way as other modules.