### PR TITLE
Fixed variables hyphen symbol issue #1634

### DIFF
--- a/addons/dialogic/Modules/Variable/variables_editor/variable_field.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variable_field.gd
@@ -91,6 +91,8 @@ func _on_NameEdit_focus_exited() -> void:
 
 func _on_name_edit_text_submitted(new_text:String) -> void:
 	%NameEdit.text = new_text.replace(' ', '_')
+	%NameEdit.text = %NameEdit.text.replace('-', '_')
+
 	if %NameEdit.text != previous_name and !actually_new:
 		if parent_Group.get_group_path().is_empty():
 			variables_editor.variable_renamed(previous_name, %NameEdit.text)

--- a/addons/dialogic/Modules/Variable/variables_editor/variable_group.gd
+++ b/addons/dialogic/Modules/Variable/variables_editor/variable_group.gd
@@ -289,6 +289,8 @@ func _on_NameEdit_focus_exited() -> void:
 
 func disable_name_edit() -> void:
 	%NameEdit.text = %NameEdit.text.replace(' ', '_')
+	%NameEdit.text = %NameEdit.text.replace('-', '_')
+
 	if get_group_path() != previous_path and !actually_new:
 		variables_editor.group_renamed(previous_path, get_group_path(), get_data())
 		previous_path = get_group_path()


### PR DESCRIPTION
Now variable groups and fields autocorrect hyphens in it's name by changing them to underscores as they did with spaces.