### PR TITLE
Fixed ERR_INVALID_PARAMETER in animation.gd

### DIFF
--- a/addons/dialogic/Modules/DefaultStyles/Default/animations.gd
+++ b/addons/dialogic/Modules/DefaultStyles/Default/animations.gd
@@ -13,16 +13,19 @@ func _on_textbox_show():
 	%DialogicNode_DialogText.text = ""
 	get_node("../DialogTextAnimationParent").modulate = Color.TRANSPARENT
 	play("text_box_reveal")
-	animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)
+	if not animation_finished.is_connected(Dialogic.Animation.animation_finished):
+		animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)
 
 
 func _on_textbox_hide():
 	Dialogic.Animation.start_animating()
 	play_backwards("text_box_reveal")
-	animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)
+	if not animation_finished.is_connected(Dialogic.Animation.animation_finished):
+		animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)
 
 
 func _on_textbox_new_text():
 	Dialogic.Animation.start_animating()
 	play("new_text")
-	animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)
+	if not animation_finished.is_connected(Dialogic.Animation.animation_finished):
+		animation_finished.connect(Dialogic.Animation.animation_finished, CONNECT_ONE_SHOT)


### PR DESCRIPTION
Fixed an error in `animation.gd`.

## Problem

* If `animation_finished` signal is already connected to `Dialogic.Animation.animation_finished`, it will cause this error  [@GlobalScope.ERR_INVALID_PARAMETER](https://docs.godotengine.org/en/stable/classes/class_%40globalscope.html#class-globalscope-constant-err-invalid-parameter)
<img width="958" alt="image" src="https://github.com/coppolaemilio/dialogic/assets/4829591/3b526a23-d464-49c4-86d7-94e21bf22467">


## Solution

* According to [Signal](https://docs.godotengine.org/en/stable/classes/class_signal.html#class-signal-method-connect) docs, use [is_connected](https://docs.godotengine.org/en/stable/classes/class_signal.html#class-signal-method-is-connected) first to check for existing connections.