### PR TITLE
Remove fit_content_height from Description TextEdit to prevent crash

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.tscn
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_section_general.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=2 format=3 uid="uid://bnkck3hocbkk5"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Editor/CharacterEditor/char_edit_section_general.gd" id="1_3e1i1"]
 
@@ -62,8 +62,8 @@ text = "Description:"
 
 [node name="DescriptionTextEdit" type="TextEdit" parent="."]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 65)
 layout_mode = 2
 size_flags_horizontal = 3
 tooltip_text = "No effect, just for you."
 wrap_mode = 1
-scroll_fit_content_height = true

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -191,7 +191,7 @@ func _on_section_button_pressed(button:Button) -> void:
 func something_changed(fake_argument = "", fake_arg2 = null) -> void:
 	if not loading:
 		current_resource_state = ResourceStates.UNSAVED
-		editors_manager.save_current_resource() #TODO, should this happen?
+
 
 
 ##############################################################################
@@ -200,7 +200,6 @@ func something_changed(fake_argument = "", fake_arg2 = null) -> void:
 
 func setup_portrait_list_tab() -> void:
 	%PortraitTree.editor = self
-	
 	
 	## Portrait section styling/connections
 	%AddPortraitButton.icon = get_theme_icon("Add", "EditorIcons")


### PR DESCRIPTION
Also removes constant saving of character resources.