### PR TITLE
Fix input event handling

### DIFF
--- a/addons/dialogic/Modules/LayoutEditor/Components/StyleItem.gd
+++ b/addons/dialogic/Modules/LayoutEditor/Components/StyleItem.gd
@@ -35,7 +35,7 @@ func set_scene_preview(path:String, preview:Texture2D, thumbnail:Texture2D, user
 		%Image.texture = preview
 	else:
 		%Image.texture = get_theme_icon("PackedScene", "EditorIcons")
-	
+
 
 
 func set_current(current:bool):
@@ -51,7 +51,7 @@ func _on_mouse_exited():
 
 
 func _on_gui_input(event):
-	if Input.is_action_just_pressed('ui_accept') or Input.is_action_just_pressed("ui_select") or (
+	if event.is_action_pressed('ui_accept') or event.is_action_pressed("ui_select") or (
 				event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT):
 		clicked.emit()
 	elif event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_MIDDLE:

--- a/addons/dialogic/Modules/Text/default_input_handler.gd
+++ b/addons/dialogic/Modules/Text/default_input_handler.gd
@@ -11,22 +11,22 @@ var skip_delay :float = ProjectSettings.get_setting('dialogic/text/skippable_del
 ## 						INPUT
 ################################################################################
 func _input(event:InputEvent) -> void:
-	if Input.is_action_just_pressed(ProjectSettings.get_setting('dialogic/text/input_action', 'dialogic_default_action')):
+	if event.is_action_pressed(ProjectSettings.get_setting('dialogic/text/input_action', 'dialogic_default_action')):
 		if Dialogic.paused:
 			return
-		
+
 		if is_input_blocked():
 			return
-		
+
 		if Dialogic.current_state == Dialogic.States.IDLE and Dialogic.Text.can_manual_advance():
 			Dialogic.handle_next_event()
 			autoadvance_timer.stop()
 			block_input(skip_delay)
-		
+
 		elif Dialogic.current_state == Dialogic.States.SHOWING_TEXT and Dialogic.Text.can_skip():
 			Dialogic.Text.skip_text_animation()
 			block_input(skip_delay)
-		
+
 		dialogic_action.emit()
 
 
@@ -49,7 +49,7 @@ func _ready() -> void:
 	add_child(autoadvance_timer)
 	autoadvance_timer.one_shot = true
 	autoadvance_timer.timeout.connect(_on_autoadvance_timer_timeout)
-	
+
 	add_child(input_block_timer)
 	input_block_timer.one_shot = true
 


### PR DESCRIPTION
this somewhat fixes a particular bug I've experienced in text handling, in which as far as i can tell:
 - the user triggers `dialogic_default_action` on the same frame they also trigger another input action (say, moving the mouse)
 - `_input` is called for the `dialog_default_action`, `dialogic_default_action` has been pressed this frame, so the coroutine to advance text (`handle_event`) starts
 - `_input` is called for the other action, `dialogic_default_action` has been pressed this frame, so the coroutine to advance text starts again
 - the coroutines resolve, text is advanced twice, and a line gets skipped

i believe this PR fixes the input situation, but the race condition still probably exists. i don't understand how godot godot coroutines work well enough to tell if it's actually an issue, though.