### PR TITLE
Fix regex for expressions with two variables

### DIFF
--- a/addons/dialogic/Modules/Core/subsystem_expression.gd
+++ b/addons/dialogic/Modules/Core/subsystem_expression.gd
@@ -16,7 +16,7 @@ func execute_string(string:String, default = null) -> Variant:
 	string = string.replace('len(', 'd_len(')
 	
 	
-	var regex: RegEx = RegEx.create_from_string('{(\\w.*)}')
+	var regex: RegEx = RegEx.create_from_string('{([^{}]*)}')
 	
 	for res in regex.search_all(string):
 		var value: String = str(dialogic.VAR.get_variable(res.get_string()))


### PR DESCRIPTION
Found by (@)siberius on discord. A simple regex failure.