### PR TITLE
Invalid operands 'Object' and 'String' in operator '!=' fix.

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -540,7 +540,7 @@ func change_speaker(speaker:DialogicCharacter= null, portrait:= ""):
 		
 		_change_portrait_mirror(con.get_child(0))
 	
-	if speaker != dialogic.current_state_info['character']:
+	if speaker.to_string() != dialogic.current_state_info['character']:
 		if dialogic.current_state_info['character'] and is_character_joined(load(dialogic.current_state_info['character'])):
 			dialogic.current_state_info['portraits'][dialogic.current_state_info['character']].node.get_child(0)._unhighlight()
 		if speaker and is_character_joined(speaker):


### PR DESCRIPTION
The line "Aracelia: foo" followed by "James: bar" would cause the error to occur and Godot to hit a breakpoint.

By converting the speaker value to a string, the error goes away and Dialogic proceeds as normal.