### PR TITLE
Small fixes / improvements to portrait system

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_general.gd
+++ b/addons/dialogic/Editor/Settings/settings_general.gd
@@ -79,7 +79,7 @@ func _on_section_list_button_clicked(item:TreeItem, column, id, mouse_button_ind
 
 
 func force_event_button_list_reload() -> void:
-	find_parent('EditorsManager').editors['Timeline'].node.get_node('VisualEditor').load_event_buttons()
+	find_parent('EditorsManager').editors['Timeline'].node.get_node('%VisualEditor').load_event_buttons()
 
 
 func update_color_palette() -> void:

--- a/addons/dialogic/Modules/Character/event_character.gd
+++ b/addons/dialogic/Modules/Character/event_character.gd
@@ -261,7 +261,7 @@ func from_text(string:String) -> void:
 		animation_name = shortcode_params.get('animation', '')
 		if animation_name != "":
 			if !animation_name.ends_with('.gd'):
-				animation_name = guess_animation_file(animation_name)
+				animation_name = DialogicUtil.guess_animation_file(animation_name)
 			if !animation_name.ends_with('.gd'):
 				printerr("[Dialogic] Couldn't identify animation '"+animation_name+"'.")
 				animation_name = ""
@@ -457,13 +457,6 @@ func get_animation_suggestions(search_text:String) -> Dictionary:
 				suggestions[DialogicUtil.pretty_name(anim)] = {'value':anim, 'editor_icon':["Animation", "EditorIcons"]}
 
 	return suggestions
-
-
-func guess_animation_file(animation_name: String) -> String:
-	for file in DialogicUtil.get_portrait_animation_scripts():
-		if DialogicUtil.pretty_name(animation_name) == DialogicUtil.pretty_name(file):
-			return file
-	return animation_name
 
 
 func _on_character_edit_pressed() -> void:

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -157,7 +157,7 @@ func _update_portrait_transform(character_node:Node2D, time:float = 0.0) -> void
 	var apply_character_scale :bool= !portrait_info.get('ignore_char_scale', false)
 	var transform :Rect2 = character_node.get_parent().get_local_portrait_transform(
 		portrait_node._get_covered_rect(),
-		(character.scale * portrait_info.get('scale', 1))*int(apply_character_scale)+portrait_info.get('scale')*int(!apply_character_scale))
+		(character.scale * portrait_info.get('scale', 1))*int(apply_character_scale)+portrait_info.get('scale', 1)*int(!apply_character_scale))
 	
 	var tween : Tween
 	if character_node.has_meta('move_tween'):
@@ -459,6 +459,13 @@ func get_character_info(character:DialogicCharacter) -> Dictionary:
 
 ################### Positions  #####################################################################
 ####################################################################################################
+
+func get_portrait_container(postion_index:int) -> DialogicNode_PortraitContainer:
+	for portrait_position in get_tree().get_nodes_in_group('dialogic_portrait_con_position'):
+		if portrait_position.is_visible_in_tree() and portrait_position.position_index == postion_index:
+			return portrait_position
+	return null
+
 
 ## Creates a new portrait container node. 
 ## It will copy it's size and most settings from the first p_container in the tree. 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -110,6 +110,12 @@ static func get_indexers(include_custom := true, force_reload := false) -> Array
 	return indexers
 
 
+static func guess_animation_file(animation_name: String) -> String:
+	for file in DialogicUtil.get_portrait_animation_scripts():
+		if DialogicUtil.pretty_name(animation_name) == DialogicUtil.pretty_name(file):
+			return file
+	return animation_name
+
 static func get_portrait_animation_scripts(type:=AnimationType.ALL, include_custom:=true) -> Array:
 	var animations := []
 	if Engine.get_main_loop().has_meta('dialogic_animation_names'):

--- a/addons/dialogic/Resources/character.gd
+++ b/addons/dialogic/Resources/character.gd
@@ -30,7 +30,12 @@ func _hide_script_from_inspector() -> bool:
 
 ## Returns the name of the file (without the extension).
 func get_character_name() -> String:
-	return resource_path.get_file().trim_suffix('.dch')
+	if !resource_path.is_empty():
+		return resource_path.get_file().trim_suffix('.dch')
+	elif !display_name.is_empty():
+		return display_name.validate_node_name()
+	else:
+		return "UnnamedCharacter"
 
 ## Returns the info of the given portrait.
 ## Uses the default portrait if the given portrait doesn't exist.


### PR DESCRIPTION
- make runtime characters possible by removing need for resource_path
- move `guess_animation_file` to DialogicUtil
- remove need for scale property on portrait info (fixed get() statement)
- add a get_portrait_container(idx) method to portrait subsystem

Also
- fix bad reference to visual editor in settings general
