### PR TITLE
Allow spaces in jump's Label and Timeline regex

### DIFF
--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -74,7 +74,7 @@ func to_text() -> String:
 
 
 func from_text(string:String) -> void:
-	var result := RegEx.create_from_string('jump (?<timeline>\\w*\\/)?(?<label>\\w*)?').search(string.strip_edges())
+	var result := RegEx.create_from_string('jump (?<timeline>.*\\/)?(?<label>.*)?').search(string.strip_edges())
 	if result:
 		_timeline_file = result.get_string('timeline').trim_suffix('/')
 		label_name = result.get_string('label')


### PR DESCRIPTION
Previously jumps to labels with spaces in them would just do nothing.