### PR TITLE
Change file exists method for CharacterResource

### DIFF
--- a/addons/dialogic/Resources/CharacterResourceLoader.gd
+++ b/addons/dialogic/Resources/CharacterResourceLoader.gd
@@ -27,7 +27,7 @@ func _handles_type(typename: StringName) -> bool:
 # parse the file and return a resource
 func _load(path: String, original_path: String, use_sub_threads: bool, cache_mode: int):
 #	print('[Dialogic] Reimporting character "' , path, '"')
-	if FileAccess.file_exists(path):
+	if ResourceLoader.exists(path):
 		var file = FileAccess.open(path, FileAccess.READ)
 		return dict_to_inst(str_to_var(file.get_as_text()))
 	else:


### PR DESCRIPTION
If using FileAccess.file_exists(), I can't load character portrait in HTML game. This is the same issue in #90 and fixed in PR #91. It seem like the fix not carried over to Dialogic 2.0.