### PR TITLE
Add a separate install step after adding all subsystems

### DIFF
--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -461,6 +461,8 @@ func _ready():
 	input_handler.set_script(load(get_script().resource_path.get_base_dir().path_join('default_input_handler.gd')))
 	add_child(input_handler)
 
+
+func install():
 	Dialogic.Settings.connect_to_change('text_speed', _update_user_speed)
 	Dialogic.Settings.connect_to_change('autoadvance_delay_modifier', _update_autoadvance_delay_modifier)
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -462,7 +462,7 @@ func _ready():
 	add_child(input_handler)
 
 
-func install():
+func post_install():
 	Dialogic.Settings.connect_to_change('text_speed', _update_user_speed)
 	Dialogic.Settings.connect_to_change('autoadvance_delay_modifier', _update_autoadvance_delay_modifier)
 

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -206,7 +206,7 @@ func collect_subsystems() -> void:
 				subsystem_nodes.push_back(node)
 
 	for subsystem in subsystem_nodes:
-		subsystem.install()
+		subsystem.post_install()
 	
 	# Events are checked in order while testing them. EndBranch needs to be first, Text needs to be last
 	_event_script_cache.push_front(DialogicEndBranchEvent.new())

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -202,7 +202,7 @@ func collect_subsystems() -> void:
 		if !Engine.is_editor_hint():
 			
 			for subsystem in indexer._get_subsystems():
-				var subsystem_node := add_subsytsem(subsystem.name, subsystem.script) as DialogicSubsystem
+				var subsystem_node := add_subsystem(subsystem.name, subsystem.script) as DialogicSubsystem
 				if subsystem_node:
 					subsystem_nodes.push_back(subsystem_node)
 
@@ -223,7 +223,7 @@ func get_subsystem(_name:String) -> Variant:
 	return get_node(_name)
 
 
-func add_subsytsem(_name:String, _script_path:String) -> Node:
+func add_subsystem(_name:String, _script_path:String) -> Node:
 	var node:Node = Node.new()
 	node.name = _name
 	node.set_script(load(_script_path))

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -202,8 +202,9 @@ func collect_subsystems() -> void:
 		if !Engine.is_editor_hint():
 			
 			for subsystem in indexer._get_subsystems():
-				var node = add_subsytsem(subsystem.name, subsystem.script)
-				subsystem_nodes.push_back(node)
+				var subsystem_node := add_subsytsem(subsystem.name, subsystem.script) as DialogicSubsystem
+				if subsystem_node:
+					subsystem_nodes.push_back(subsystem_node)
 
 	for subsystem in subsystem_nodes:
 		subsystem.post_install()

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -202,9 +202,8 @@ func collect_subsystems() -> void:
 		if !Engine.is_editor_hint():
 			
 			for subsystem in indexer._get_subsystems():
-				var subsystem_node := add_subsystem(subsystem.name, subsystem.script) as DialogicSubsystem
-				if subsystem_node:
-					subsystem_nodes.push_back(subsystem_node)
+				var subsystem_node := add_subsystem(subsystem.name, subsystem.script)
+				subsystem_nodes.push_back(subsystem_node)
 
 	for subsystem in subsystem_nodes:
 		subsystem.post_install()
@@ -223,13 +222,14 @@ func get_subsystem(_name:String) -> Variant:
 	return get_node(_name)
 
 
-func add_subsystem(_name:String, _script_path:String) -> Node:
+func add_subsystem(_name:String, _script_path:String) -> DialogicSubsystem:
 	var node:Node = Node.new()
 	node.name = _name
 	node.set_script(load(_script_path))
+	assert(node is DialogicSubsystem)
 	node.dialogic = self
 	add_child(node)
-	return node
+	return node as DialogicSubsystem
 
 
 func _get(property):

--- a/addons/dialogic/Other/DialogicGameHandler.gd
+++ b/addons/dialogic/Other/DialogicGameHandler.gd
@@ -188,6 +188,7 @@ func collect_subsystems() -> void:
 	# This also builds the event script cache as well
 	_event_script_cache = []
 	
+	var subsystem_nodes := [] as Array[DialogicSubsystem]
 	for indexer in DialogicUtil.get_indexers():
 		
 		# build event cache
@@ -199,8 +200,13 @@ func collect_subsystems() -> void:
 		
 		# build the subsystems (only at runtime)
 		if !Engine.is_editor_hint():
+			
 			for subsystem in indexer._get_subsystems():
-				add_subsytsem(subsystem.name, subsystem.script)
+				var node = add_subsytsem(subsystem.name, subsystem.script)
+				subsystem_nodes.push_back(node)
+
+	for subsystem in subsystem_nodes:
+		subsystem.install()
 	
 	# Events are checked in order while testing them. EndBranch needs to be first, Text needs to be last
 	_event_script_cache.push_front(DialogicEndBranchEvent.new())

--- a/addons/dialogic/Other/Dialogic_Subsystem.gd
+++ b/addons/dialogic/Other/Dialogic_Subsystem.gd
@@ -7,7 +7,7 @@ enum LoadFlags {FULL_LOAD, ONLY_DNODES}
 
 # To be overriden by sub-classes
 # Called once after every subsystem has been added to the tree
-func install() -> void:
+func post_install() -> void:
 	pass
 
 # To be overriden by sub-classes

--- a/addons/dialogic/Other/Dialogic_Subsystem.gd
+++ b/addons/dialogic/Other/Dialogic_Subsystem.gd
@@ -6,6 +6,11 @@ var dialogic = null
 enum LoadFlags {FULL_LOAD, ONLY_DNODES}
 
 # To be overriden by sub-classes
+# Called once after every subsystem has been added to the tree
+func install() -> void:
+	pass
+
+# To be overriden by sub-classes
 # Fill in everything that should be cleared (for example before loading a different state)
 func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR) -> void:
 	pass


### PR DESCRIPTION
* this "install" method can be safely used by subsystems which rely on other subsystems
* fixes #1819 which was caused by a subsystem fetching another subsytem not yet in the tree (introduced by #1718)

Since the subsystems are loaded by parsing the directory, I assume the order might vary by OS (I'm on Linux and could reproduce #1819).