### PR TITLE
Support saving with encryption enabled

### DIFF
--- a/addons/dialogic/Modules/Save/settings_save.gd
+++ b/addons/dialogic/Modules/Save/settings_save.gd
@@ -21,6 +21,8 @@ func _refresh():
 	%AutosaveDelay.visible = %AutosaveMode.selected == 1
 	
 	%DefaultSaveSlotName.text = ProjectSettings.get_setting('dialogic/save/default_slot', 'Default')
+	
+	%EncryptionPassword.text = ProjectSettings.get_setting('dialogic/save/encryption_password', "")
 
 
 func _on_autosave_toggled(button_pressed:bool) -> void:
@@ -43,4 +45,9 @@ func _on_autosave_delay_value_changed(value:float):
 
 func _on_default_save_slot_name_text_changed(new_text:String):
 	ProjectSettings.set_setting('dialogic/save/default_slot', new_text)
+	ProjectSettings.save()
+
+
+func _on_encryption_password_text_changed(new_text: String) -> void:
+	ProjectSettings.set_setting('dialogic/save/encryption_password', new_text)
 	ProjectSettings.save()

--- a/addons/dialogic/Modules/Save/settings_save.tscn
+++ b/addons/dialogic/Modules/Save/settings_save.tscn
@@ -1,7 +1,19 @@
-[gd_scene load_steps=3 format=3 uid="uid://cd340w7blofak"]
+[gd_scene load_steps=5 format=3 uid="uid://cd340w7blofak"]
 
 [ext_resource type="Script" path="res://addons/dialogic/Modules/Save/settings_save.gd" id="2"]
 [ext_resource type="PackedScene" uid="uid://dbpkta2tjsqim" path="res://addons/dialogic/Editor/Common/hint_tooltip_icon.tscn" id="2_v2wt8"]
+
+[sub_resource type="Image" id="Image_sibia"]
+data = {
+"data": PackedByteArray(255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 94, 94, 127, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 231, 255, 94, 94, 54, 255, 94, 94, 57, 255, 93, 93, 233, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 93, 93, 41, 255, 255, 255, 0, 255, 255, 255, 0, 255, 97, 97, 42, 255, 93, 93, 233, 255, 93, 93, 232, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 44, 255, 255, 255, 0, 255, 97, 97, 42, 255, 97, 97, 42, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 96, 96, 45, 255, 93, 93, 235, 255, 94, 94, 234, 255, 95, 95, 43, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 93, 93, 235, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 233, 255, 95, 95, 59, 255, 96, 96, 61, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 93, 93, 255, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0),
+"format": "RGBA8",
+"height": 16,
+"mipmaps": false,
+"width": 16
+}
+
+[sub_resource type="ImageTexture" id="ImageTexture_ixrey"]
+image = SubResource("Image_sibia")
 
 [node name="Saving" type="VBoxContainer"]
 offset_right = 1084.0
@@ -22,6 +34,8 @@ text = "Autosave"
 
 [node name="HintTooltip" parent="Grid/HBoxContainer" instance=ExtResource("2_v2wt8")]
 layout_mode = 2
+tooltip_text = "If enabled dialogic will autosave the full state to the current slot depending on the autosave method."
+texture = SubResource("ImageTexture_ixrey")
 hint_text = "If enabled dialogic will autosave the full state to the current slot depending on the autosave method."
 
 [node name="Autosave" type="CheckBox" parent="Grid"]
@@ -67,13 +81,32 @@ text = "Default slot name"
 
 [node name="HintTooltip3" parent="Grid/HBoxContainer2" instance=ExtResource("2_v2wt8")]
 layout_mode = 2
-tooltip_text = "If enabled dialogic will autosave the full state to the current slot depending on the autosave method."
+tooltip_text = "The name of the default slot. "
+texture = SubResource("ImageTexture_ixrey")
 hint_text = "The name of the default slot. "
 
 [node name="DefaultSaveSlotName" type="LineEdit" parent="Grid"]
 unique_name_in_owner = true
 layout_mode = 2
 expand_to_text_length = true
+
+[node name="HBoxContainer3" type="HBoxContainer" parent="Grid"]
+layout_mode = 2
+
+[node name="EncryptionPasswordLabel" type="Label" parent="Grid/HBoxContainer3"]
+layout_mode = 2
+text = "Encryption Password"
+
+[node name="HintTooltip" parent="Grid/HBoxContainer3" instance=ExtResource("2_v2wt8")]
+layout_mode = 2
+tooltip_text = "The encryption password used to obfuscate save files. When left empty, the save files will not be encrypted."
+texture = SubResource("ImageTexture_ixrey")
+hint_text = "The encryption password used to obfuscate save files. When left empty, the save files will not be encrypted."
+
+[node name="EncryptionPassword" type="LineEdit" parent="Grid"]
+unique_name_in_owner = true
+layout_mode = 2
+placeholder_text = "not set"
 
 [node name="InfoSection" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -90,3 +123,4 @@ autowrap_mode = 3
 [connection signal="item_selected" from="Grid/AutosaveModeContent/AutosaveMode" to="." method="_on_autosave_mode_item_selected"]
 [connection signal="value_changed" from="Grid/AutosaveModeContent/AutosaveDelay" to="." method="_on_autosave_delay_value_changed"]
 [connection signal="text_changed" from="Grid/DefaultSaveSlotName" to="." method="_on_default_save_slot_name_text_changed"]
+[connection signal="text_changed" from="Grid/EncryptionPassword" to="." method="_on_encryption_password_text_changed"]

--- a/addons/dialogic/Modules/Save/subsystem_save.gd
+++ b/addons/dialogic/Modules/Save/subsystem_save.gd
@@ -237,8 +237,14 @@ func set_latest_slot(slot_name:String) -> void:
 func _make_sure_slot_dir_exists() -> void:
 	if not DirAccess.dir_exists_absolute(SAVE_SLOTS_DIR):
 		DirAccess.make_dir_recursive_absolute(SAVE_SLOTS_DIR)
-	if not FileAccess.file_exists(SAVE_SLOTS_DIR.path_join('global_info.txt')):
-		FileAccess.open(SAVE_SLOTS_DIR.path_join('global_info.txt'), FileAccess.WRITE)
+	var global_info_path = SAVE_SLOTS_DIR.path_join('global_info.txt')
+	if not FileAccess.file_exists(global_info_path):
+		var config := ConfigFile.new()
+		var password := get_encryption_password()
+		if password.is_empty():
+			config.save(global_info_path)
+		else:
+			config.save_encrypted_pass(global_info_path, password)
 
 
 ####################################################################################################


### PR DESCRIPTION
This allows for developers to opt-into saving their data with a layer of encryption. In order to opt-in, they have to go to the settings, navigate to the `Saving` section and add a password to the `Encryption Password` field.

When setting a password, it is highly likely that existing saves made for testing become invalid and cause errors to pop up. To get rid of the errors, they can remove the files and let it set up new ones. But i would recommend to ignore setting an encryption password until exporting the game in order to make debugging easier.

Along the way i did come across some security concern when it comes to arbitrary code execution when loading variables from a file. It is possible to inject code into a save file and have it run on the end user's computer.https://github.com/godotengine/godot/issues/80562

It should be noted that by making use of encryption, it becomes a fair bit harder to create a code injection, as long as the password does not get known to the attacker.

So for now _I would personally_ recommend developers making use of an encryption password when releasing their game.