### PR TITLE
Fix CSV breaking when new rows get added.

### DIFF
--- a/addons/dialogic/Editor/Settings/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/settings_translation.gd
@@ -28,7 +28,7 @@ func _ready() -> void:
 	%TestingLocale.resource_icon = get_theme_icon("Translation", "EditorIcons")
 	%TestingLocale.value_changed.connect(store_changes)
 	%TransFolderPicker.value_changed.connect(store_changes)
-	
+
 	%UpdateCsvFiles.pressed.connect(update_csv_files)
 	%CollectTranslations.pressed.connect(collect_translations)
 	%TransRemove.pressed.connect(_on_erase_translations_pressed)
@@ -66,111 +66,187 @@ func get_locales(filter:String) -> Dictionary:
 	return suggestions
 
 
+
 func update_csv_files() -> void:
-	var orig_locale :String= %OrigLocale.current_value.strip_edges()
+	var orig_locale: String = %OrigLocale.current_value.strip_edges()
+
 	if orig_locale.is_empty():
 		orig_locale = ProjectSettings.get_setting('internationalization/locale/fallback')
 		%OrigLocale.set_value(orig_locale)
-	
-	var translation_mode :int = %TransMode.selected
-	
-	var counts := [0,0,0,0] # [new events, new_timelines, updated_events, updated_timelines]
+
+	var translation_mode: int = %TransMode.selected
+
+	# [new events, new_timelines, updated_events, updated_timelines]
+	var counts := [0,0,0,0]
 	var file : FileAccess
-	var csv_lines := [] # collects all current lines
-	var old_csv_lines := {} # contains already existing csv_lines as [key] = [value, value, ...] dict
-	
-	settings_editor.editors_manager.clear_editor(settings_editor.editors_manager.editors['Timeline']['node'])
-	
-	# collect old lines in per project mode 
+	var csv_lines := []
+	# Contains already existing csv_lines as [key] = [value, value, ...] dict
+	var old_csv_lines := {}
+
+	var csv_columns := 0
+
+	var timeline_node = settings_editor.editors_manager.editors['Timeline']['node']
+	# We will close this timeline to ensure it will properly update.
+	# By saving this reference, we can open it again.
+	var current_timeline = timeline_node.current_resource
+	# Clean the current editor, this will also close the timeline.
+	settings_editor.editors_manager.clear_editor(timeline_node)
+
+	# Collect old lines in per project mode.
 	if translation_mode == TranslationModes.PER_PROJECT:
-		var file_path :String= ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://').path_join('dialogic_translations.csv')
+		var file_path: String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://').path_join('dialogic_translations.csv')
+
 		if FileAccess.file_exists(file_path):
-			file = FileAccess.open(file_path,FileAccess.READ_WRITE)
+			file = FileAccess.open(file_path, FileAccess.READ_WRITE)
 			counts[3] += 1
+
+			var locale_csv_row := file.get_csv_line()
+			csv_columns = locale_csv_row.size()
+			old_csv_lines[locale_csv_row[0]] = locale_csv_row
+
 			while !file.eof_reached():
 				var line := file.get_csv_line()
 				old_csv_lines[line[0]] = line
+
 		else:
 			counts[1] += 1
+
 		csv_lines.append(['keys', orig_locale])
-	
+
 	for timeline_path in DialogicUtil.list_resources_of_type('.dtl'):
-		
-		# collect old lines in per timeline mode
-		var file_path :String= timeline_path.trim_suffix('.dtl')+'_translation.csv'
+		var file_path: String = timeline_path.trim_suffix('.dtl')+'_translation.csv'
+
+		# Collect old lines in per timeline mode.
 		if translation_mode == TranslationModes.PER_TIMELINE:
+
 			if FileAccess.file_exists(file_path):
-				file = FileAccess.open(file_path,FileAccess.READ_WRITE)
+				file = FileAccess.open(file_path, FileAccess.READ_WRITE)
+
+				var locale_csv_row := file.get_csv_line()
+				csv_columns = locale_csv_row.size()
+				old_csv_lines[locale_csv_row[0]] = locale_csv_row
+
 				while !file.eof_reached():
 					var line := file.get_csv_line()
 					old_csv_lines[line[0]] = line
+
 			csv_lines.append(['keys', orig_locale])
-		
+
 		# load and process timeline (make events to resources)
 		var tml : DialogicTimeline = load(timeline_path)
 		await tml.process()
-		
+
 		# now collect all the current csv_lines from timeline
 		for event in tml.events:
+
 			if event.can_be_translated():
+
 				if event._translation_id.is_empty():
 					event.add_translation_id()
 					event.update_text_version()
+
 				for property in event._get_translatable_properties():
 					csv_lines.append([event.get_property_translation_key(property), event._get_property_original_translation(property)])
-		
+
 		# in case new translation_id's were added, we save the timeline again
 		tml.set_meta("timeline_not_saved", true)
 		ResourceSaver.save(tml, timeline_path)
-		
+
 		# for per_timeline mode save the file now, then reset for next timeline
 		if translation_mode == TranslationModes.PER_TIMELINE:
 			if !FileAccess.file_exists(file_path):
 				pass#counts[1] += 1
+
 			elif len(csv_lines):
 				counts[3] += 1
+
 			file = FileAccess.open(file_path, FileAccess.WRITE)
+
 			for line in csv_lines:
-				# in case there might be translations for this line already, 
+
+				# In case there might be translations for this line already,
 				# add them at the end again (orig locale text is replaced).
 				if line[0] in old_csv_lines:
-					file.store_csv_line(line+Array(old_csv_lines[line[0]]).slice(2))
+					var old_line = old_csv_lines[line[0]]
+					var updated_line: PackedStringArray = line + Array(old_line).slice(2)
+
+					var line_columns: int = updated_line.size()
+					var line_columns_to_add = csv_columns - line_columns
+
+					# Add trailing commas to match the amount of columns.
+					for _i in range(line_columns_to_add):
+						updated_line.append("")
+
+					file.store_csv_line(updated_line)
 					counts[2] += 1
+
 				else:
+					var line_columns: int = line.size()
+					var line_columns_to_add = csv_columns - line_columns
+
+					# Add trailing commas to match the amount of columns.
+					for _i in range(line_columns_to_add):
+						line.append("")
+
+
 					file.store_csv_line(line)
 					counts[0] += 1
-			
+
 			csv_lines.clear()
 			old_csv_lines.clear()
-	
+
 	if translation_mode == TranslationModes.PER_PROJECT:
 		var file_path :String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://').path_join('dialogic_translations.csv')
+
 		if FileAccess.file_exists(file_path):
 			counts[3] += 1
 		else:
 			counts[1] += 1
+
 		file = FileAccess.open(file_path, FileAccess.WRITE)
+
 		for line in csv_lines:
-			# in case there might be translations for this line already, 
+			# in case there might be translations for this line already,
 			# add them at the end again (orig locale text is replaced).
 			if line[0] in old_csv_lines:
-				file.store_csv_line(PackedStringArray(line)+old_csv_lines[line[0]].slice(2))
+				var old_line: PackedStringArray = old_csv_lines[line[0]]
+				var updated_line: PackedStringArray = PackedStringArray(line)+old_line.slice(2)
+
+				var line_columns: int = updated_line.size()
+				var line_columns_to_add = csv_columns - line_columns
+
+				# Add trailing commas to match the amount of columns.
+				for _i in range(line_columns_to_add):
+					updated_line.append("")
+
+				file.store_csv_line(updated_line)
 				counts[2] += 1
+
 			else:
+				var line_columns: int = line.size()
+				var line_columns_to_add = csv_columns - line_columns
+
+				# Add trailing commas to match the amount of columns.
+				for _i in range(line_columns_to_add):
+					line.append("")
+
 				file.store_csv_line(line)
 				counts[0] += 1
-	
+
 	## ADD CREATION/UPDATE OF CHARACTER NAMES FILE HERE!
-	
-	# trigger reimport
+
+	# Silently open the closed timeline.
+	settings_editor.editors_manager.edit_resource(current_timeline, true, true)
+
+	# Trigger reimport.
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_resource_filesystem().scan_sources()
-	%StatusMessage.text = "Indexed "+str(counts[0])+" new events ("+str(counts[2])+" were updated). \nAdded "+str(counts[1])+" new csv files ("+str(counts[3])+" were updated)."
+	%StatusMessage.text = "Indexed " +str(counts[0])+ " new events ("+str(counts[2])+" were updated). \nAdded "+str(counts[1])+" new csv files ("+str(counts[3])+" were updated)."
 
 
 func collect_translations() -> void:
 	var trans_files := []
 	var translation_mode :int = %TransMode.selected
-	
+
 	if translation_mode == TranslationModes.PER_TIMELINE:
 		for timeline_path in DialogicUtil.list_resources_of_type('.dtl'):
 			for file in DialogicUtil.listdir(timeline_path.get_base_dir()):
@@ -178,7 +254,7 @@ func collect_translations() -> void:
 				if file.ends_with('.translation'):
 					if not file in trans_files:
 						trans_files.append(file)
-	
+
 	if translation_mode == TranslationModes.PER_PROJECT:
 		var trans_folder :String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://')
 		for file in DialogicUtil.listdir(trans_folder):
@@ -186,16 +262,16 @@ func collect_translations() -> void:
 			if file.ends_with('.translation'):
 				if not file in trans_files:
 					trans_files.append(file)
-	
+
 	var all_trans_files : Array = ProjectSettings.get_setting('internationalization/locale/translations', [])
 	var orig_file_amount := len(all_trans_files)
 	for file in trans_files:
 		if not file in all_trans_files:
 			all_trans_files.append(file)
-	
+
 	ProjectSettings.set_setting('internationalization/locale/translations', PackedStringArray(all_trans_files))
 	ProjectSettings.save()
-	
+
 	%StatusMessage.text = "Collected "+str(len(all_trans_files)-orig_file_amount) + " new translation files."
 
 
@@ -206,9 +282,9 @@ func _on_erase_translations_pressed():
 func erase_translations() -> void:
 	var trans_files := Array(ProjectSettings.get_setting('internationalization/locale/translations', []))
 	var translation_mode : int = %TransMode.selected
-	
+
 	var counts := [0,0] # csv files, translation files
-	
+
 	if translation_mode == TranslationModes.PER_PROJECT:
 		var trans_path :String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://')
 		DirAccess.remove_absolute(trans_path+'dialogic_translations.csv')
@@ -231,24 +307,25 @@ func erase_translations() -> void:
 					trans_files.erase(timeline_path.get_base_dir().path_join(x_file))
 					DirAccess.remove_absolute(timeline_path.get_base_dir().path_join(x_file))
 					counts[1] += 1
-		
+
 		# clear the timeline events of their translation_id's
 		var tml:DialogicTimeline = load(timeline_path)
 		await tml.process()
-		
+
 		for event in tml.events:
 			if event._translation_id:
 				event.remove_translation_id()
 				event.update_text_version()
+
 		tml.set_meta("timeline_not_saved", true)
-		ResourceSaver.save(tml, timeline_path)
-	
+		var result = ResourceSaver.save(tml, timeline_path)
+
 	ProjectSettings.set_setting('dialogic/translation/id_counter', 16)
 	ProjectSettings.set_setting('internationalization/locale/translations', PackedStringArray(trans_files))
 	ProjectSettings.save()
-	
+
 	find_parent('EditorView').plugin_reference.get_editor_interface().get_resource_filesystem().scan_sources()
-	
+
 	%StatusMessage.text = "Removed "+str(counts[0])+" csv files, "+str(counts[1])+" translations and all translation id's."
 	_refresh()
 

--- a/addons/dialogic/Editor/Settings/settings_translation.gd
+++ b/addons/dialogic/Editor/Settings/settings_translation.gd
@@ -85,10 +85,10 @@ func update_csv_files() -> void:
 
 	var csv_columns := 0
 
-	var timeline_node = settings_editor.editors_manager.editors['Timeline']['node']
+	var timeline_node: DialogicEditor = settings_editor.editors_manager.editors['Timeline']['node']
 	# We will close this timeline to ensure it will properly update.
 	# By saving this reference, we can open it again.
-	var current_timeline = timeline_node.current_resource
+	var current_timeline := timeline_node.current_resource
 	# Clean the current editor, this will also close the timeline.
 	settings_editor.editors_manager.clear_editor(timeline_node)
 
@@ -171,7 +171,7 @@ func update_csv_files() -> void:
 					var updated_line: PackedStringArray = line + Array(old_line).slice(2)
 
 					var line_columns: int = updated_line.size()
-					var line_columns_to_add = csv_columns - line_columns
+					var line_columns_to_add := csv_columns - line_columns
 
 					# Add trailing commas to match the amount of columns.
 					for _i in range(line_columns_to_add):
@@ -182,7 +182,7 @@ func update_csv_files() -> void:
 
 				else:
 					var line_columns: int = line.size()
-					var line_columns_to_add = csv_columns - line_columns
+					var line_columns_to_add := csv_columns - line_columns
 
 					# Add trailing commas to match the amount of columns.
 					for _i in range(line_columns_to_add):
@@ -196,7 +196,7 @@ func update_csv_files() -> void:
 			old_csv_lines.clear()
 
 	if translation_mode == TranslationModes.PER_PROJECT:
-		var file_path :String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://').path_join('dialogic_translations.csv')
+		var file_path: String = ProjectSettings.get_setting('dialogic/translation/translation_folder', 'res://').path_join('dialogic_translations.csv')
 
 		if FileAccess.file_exists(file_path):
 			counts[3] += 1
@@ -213,7 +213,7 @@ func update_csv_files() -> void:
 				var updated_line: PackedStringArray = PackedStringArray(line)+old_line.slice(2)
 
 				var line_columns: int = updated_line.size()
-				var line_columns_to_add = csv_columns - line_columns
+				var line_columns_to_add := csv_columns - line_columns
 
 				# Add trailing commas to match the amount of columns.
 				for _i in range(line_columns_to_add):
@@ -224,7 +224,7 @@ func update_csv_files() -> void:
 
 			else:
 				var line_columns: int = line.size()
-				var line_columns_to_add = csv_columns - line_columns
+				var line_columns_to_add := csv_columns - line_columns
 
 				# Add trailing commas to match the amount of columns.
 				for _i in range(line_columns_to_add):
@@ -245,7 +245,7 @@ func update_csv_files() -> void:
 
 func collect_translations() -> void:
 	var trans_files := []
-	var translation_mode :int = %TransMode.selected
+	var translation_mode: int = %TransMode.selected
 
 	if translation_mode == TranslationModes.PER_TIMELINE:
 		for timeline_path in DialogicUtil.list_resources_of_type('.dtl'):
@@ -318,7 +318,7 @@ func erase_translations() -> void:
 				event.update_text_version()
 
 		tml.set_meta("timeline_not_saved", true)
-		var result = ResourceSaver.save(tml, timeline_path)
+		ResourceSaver.save(tml, timeline_path)
 
 	ProjectSettings.set_setting('dialogic/translation/id_counter', 16)
 	ProjectSettings.set_setting('internationalization/locale/translations', PackedStringArray(trans_files))


### PR DESCRIPTION
## Summary
This PR fixes two bugs when updating CSV using the Translation feature.
- Adding a new translatable event breaks CSV file, if there are more than 2 locale keys.
- Updating the CSVs closed the currently opened timeline.

## Bug Cause

When a new line of text gets added to the CSV, eg. by adding a Text Event, it did not add trailing commas for each available locale.
Additionally, updating CSVs closed the current timeline node, but did not re-open it.

## Bug Fix

We count the number of locale entries and count each entry per CSV row.
For every missing entry, we add trailing commas.

We also save the resource at the beginning of the method and once finished, silently open it again.

## Additional Information

Changes comments and their positioning, adds a newlines were it helps readability.
In the future, this code section will require a full refactoring, as the overall method is quite complex.