### PR TITLE
Fix Choice Selection via Key Inputs

### DIFF
--- a/addons/dialogic/Modules/Choice/node_choice_button.gd
+++ b/addons/dialogic/Modules/Choice/node_choice_button.gd
@@ -3,7 +3,7 @@ extends Button
 
 ## Dialogic Node that displays choices.
 
-## Used to identify what choices to put on. If you leave it at -1, choices will be distributed automatically. 
+## Used to identify what choices to put on. If you leave it at -1, choices will be distributed automatically.
 @export var choice_index:int = -1
 
 ## Can be set to play this sound when pressed. Requires a sibling DialogicNode_ButtonSound node.
@@ -12,7 +12,9 @@ extends Button
 @export var sound_hover: AudioStream
 ## Can be set to play this sound when focused. Requires a sibling DialogicNode_ButtonSound node.
 @export var sound_focus: AudioStream
-
+## These keys will be added to the shortcut mechanism on the choice button.
+## Pressing the key will press the button and pick the choice.
+@export var press_choice_keys: Array[Key]
 
 func _ready():
 	add_to_group('dialogic_choice_button')

--- a/addons/dialogic/Modules/Choice/node_choice_button.gd
+++ b/addons/dialogic/Modules/Choice/node_choice_button.gd
@@ -12,9 +12,7 @@ extends Button
 @export var sound_hover: AudioStream
 ## Can be set to play this sound when focused. Requires a sibling DialogicNode_ButtonSound node.
 @export var sound_focus: AudioStream
-## These keys will be added to the shortcut mechanism on the choice button.
-## Pressing the key will press the button and pick the choice.
-@export var press_choice_keys: Array[Key]
+
 
 func _ready():
 	add_to_group('dialogic_choice_button')

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -111,20 +111,20 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 			if (ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0) or
 			not choice_button.press_choice_keys.is_empty()):
 				var shortcut := Shortcut.new()
-				var input_key := InputEventKey.new()
 				var shortcut_events: Array[InputEventKey] = []
 
 				if idx == 1 and idx < 10:
+					var input_key := InputEventKey.new()
 					input_key.keycode = OS.find_keycode_from_string(str(idx))
 					shortcut_events.append(input_key)
 
-				# If it was empty, nothing will be appended.
+				# Adding the defined keys from the choice button.
 				for key in choice_button.press_choice_keys:
 					var button_input_key := InputEventKey.new()
 					button_input_key.keycode = key
 					shortcut_events.append_array(choice_button.press_choice_keys)
 
-				shortcut.events = [input_key]
+				shortcut.events = shortcut_events
 
 				node.shortcut = shortcut
 				node.pressed.connect(button_binding)

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -29,7 +29,7 @@ func clear_game_state(clear_flag:=Dialogic.ClearFlags.FULL_CLEAR):
 ##					MAIN METHODS
 ####################################################################################################
 
-## Hides all choice buttons.  
+## Hides all choice buttons.
 func hide_all_choices() -> void:
 	for node in get_tree().get_nodes_in_group('dialogic_choice_button'):
 		node.hide()
@@ -41,10 +41,10 @@ func hide_all_choices() -> void:
 func show_current_choices(instant:=true) -> void:
 	hide_all_choices()
 	choice_blocker.stop()
-	
+
 	var reveal_delay := float(ProjectSettings.get_setting('dialogic/choices/reveal_delay', 0.0))
 	var reveal_by_input :bool = ProjectSettings.get_setting('dialogic/choices/reveal_by_input', false)
-	
+
 	if !instant and (reveal_delay != 0 or reveal_by_input):
 		if reveal_delay != 0:
 			choice_blocker.start(reveal_delay)
@@ -52,13 +52,13 @@ func show_current_choices(instant:=true) -> void:
 		if reveal_by_input:
 			Dialogic.Input.dialogic_action.connect(show_current_choices)
 		return
-	
+
 	if choice_blocker.timeout.is_connected(show_current_choices):
 		choice_blocker.timeout.disconnect(show_current_choices)
 	if Dialogic.Input.dialogic_action.is_connected(show_current_choices):
 		Dialogic.Input.dialogic_action.disconnect(show_current_choices)
-	
-	
+
+
 	var button_idx := 1
 	last_question_info = {'choices':[]}
 	for choice_index in get_current_choice_indexes():
@@ -67,7 +67,7 @@ func show_current_choices(instant:=true) -> void:
 		if not choice_event.condition.is_empty() and not dialogic.Expression.execute_condition(choice_event.condition):
 			if choice_event.else_action == DialogicChoiceEvent.ElseActions.DEFAULT:
 				choice_event.else_action = ProjectSettings.get_setting('dialogic/choices/def_false_behaviour', 0)
-			
+
 			# check what to do in this case
 			if choice_event.else_action == DialogicChoiceEvent.ElseActions.DISABLE:
 				if !choice_event.disabled_text.is_empty():
@@ -98,21 +98,21 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 				node.text = dialogic.Text.parse_text(text, true, true, false, true, false, false)
 			else:
 				node.text = text
-			
+
 			if idx == 1 and ProjectSettings.get_setting('dialogic/choices/autofocus_first', true):
 				node.grab_focus()
-			
+
 			if ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0) == 1 and idx < 10:
 				var shortcut := Shortcut.new()
 				var input_key := InputEventKey.new()
-				input_key.scancode = OS.find_keycode_from_string(str(idx))
-				shortcut.shortcut = input_key
+				input_key.keycode = OS.find_keycode_from_string(str(idx))
+				shortcut.events = [input_key]
 				node.shortcut = shortcut
-			
+
 			node.disabled = not enabled
-			node.button_up.connect(_on_ChoiceButton_choice_selected.bind(event_index, 
+			node.button_up.connect(_on_ChoiceButton_choice_selected.bind(event_index,
 				{'button_index':button_index, 'text':text, 'enabled':enabled, 'event_index':event_index}))
-			
+
 		if node.choice_index > 0:
 			idx = node.choice_index
 		idx += 1
@@ -125,14 +125,14 @@ func _on_ChoiceButton_choice_selected(event_index:int, choice_info:={}) -> void:
 	hide_all_choices()
 	dialogic.current_state = dialogic.States.IDLE
 	dialogic.handle_event(event_index)
-	
+
 
 func get_current_choice_indexes() -> Array:
 	var choices := []
 	var evt_idx :int= dialogic.current_event_idx
 	var ignore := 0
 	while true:
-		
+
 		evt_idx += 1
 		if evt_idx >= len(dialogic.current_timeline_events):
 			break
@@ -145,7 +145,7 @@ func get_current_choice_indexes() -> Array:
 		else:
 			if ignore == 0:
 				break
-		
+
 		if dialogic.current_timeline_events[evt_idx] is DialogicEndBranchEvent:
 			ignore -= 1
 	return choices

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -105,32 +105,24 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 			if idx == 1 and ProjectSettings.get_setting('dialogic/choices/autofocus_first', true):
 				node.grab_focus()
 
-			var button_binding := _on_ChoiceButton_choice_selected.bind(event_index,
-			{'button_index':button_index, 'text':text, 'enabled':enabled, 'event_index':event_index})
-
-			if (ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0) or
-			not choice_button.press_choice_keys.is_empty()):
-				var shortcut := Shortcut.new()
-				var shortcut_events: Array[InputEventKey] = []
-
+			## Add 1 to 9 as shortcuts if it's enabled
+			if ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0):
 				if idx > 0 and idx < 10:
+					var shortcut: Shortcut
+					if node.shortcut != null:
+						shortcut = node.shortcut
+					else:
+						shortcut = Shortcut.new()
+
+					var shortcut_events: Array[InputEventKey] = []
 					var input_key := InputEventKey.new()
 					input_key.keycode = OS.find_keycode_from_string(str(idx))
-					shortcut_events.append(input_key)
-
-				# Adding the defined keys from the choice button.
-				for key in choice_button.press_choice_keys:
-					var button_input_key := InputEventKey.new()
-					button_input_key.keycode = key
-					shortcut_events.append_array(choice_button.press_choice_keys)
-
-				shortcut.events = shortcut_events
-
-				node.shortcut = shortcut
-				node.pressed.connect(button_binding)
+					shortcut.events.append(input_key)
+					node.shortcut = shortcut
 
 			node.disabled = not enabled
-			node.button_up.connect(button_binding)
+			node.pressed.connect(_on_ChoiceButton_choice_selected.bind(event_index,
+					{'button_index':button_index, 'text':text, 'enabled':enabled, 'event_index':event_index}))
 
 		if node.choice_index > 0:
 			idx = node.choice_index

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -113,7 +113,7 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 				var shortcut := Shortcut.new()
 				var shortcut_events: Array[InputEventKey] = []
 
-				if idx == 1 and idx < 10:
+				if idx > 0 and idx < 10:
 					var input_key := InputEventKey.new()
 					input_key.keycode = OS.find_keycode_from_string(str(idx))
 					shortcut_events.append(input_key)

--- a/addons/dialogic/Modules/Choice/subsystem_choices.gd
+++ b/addons/dialogic/Modules/Choice/subsystem_choices.gd
@@ -102,16 +102,21 @@ func show_choice(button_index:int, text:String, enabled:bool, event_index:int) -
 			if idx == 1 and ProjectSettings.get_setting('dialogic/choices/autofocus_first', true):
 				node.grab_focus()
 
+			var button_binding := _on_ChoiceButton_choice_selected.bind(event_index,
+			{'button_index':button_index, 'text':text, 'enabled':enabled, 'event_index':event_index})
+
 			if ProjectSettings.get_setting('dialogic/choices/hotkey_behaviour', 0) == 1 and idx < 10:
 				var shortcut := Shortcut.new()
 				var input_key := InputEventKey.new()
+
 				input_key.keycode = OS.find_keycode_from_string(str(idx))
 				shortcut.events = [input_key]
+
 				node.shortcut = shortcut
+				node.pressed.connect(button_binding)
 
 			node.disabled = not enabled
-			node.button_up.connect(_on_ChoiceButton_choice_selected.bind(event_index,
-				{'button_index':button_index, 'text':text, 'enabled':enabled, 'event_index':event_index}))
+			node.button_up.connect(button_binding)
 
 		if node.choice_index > 0:
 			idx = node.choice_index


### PR DESCRIPTION
# Summary
Using a key input crashes the choice selection using hotkeys.

# Solution
Use `keycode` instead of `scancode`.

# Note
This PR adds an export to the Choice button class, allowing developers to define customisable inputs. This has been advertised by the settings page for Choices, but was not doable.
The variable for this is a typed array, allowing developers to provide multiple input choices, in case of different platforms.

This closes: #1870 