### PR TITLE
Handle incorrect Portrait Scene path case

### DIFF
--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -112,18 +112,18 @@ func _change_portrait(character_node:Node2D, portrait:String, update_transform:=
 			character_node.get_child(0).queue_free()
 			character_node.remove_child(character_node.get_child(0))
 
-		if not scene_path.is_empty():
-			var p :PackedScene = load(scene_path)
+		if ResourceLoader.exists(scene_path):
+			var p: PackedScene = load(scene_path)
 			if p:
 				portrait_node = p.instantiate()
 			else:
-				push_error('Dialogic: Portrait node "' + str(scene_path) + '" for character [' + character.display_name + '] could not be loaded. Your portrait might not show up on the screen. Confirm the path is correct.')
-		
+				push_error('[Dialogic] Portrait node "' + str(scene_path) + '" for character [' + character.display_name + '] could not be loaded. Your portrait might not show up on the screen. Confirm the path is correct.')
+
 		if !portrait_node:
 			portrait_node = default_portrait_scene.instantiate()
-		
+
 		portrait_node.set_meta('scene', scene_path)
-	
+
 	if portrait_node:
 		character_node.set_meta('portrait', portrait)
 

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -112,17 +112,18 @@ func _change_portrait(character_node:Node2D, portrait:String, update_transform:=
 			character_node.get_child(0).queue_free()
 			character_node.remove_child(character_node.get_child(0))
 
-		if scene_path.is_empty():
-			portrait_node = default_portrait_scene.instantiate()
-		else:
+		if not scene_path.is_empty():
 			var p :PackedScene = load(scene_path)
 			if p:
 				portrait_node = p.instantiate()
 			else:
-				push_error('Dialogic: Portrait node "' + str(scene_path) + '" for character [' + character.display_name + '] could not be loaded. Your portrait might not show up on the screen.')
-
+				push_error('Dialogic: Portrait node "' + str(scene_path) + '" for character [' + character.display_name + '] could not be loaded. Your portrait might not show up on the screen. Confirm the path is correct.')
+		
+		if !portrait_node:
+			portrait_node = default_portrait_scene.instantiate()
+		
 		portrait_node.set_meta('scene', scene_path)
-
+	
 	if portrait_node:
 		character_node.set_meta('portrait', portrait)
 


### PR DESCRIPTION
When the custom defined portrait path fails to load, the code still tries to interact with the null instance, since it only handled the case where the path was Empty, but not when simply incorrect/broken path.

Instead of `scene_path.is_empty()`, we could also use `FileAccess.file_exists(scene_path)`, but figured I'd avoid the double file access command. But maybe it would be better, to avoid the load exception, I'm not sure.