### PR TITLE
Fix Character Speaker changing

### DIFF
--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -122,7 +122,8 @@ func _on_dialog_text_finished():
 
 
 func update_name_label(character:DialogicCharacter) -> void:
-	var character_path = character.resource_path if character else null
+	var character_path := character.resource_path if character else ""
+
 	if character_path != dialogic.current_state_info.get('character'):
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -121,6 +121,8 @@ func _on_dialog_text_finished():
 	text_finished.emit({'text':dialogic.current_state_info['text'], 'character':dialogic.current_state_info['speaker']})
 
 
+## Updates the visible name on all name labels nodes.
+## If a name changes, the [signal speaker_updated] signal is emitted.
 func update_name_label(character:DialogicCharacter) -> void:
 	var character_path := character.resource_path if character else ""
 

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -130,14 +130,19 @@ func update_name_label(character:DialogicCharacter) -> void:
 	if character_path != current_character_path:
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)
+
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):
+
 		if character:
+
 			if dialogic.has_subsystem('VAR'):
 				name_label.text = dialogic.VAR.parse_variables(character.display_name)
 			else:
 				name_label.text = character.display_name
+
 			if !'use_character_color' in name_label or name_label.use_character_color:
 				name_label.self_modulate = character.color
+
 		else:
 			name_label.text = ''
 			name_label.self_modulate = Color(1,1,1,1)

--- a/addons/dialogic/Modules/Text/subsystem_text.gd
+++ b/addons/dialogic/Modules/Text/subsystem_text.gd
@@ -125,8 +125,9 @@ func _on_dialog_text_finished():
 ## If a name changes, the [signal speaker_updated] signal is emitted.
 func update_name_label(character:DialogicCharacter) -> void:
 	var character_path := character.resource_path if character else ""
+	var current_character_path: String = dialogic.current_state_info.get('character')
 
-	if character_path != dialogic.current_state_info.get('character'):
+	if character_path != current_character_path:
 		dialogic.current_state_info['speaker'] = character_path
 		speaker_updated.emit(character)
 	for name_label in get_tree().get_nodes_in_group('dialogic_name_label'):


### PR DESCRIPTION
# Problem
When the speaker changes from a character to none, neither the `speaker_changed` signal changed nor the state info updated.

# Solution
This changes the ternary to fall back to an empty string instead of `null`.

# Context
I am modifying my text whenever there is a valid speaker. I added a text event with a speaker and then a couple of text events without speakers.
However, the state info reported the same speaker for every text event.

# Appendix
I added documentation and adjusted the formatting of the function to be less tense and adhere to the Godot "newline per new section" mindset.
