### PR TITLE
Speaker highlight improvements

### DIFF
--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_exports.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_exports.gd
@@ -59,6 +59,8 @@ func load_portrait_scene_export_variables():
 			var current_value :Variant = scene.get(i['name'])
 			if current_portrait_data.has('export_overrides') and current_portrait_data['export_overrides'].has(i['name']):
 				current_value = str_to_var(current_portrait_data.export_overrides[i['name']])
+				if current_value == null and typeof(scene.get(i['name'])) == TYPE_STRING:
+					current_value = current_portrait_data['export_overrides'][i['name']]
 
 			var input :Node = DialogicUtil.setup_script_property_edit_node(i, current_value, set_export_override)
 			input.size_flags_horizontal = SIZE_EXPAND_FILL

--- a/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main_exports.gd
+++ b/addons/dialogic/Editor/CharacterEditor/char_edit_p_section_main_exports.gd
@@ -39,6 +39,8 @@ func load_portrait_scene_export_variables():
 			var current_value :Variant = scene.get(i['name'])
 			if current_portrait_data.has('export_overrides') and current_portrait_data['export_overrides'].has(i['name']):
 				current_value = str_to_var(current_portrait_data['export_overrides'][i['name']])
+				if current_value == null and typeof(scene.get(i['name'])) == TYPE_STRING:
+					current_value = current_portrait_data['export_overrides'][i['name']]
 
 			var input :Node = DialogicUtil.setup_script_property_edit_node(i, current_value, set_export_override)
 			input.size_flags_horizontal = SIZE_EXPAND_FILL

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -309,7 +309,7 @@ func import_portraits_from_folder(path:String) -> void:
 				if not '.import' in file_lower:
 					var final_name: String = path.path_join(file_name)
 					%PortraitTree.add_portrait_item(file_name.trim_suffix('.'+file_name.get_extension()),
-							{'scene':"",'export_overrides':{'image':final_name}, 'scale':1, 'offset':Vector2(), 'mirror':false}, parent)
+							{'scene':"",'export_overrides':{'image':var_to_str(final_name)}, 'scale':1, 'offset':Vector2(), 'mirror':false}, parent)
 		file_name = dir.get_next()
 
 	## Handle selection

--- a/addons/dialogic/Editor/CharacterEditor/character_editor.gd
+++ b/addons/dialogic/Editor/CharacterEditor/character_editor.gd
@@ -307,9 +307,9 @@ func import_portraits_from_folder(path:String) -> void:
 			var file_lower = file_name.to_lower()
 			if '.svg' in file_lower or '.png' in file_lower:
 				if not '.import' in file_lower:
-					var final_name: String= path+ "/" + file_name
+					var final_name: String = path.path_join(file_name)
 					%PortraitTree.add_portrait_item(file_name.trim_suffix('.'+file_name.get_extension()),
-							{'scene':"",'image':final_name, 'scale':1, 'offset':Vector2(), 'mirror':false}, parent)
+							{'scene':"",'export_overrides':{'image':final_name}, 'scale':1, 'offset':Vector2(), 'mirror':false}, parent)
 		file_name = dir.get_next()
 
 	## Handle selection
@@ -322,10 +322,10 @@ func import_portraits_from_folder(path:String) -> void:
 	something_changed()
 
 
-func add_portrait(portrait_name:String='New portrait', portrait_data:Dictionary={'scene':"", 'image':'', 'scale':1, 'offset':Vector2(), 'mirror':false}) -> void:
+func add_portrait(portrait_name:String='New portrait', portrait_data:Dictionary={'scene':"", 'export_overrides':{'image':''}, 'scale':1, 'offset':Vector2(), 'mirror':false}) -> void:
 	var parent: TreeItem = %PortraitTree.get_root()
 	if %PortraitTree.get_selected():
-		if %PortraitTree.get_selected().get_metadata(0).has('group'):
+		if %PortraitTree.get_selected().get_metadata(0) and %PortraitTree.get_selected().get_metadata(0).has('group'):
 			parent = %PortraitTree.get_selected()
 		else:
 			parent = %PortraitTree.get_selected().get_parent()

--- a/addons/dialogic/Example Assets/default_event.gd
+++ b/addons/dialogic/Example Assets/default_event.gd
@@ -20,7 +20,7 @@ func _init() -> void:
 	event_color = Color("#ffffff")
 	event_category = "Main"
 	event_sorting_index = 0
-	
+
 
 
 ################################################################################
@@ -36,7 +36,7 @@ func get_shortcode_parameters() -> Dictionary:
 	}
 
 # You can alternatively overwrite these 3 functions:
-# - to_text(), 
+# - to_text(),
 # - from_text(),
 # - is_valid_event()
 

--- a/addons/dialogic/Example Assets/portraits/simple_highlight_portrait.gd
+++ b/addons/dialogic/Example Assets/portraits/simple_highlight_portrait.gd
@@ -1,0 +1,29 @@
+@tool
+extends DialogicPortrait
+
+@export_group('Main')
+@export_file var image : String = ""
+
+var unhighlighted_color := Color.DARK_GRAY
+var prev_z_index := 0
+
+## Load anything related to the given character and portrait
+func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
+	apply_character_and_portrait(passed_character, passed_portrait)
+
+	apply_texture($Portrait, image)
+
+
+func _ready() -> void:
+	self.modulate = unhighlighted_color
+
+
+func _highlight():
+	create_tween().tween_property(self, 'modulate', Color.WHITE, 0.15)
+	prev_z_index = Dialogic.Portraits.get_character_info(character).get('z_index', 0)
+	Dialogic.Portraits.change_character_z_index(character, 10)
+
+
+func _unhighlight():
+	create_tween().tween_property(self, 'modulate', unhighlighted_color, 0.15)
+	Dialogic.Portraits.change_character_z_index(character, prev_z_index)

--- a/addons/dialogic/Example Assets/portraits/simple_highlight_portrait.tscn
+++ b/addons/dialogic/Example Assets/portraits/simple_highlight_portrait.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3 uid="uid://br18lgpga2y2v"]
+
+[ext_resource type="Script" path="res://addons/dialogic/Example Assets/portraits/simple_highlight_portrait.gd" id="1_ceqva"]
+
+[node name="DefaultPortrait" type="Node2D"]
+script = ExtResource("1_ceqva")
+
+[node name="Portrait" type="Sprite2D" parent="."]
+centered = false

--- a/addons/dialogic/Modules/Character/default_portrait.gd
+++ b/addons/dialogic/Modules/Character/default_portrait.gd
@@ -2,39 +2,15 @@
 extends DialogicPortrait
 
 ## Default portrait scene.
-
 ## The parent class has a character and portrait variable.
+
 @export_group('Main')
 @export_file var image : String = ""
 
-## If the custom portrait accepts a change, then accept it here
+
+## Load anything related to the given character and portrait
 func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
-	if passed_portrait == "" or not passed_portrait in passed_character.portraits.keys():
-		passed_portrait = passed_character.default_portrait
+	apply_character_and_portrait(passed_character, passed_portrait)
 
-	portrait = passed_portrait
-	character = passed_character
+	apply_texture($Portrait, image)
 
-	if character.portraits.has(portrait):
-		$Portrait.texture = null
-		if !image.is_empty():
-			$Portrait.texture = load(image)
-		# This is a leftover from alpha.
-		# Removing this will break any portraits made before alpha-10
-		elif !character.portraits[portrait].get('image', '').is_empty():
-			$Portrait.texture = load(character.portraits[portrait].get('image'))
-		$Portrait.centered = false
-		$Portrait.scale = Vector2.ONE
-		$Portrait.position = $Portrait.get_rect().size * Vector2(-0.5, -1)
-
-
-## This is called when the mirror changes
-func _set_mirror(mirror:bool) -> void:
-	$Portrait.flip_h = mirror
-
-
-## This is used by the editor preview and portrait containers
-func _get_covered_rect() -> Rect2:
-	if $Portrait.texture == null:
-		return Rect2()
-	return Rect2($Portrait.position, $Portrait.get_rect().size)

--- a/addons/dialogic/Modules/Character/default_portrait.tscn
+++ b/addons/dialogic/Modules/Character/default_portrait.tscn
@@ -4,7 +4,6 @@
 
 [node name="DefaultPortrait" type="Node2D"]
 script = ExtResource("1_wn77n")
-image = null
 
 [node name="Portrait" type="Sprite2D" parent="."]
 centered = false

--- a/addons/dialogic/Modules/Character/dialogic_portrait.gd
+++ b/addons/dialogic/Modules/Character/dialogic_portrait.gd
@@ -8,6 +8,8 @@ var character: DialogicCharacter
 ## Stores the name of the current portrait.
 var portrait: String
 
+#region MAIN OVERRIDES
+################################################################################
 
 ## This function can be overridden.
 ## If this returns true, it won't insatnce a new scene, but call _update_portrait on this one.
@@ -34,19 +36,32 @@ func _update_portrait(passed_character:DialogicCharacter, passed_portrait:String
 ## >>> return Rect2($Sprite.position, $Sprite.get_rect().size)
 ##
 ## This will only work as expected if the portrait is positioned so that the root is at the pivot point.
+##
+## If you've used apply_texture this should work automatically.
 func _get_covered_rect() -> Rect2:
+	if has_meta('texture_holder_node') and get_meta('texture_holder_node', null) != null and is_instance_valid(get_meta('texture_holder_node')):
+		var node: Node = get_meta('texture_holder_node')
+		if node is Sprite2D or node is TextureRect:
+			return Rect2(node.position, node.get_rect().size)
 	return Rect2()
 
 
 ## If implemented, this is called when the mirror changes
 func _set_mirror(mirror:bool) -> void:
-	pass
+	if has_meta('texture_holder_node') and get_meta('texture_holder_node', null) != null and is_instance_valid(get_meta('texture_holder_node')):
+		var node: Node = get_meta('texture_holder_node')
+		if node is Sprite2D or node is TextureRect:
+			node.flip_h = mirror
 
 
 ## Function to accept and use the extra data, if the custom portrait wants to accept it
 func _set_extra_data(data: String) -> void:
 	pass
 
+#endregion
+
+#region HIGHLIGHT OVERRIDES
+################################################################################
 
 ## Called when this becomes the active speaker
 func _highlight() -> void:
@@ -56,3 +71,49 @@ func _highlight() -> void:
 ## Called when this stops being the active speaker
 func _unhighlight() -> void:
 	pass
+#endregion
+
+
+#region HELPERS
+################################################################################
+
+## Helper that quickly setups and checks the character and portrait.
+func apply_character_and_portrait(passed_character:DialogicCharacter, passed_portrait:String) -> void:
+	if passed_portrait == "" or not passed_portrait in passed_character.portraits.keys():
+		passed_portrait = passed_character.default_portrait
+
+	portrait = passed_portrait
+	character = passed_character
+
+
+func apply_texture(node:Node, texture_path:String) -> void:
+	if not character or not character.portraits.has(portrait):
+		return
+
+	if not "texture" in node:
+		return
+
+	node.texture = null
+
+	if not ResourceLoader.exists(texture_path):
+		# This is a leftover from alpha.
+		# Removing this will break any portraits made before alpha-10
+		if ResourceLoader.exists(character.portraits[portrait].get('image', '')):
+			texture_path = character.portraits[portrait].get('image', '')
+		else:
+			return
+
+	node.texture = load(texture_path)
+
+	if node is Sprite2D or node is TextureRect:
+		if node is Sprite2D:
+			node.centered = false
+		node.scale = Vector2.ONE
+		if node is TextureRect:
+			if !is_inside_tree():
+				await ready
+		node.position = node.get_rect().size * Vector2(-0.5, -1)
+
+	set_meta('texture_holder_node', node)
+
+#endregion

--- a/addons/dialogic/Modules/Character/subsystem_portraits.gd
+++ b/addons/dialogic/Modules/Character/subsystem_portraits.gd
@@ -595,12 +595,14 @@ func change_speaker(speaker:DialogicCharacter= null, portrait:= ""):
 		_change_portrait_mirror(con.get_child(0))
 
 
-	if speaker and speaker.resource_path != dialogic.current_state_info['speaker']:
-		if dialogic.current_state_info['speaker'] and is_character_joined(load(dialogic.current_state_info['speaker'])):
-			dialogic.current_state_info['portraits'][dialogic.current_state_info['speaker']].node.get_child(0)._unhighlight()
-		if speaker and is_character_joined(speaker):
-			dialogic.current_state_info['portraits'][speaker.resource_path].node.get_child(0)._highlight()
-
+	if speaker:
+		if speaker.resource_path != dialogic.current_state_info['speaker']:
+			if dialogic.current_state_info['speaker'] and is_character_joined(load(dialogic.current_state_info['speaker'])):
+				dialogic.current_state_info['portraits'][dialogic.current_state_info['speaker']].node.get_child(0)._unhighlight()
+			if speaker and is_character_joined(speaker):
+				dialogic.current_state_info['portraits'][speaker.resource_path].node.get_child(0)._highlight()
+	elif dialogic.current_state_info['speaker'] and is_character_joined(load(dialogic.current_state_info['speaker'])):
+		dialogic.current_state_info['portraits'][dialogic.current_state_info['speaker']].node.get_child(0)._unhighlight()
 
 ################### TEXT EFFECTS ###################################################################
 ####################################################################################################

--- a/addons/dialogic/Modules/Jump/event_jump.gd
+++ b/addons/dialogic/Modules/Jump/event_jump.gd
@@ -14,7 +14,7 @@ var timeline :DialogicTimeline = null:
 			if !_timeline_file.is_empty():
 				if _timeline_file.contains("res://"):
 					return load(_timeline_file)
-				else: 
+				else:
 					return load(Dialogic.find_timeline(_timeline_file))
 		return timeline
 ## If not empty, the event will try to find a Label event with this set as name. Empty by default..
@@ -89,7 +89,7 @@ func is_valid_event(string:String) -> bool:
 func get_shortcode_parameters() -> Dictionary:
 	return {
 		#param_name 	: property_info
-		"timeline"		: {"property": "_timeline_file", 	"default": null, 
+		"timeline"		: {"property": "_timeline_file", 	"default": null,
 							"suggestions": get_timeline_suggestions},
 		"label"			: {"property": "label_name", 		"default": ""},
 	}
@@ -107,7 +107,7 @@ func build_event_editor():
 		'empty_text': '(this timeline)',
 		'autofocus':true
 	})
-	add_header_edit("label_name", ValueType.COMPLEX_PICKER, {'left_text':"at", 
+	add_header_edit("label_name", ValueType.COMPLEX_PICKER, {'left_text':"at",
 		'empty_text':'the beginning',
 		'suggestions_func':get_label_suggestions,
 		'editor_icon':["ArrowRight", "EditorIcons"]})
@@ -116,9 +116,9 @@ func build_event_editor():
 func get_timeline_suggestions(filter:String= "") -> Dictionary:
 	var suggestions := {}
 	var resources := DialogicUtil.list_resources_of_type('.dtl')
-	
+
 	suggestions['(this timeline)'] = {'value':'', 'editor_icon':['GuiRadioUnchecked', 'EditorIcons']}
-	
+
 	for resource in Engine.get_main_loop().get_meta('dialogic_timeline_directory').keys():
 		suggestions[resource] = {'value': resource, 'tooltip':Engine.get_main_loop().get_meta('dialogic_timeline_directory')[resource], 'editor_icon': ["TripleBar", "EditorIcons"]}
 	return suggestions
@@ -127,7 +127,7 @@ func get_timeline_suggestions(filter:String= "") -> Dictionary:
 func get_label_suggestions(filter:String="") -> Dictionary:
 	var suggestions := {}
 	suggestions['at the beginning'] = {'value':'', 'editor_icon':['GuiRadioUnchecked', 'EditorIcons']}
-	
+
 	if _timeline_file in Engine.get_main_loop().get_meta('dialogic_label_directory').keys():
 		for label in Engine.get_main_loop().get_meta('dialogic_label_directory')[_timeline_file]:
 			suggestions[label] = {'value': label, 'tooltip':label, 'editor_icon': ["ArrowRight", "EditorIcons"]}
@@ -139,8 +139,8 @@ func get_label_suggestions(filter:String="") -> Dictionary:
 
 func _get_code_completion(CodeCompletionHelper:Node, TextNode:TextEdit, line:String, word:String, symbol:String) -> void:
 	if symbol == ' ' and line.count(' ') == 1:
-		CodeCompletionHelper.suggest_timelines(TextNode, CodeEdit.KIND_MEMBER, event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
 		CodeCompletionHelper.suggest_labels(TextNode, '', '\n', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
+		CodeCompletionHelper.suggest_timelines(TextNode, CodeEdit.KIND_MEMBER, event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
 	if symbol == '/':
 		CodeCompletionHelper.suggest_labels(TextNode, line.strip_edges().trim_prefix('jump ').trim_suffix('/'+String.chr(0xFFFF)).strip_edges(), '\n', event_color.lerp(TextNode.syntax_highlighter.normal_color, 0.6))
 

--- a/addons/dialogic/Other/DialogicUtil.gd
+++ b/addons/dialogic/Other/DialogicUtil.gd
@@ -239,7 +239,10 @@ static func apply_scene_export_overrides(node:Node, export_overrides:Dictionary,
 	for i in property_info:
 		if i['usage'] & PROPERTY_USAGE_EDITOR:
 			if i['name'] in export_overrides:
-				node.set(i['name'], str_to_var(export_overrides[i['name']]))
+				if str_to_var(export_overrides[i['name']]) == null and typeof(node.get(i['name'])) == TYPE_STRING:
+					node.set(i['name'], export_overrides[i['name']])
+				else:
+					node.set(i['name'], str_to_var(export_overrides[i['name']]))
 			elif i['name'] in default_info:
 				node.set(i['name'], default_info.get(i['name']))
 	if apply:


### PR DESCRIPTION
- fixes Importing portraits from folders
- moves a bunch of code into the DialogicPortrait class so simple custom portraits are easier to create.

- makes it so _unhighlight is called if noone speaks. 
- adds a example custom portrait scene that can highlight and bring the speaker to the front