### PR TITLE
Fix WAV music bug

### DIFF
--- a/addons/dialogic/Modules/Audio/event_music.gd
+++ b/addons/dialogic/Modules/Audio/event_music.gd
@@ -75,7 +75,7 @@ func build_event_editor():
 	add_body_edit('fade_length', ValueType.FLOAT, {'left_text':'Fade Time:'})
 	add_body_edit('volume', ValueType.DECIBEL, {'left_text':'Volume:'}, '!file_path.is_empty()')
 	add_body_edit('audio_bus', ValueType.SINGLELINE_TEXT, {'left_text':'Audio Bus:'}, '!file_path.is_empty()')
-	add_body_edit('loop', ValueType.BOOL, {'left_text':'Loop:'}, '!file_path.is_empty()')
+	add_body_edit('loop', ValueType.BOOL, {'left_text':'Loop:'}, '!file_path.is_empty() and not file_path.to_lower().ends_with(".wav")')
 
 
 func get_bus_suggestions() -> Dictionary:

--- a/addons/dialogic/Modules/Audio/event_music.gd
+++ b/addons/dialogic/Modules/Audio/event_music.gd
@@ -2,7 +2,7 @@
 class_name DialogicMusicEvent
 extends DialogicEvent
 
-## Event that can change the currently playing background music. 
+## Event that can change the currently playing background music.
 
 
 ### Settings
@@ -56,7 +56,7 @@ func get_shortcode_parameters() -> Dictionary:
 		"path"		: {"property": "file_path", 	"default": ""},
 		"fade"		: {"property": "fade_length", 	"default": 0},
 		"volume"	: {"property": "volume", 		"default": 0},
-		"bus"		: {"property": "audio_bus", 	"default": "Master", 
+		"bus"		: {"property": "audio_bus", 	"default": "Master",
 						"suggestions": get_bus_suggestions},
 		"loop"		: {"property": "loop", 			"default": true},
 	}
@@ -69,8 +69,8 @@ func get_shortcode_parameters() -> Dictionary:
 func build_event_editor():
 	add_header_edit('file_path', ValueType.FILE, {
 			'left_text'		: 'Play',
-			'file_filter' 	: "*.mp3, *.ogg, *.wav; Supported Audio Files", 
-			'placeholder' 	: "No music", 
+			'file_filter' 	: "*.mp3, *.ogg, *.wav; Supported Audio Files",
+			'placeholder' 	: "No music",
 			'editor_icon' 	: ["AudioStreamPlayer", "EditorIcons"]})
 	add_body_edit('fade_length', ValueType.FLOAT, {'left_text':'Fade Time:'})
 	add_body_edit('volume', ValueType.DECIBEL, {'left_text':'Volume:'}, '!file_path.is_empty()')

--- a/addons/dialogic/Modules/Audio/subsystem_audio.gd
+++ b/addons/dialogic/Modules/Audio/subsystem_audio.gd
@@ -40,7 +40,7 @@ func resume() -> void:
 func _ready() -> void:
 	base_music_player.name = "Music"
 	add_child(base_music_player)
-	
+
 	base_sound_player.name = "Sound"
 	add_child(base_sound_player)
 
@@ -63,16 +63,17 @@ func update_music(path:String = '', volume:float = 0.0, audio_bus:String = "Mast
 		base_music_player.stream = load(path)
 		base_music_player.volume_db = volume
 		base_music_player.bus = audio_bus
-		if "loop" in base_music_player.stream:
-			base_music_player.stream.loop = loop
-		elif "loop_mode" in base_music_player.stream:
-			if loop:
-				base_music_player.stream.loop_mode = AudioStreamWAV.LOOP_FORWARD
-			else:
-				base_music_player.stream.loop_mode = AudioStreamWAV.LOOP_DISABLED
+		if not base_music_player.stream is AudioStreamWAV:
+			if "loop" in base_music_player.stream:
+				base_music_player.stream.loop = loop
+			elif "loop_mode" in base_music_player.stream:
+				if loop:
+					base_music_player.stream.loop_mode = AudioStreamWAV.LOOP_FORWARD
+				else:
+					base_music_player.stream.loop_mode = AudioStreamWAV.LOOP_DISABLED
 
-		base_music_player.play()
-		fader.parallel().tween_method(interpolate_volume_linearly.bind(base_music_player), 0.0,db_to_linear(volume),fade_time)
+		base_music_player.play(0)
+		fader.parallel().tween_method(interpolate_volume_linearly.bind(base_music_player), 0.0, db_to_linear(volume),fade_time)
 	else:
 		base_music_player.stop()
 	if prev_node:


### PR DESCRIPTION
The audio subsystem was setting the loop-property of the WAV audio stream which it didn't count as an error worth reporting but somehow REALLY didn't like, so it just refused to play the wav at all. 

This adds a check and removes the loop setting for wav files (from the visual editor).