### PR TITLE
Add prepare() method for styles that should preload scenes

### DIFF
--- a/addons/dialogic/Modules/Style/subsystem_styles.gd
+++ b/addons/dialogic/Modules/Style/subsystem_styles.gd
@@ -86,7 +86,12 @@ func create_layout(style:DialogicStyle) -> DialogicLayoutBase:
 		if not ResourceLoader.exists(layer.path):
 			continue
 
-		var layer_scene : DialogicLayoutLayer = load(layer.path).instantiate()
+		var layer_scene : DialogicLayoutLayer = null
+
+		if ResourceLoader.load_threaded_get_status(layer.path) == ResourceLoader.THREAD_LOAD_LOADED:
+			layer_scene = ResourceLoader.load_threaded_get(layer.path).instantiate()
+		else:
+			layer_scene = load(layer.path).instantiate()
 
 		base_scene.add_layer(layer_scene)
 

--- a/addons/dialogic/Resources/dialogic_style.gd
+++ b/addons/dialogic/Resources/dialogic_style.gd
@@ -185,3 +185,12 @@ func clone() -> DialogicStyle:
 		style.add_layer(info.path, info.overrides)
 
 	return style
+
+
+func prepare() -> void:
+	if base_scene:
+		ResourceLoader.load_threaded_request(base_scene.resource_path)
+
+	for layer in layers:
+		if layer.scene:
+			ResourceLoader.load_threaded_request(layer.scene.resource_path)


### PR DESCRIPTION
The perpare() method should preload all the packed scenes needed for the particular style, thus fixing a lag-spike when first using that style. Needs to be called manually right now (e.g. `DialogicUtil.get_style_by_name("Textbubbles").prepare()`).

Hopefully fixes/improves lags when starting dialog (#1943)