### PR TITLE
Make sure character picker is updated when characters are added

### DIFF
--- a/addons/dialogic/Editor/Events/EventBlock/event_block.gd
+++ b/addons/dialogic/Editor/Events/EventBlock/event_block.gd
@@ -262,7 +262,7 @@ func build_editor(build_header:bool = true, build_body:bool = false) ->  void:
 
 		### --------------------------------------------------------------------
 		### 2. ADD IT TO THE RIGHT PLACE (HEADER/BODY)
-		var location :Control = %HeaderContent
+		var location: Control = %HeaderContent
 		if p.location == 1:
 			location = current_body_container
 		location.add_child(editor_node)
@@ -280,8 +280,8 @@ func build_editor(build_header:bool = true, build_body:bool = false) ->  void:
 		if editor_node.has_signal('value_changed'):
 			editor_node.value_changed.connect(set_property)
 		editor_node.tooltip_text = p.display_info.get('tooltip', '')
-		var left_label :Label = null
-		var right_label :Label = null
+		var left_label: Label = null
+		var right_label: Label = null
 		if !p.get('left_text', '').is_empty():
 			left_label = Label.new()
 			left_label.text = p.get('left_text')
@@ -310,9 +310,7 @@ func build_editor(build_header:bool = true, build_body:bool = false) ->  void:
 			editor_node.call_deferred('take_autofocus')
 
 	if build_body:
-#		has_body_content = true
 		if current_body_container.get_child_count() == 0:
-#			has_body_content = false
 			expanded = false
 			body_container.visible = false
 
@@ -352,8 +350,9 @@ func set_property(property_name:String, value:Variant) -> void:
 
 func _on_resource_ui_update_needed() -> void:
 	for node_info in field_list:
-		if node_info.node.has_method('set_value'):
+		if node_info.node and node_info.node.has_method('set_value'):
 			node_info.node.set_value(resource.get(node_info.property))
+	recalculate_field_visibility()
 
 
 func _update_color() -> void:

--- a/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
+++ b/addons/dialogic/Editor/TimelineEditor/VisualEditor/timeline_editor_visual.gd
@@ -335,7 +335,9 @@ func add_event_node(event_resource:DialogicEvent, at_index:int = -1, auto_select
 	var piece :Control = event_node.instantiate()
 	piece.resource = event_resource
 	event_resource._editor_node = piece
+	event_resource._enter_visual_editor(timeline_editor)
 	piece.content_changed.connect(something_changed)
+
 	if event_resource.event_name == "Label":
 		piece.content_changed.connect(update_content_list)
 	if at_index == -1:

--- a/addons/dialogic/Editor/dialogic_editor.gd
+++ b/addons/dialogic/Editor/dialogic_editor.gd
@@ -8,6 +8,8 @@ extends Control
 signal resource_saved()
 signal resource_unsaved()
 
+signal opened
+
 var current_resource: Resource
 
 ## State of the current resource

--- a/addons/dialogic/Editor/editors_manager.gd
+++ b/addons/dialogic/Editor/editors_manager.gd
@@ -160,6 +160,7 @@ func open_editor(editor:DialogicEditor, save_previous: bool = true, extra_info:V
 		previous_editor = current_editor
 
 	editor._open(extra_info)
+	editor.opened.emit()
 	current_editor = editor
 	editor.show()
 	tabbar.current_tab = editor.get_index()

--- a/addons/dialogic/Modules/Text/event_text.gd
+++ b/addons/dialogic/Modules/Text/event_text.gd
@@ -326,6 +326,10 @@ func _get_property_original_translation(property:String) -> String:
 ## 						EVENT EDITOR
 ################################################################################
 
+func _enter_visual_editor(editor:DialogicEditor):
+	editor.opened.connect(func(): ui_update_needed.emit())
+
+
 func build_event_editor():
 	add_header_edit('character_identifier', ValueType.COMPLEX_PICKER,
 			{'file_extension' 	: '.dch',

--- a/addons/dialogic/Other/DialogicResourceUtil.gd
+++ b/addons/dialogic/Other/DialogicResourceUtil.gd
@@ -4,7 +4,6 @@ class_name DialogicResourceUtil
 static var label_cache := {}
 static var event_cache: Array[DialogicEvent] = []
 
-
 static func update() -> void:
 	update_directory('.dch')
 	update_directory('.dtl')
@@ -52,7 +51,6 @@ static func add_resource_to_directory(file_path:String, directory:Dictionary) ->
 	var suggested_name := file_path.get_file().trim_suffix("."+file_path.get_extension())
 	while suggested_name in directory:
 		suggested_name = file_path.trim_suffix("/"+suggested_name+"."+file_path.get_extension()).get_file().path_join(suggested_name)
-
 	directory[suggested_name] = file_path
 	return directory
 
@@ -97,6 +95,7 @@ static func remove_resource(file_path:String) -> void:
 	var key := directory.find_key(file_path)
 	while key != null:
 		directory.erase(key)
+		key = directory.find_key(file_path)
 	set_directory(file_path.get_extension(), directory)
 
 static func is_identifier_unused(extension:String, identifier:String) -> bool:

--- a/addons/dialogic/Resources/event.gd
+++ b/addons/dialogic/Resources/event.gd
@@ -359,6 +359,10 @@ func set_default_color(value) -> void:
 	event_color = DialogicUtil.get_color(value)
 
 
+## Called when the resource is assigned to a event block in the visual editor
+func _enter_visual_editor(timeline_editor:DialogicEditor) -> void:
+	pass
+
 ####################### CODE COMPLETION ########################################
 ################################################################################
 


### PR DESCRIPTION
Previously the character picker of already opened timelines text event (visual editor) wouldn't become visible when adding the first character. This is now fixed.