### PR TITLE
Fix Godot version from `4.2.0` to `4.2`.

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         # Insert here the Godot version you want to run your tests with.
-        godot-version: ['4.2.0']
+        godot-version: ['4.2']
 
     name: "CI Unit Test v${{ matrix.godot-version }}"
     runs-on: 'ubuntu-22.04'


### PR DESCRIPTION
This broke downloading Godot for the CI.